### PR TITLE
Improved keyboard support

### DIFF
--- a/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
+++ b/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
@@ -17,9 +17,9 @@ class HtmlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
   def unsafeInit(): Unit = {
     childNode = dom.document.body.appendChild(canvas)
     dom.document.addEventListener[KeyboardEvent]("keydown", (ev: KeyboardEvent) =>
-      HtmlCanvas.convertKeyCode(ev.keyCode).foreach(k => keyboardInput = keyboardInput.press(k)))
+      JsKeyMapping.getKey(ev.keyCode).foreach(k => keyboardInput = keyboardInput.press(k)))
     dom.document.addEventListener[KeyboardEvent]("keyup", (ev: KeyboardEvent) =>
-      HtmlCanvas.convertKeyCode(ev.keyCode).foreach(k => keyboardInput = keyboardInput.release(k)))
+      JsKeyMapping.getKey(ev.keyCode).foreach(k => keyboardInput = keyboardInput.release(k)))
   }
   def unsafeDestroy(): Unit = {
     dom.document.body.removeChild(childNode)
@@ -53,14 +53,4 @@ class HtmlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
   }
 
   def getKeyboardInput(): KeyboardInput = keyboardInput
-}
-
-object HtmlCanvas {
-  private def convertKeyCode(code: Int): Option[KeyboardInput.Key] = code match {
-    case 38 => Some(KeyboardInput.Key.Up)
-    case 40 => Some(KeyboardInput.Key.Down)
-    case 37 => Some(KeyboardInput.Key.Left)
-    case 39 => Some(KeyboardInput.Key.Right)
-    case _ => None
-  }
 }

--- a/core/js/src/main/scala/eu/joaocosta/minart/backend/JsKeyMapping.scala
+++ b/core/js/src/main/scala/eu/joaocosta/minart/backend/JsKeyMapping.scala
@@ -1,0 +1,70 @@
+package eu.joaocosta.minart.backend
+
+import eu.joaocosta.minart.core.KeyboardInput._
+
+object JsKeyMapping extends KeyMapping[Int] {
+  protected final val mappings: Map[Int, Key] = Map(
+    65 -> Key.A,
+    66 -> Key.B,
+    67 -> Key.C,
+    68 -> Key.D,
+    69 -> Key.E,
+    70 -> Key.F,
+    71 -> Key.G,
+    72 -> Key.H,
+    73 -> Key.I,
+    74 -> Key.J,
+    75 -> Key.K,
+    76 -> Key.L,
+    77 -> Key.M,
+    78 -> Key.N,
+    79 -> Key.O,
+    80 -> Key.P,
+    81 -> Key.Q,
+    82 -> Key.R,
+    83 -> Key.S,
+    84 -> Key.T,
+    85 -> Key.U,
+    86 -> Key.V,
+    87 -> Key.W,
+    88 -> Key.X,
+    89 -> Key.Y,
+    90 -> Key.Z,
+
+    48 -> Key.Digit0,
+    49 -> Key.Digit1,
+    50 -> Key.Digit2,
+    51 -> Key.Digit3,
+    52 -> Key.Digit4,
+    53 -> Key.Digit5,
+    54 -> Key.Digit6,
+    55 -> Key.Digit7,
+    56 -> Key.Digit8,
+    57 -> Key.Digit9,
+
+    96 -> Key.NumPad0,
+    97 -> Key.NumPad1,
+    98 -> Key.NumPad2,
+    99 -> Key.NumPad3,
+    100 -> Key.NumPad4,
+    101 -> Key.NumPad5,
+    102 -> Key.NumPad6,
+    103 -> Key.NumPad7,
+    104 -> Key.NumPad8,
+    105 -> Key.NumPad9,
+
+    32 -> Key.Space,
+    9 -> Key.Tab,
+    13 -> Key.Enter,
+    8 -> Key.Backspace,
+
+    16 -> Key.Shift,
+    17 -> Key.Ctrl,
+    18 -> Key.Alt,
+    224 -> Key.Meta,
+
+    38 -> Key.Up,
+    40 -> Key.Down,
+    37 -> Key.Left,
+    39 -> Key.Right)
+}

--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -106,16 +106,9 @@ object AwtCanvas {
 
   private class KeyListener extends JavaKeyListener {
     private[this] var state = KeyboardInput(Set(), Set(), Set())
-    private[this] def getKey(ev: KeyEvent): Option[Key] = ev.getKeyCode() match {
-      case KeyEvent.VK_UP => Some(Key.Up)
-      case KeyEvent.VK_DOWN => Some(Key.Down)
-      case KeyEvent.VK_LEFT => Some(Key.Left)
-      case KeyEvent.VK_RIGHT => Some(Key.Right)
-      case _ => None
-    }
 
-    def keyPressed(ev: KeyEvent): Unit = getKey(ev).foreach(key => state = state.press(key))
-    def keyReleased(ev: KeyEvent): Unit = getKey(ev).foreach(key => state = state.release(key))
+    def keyPressed(ev: KeyEvent): Unit = AwtKeyMapping.getKey(ev.getKeyCode).foreach(key => state = state.press(key))
+    def keyReleased(ev: KeyEvent): Unit = AwtKeyMapping.getKey(ev.getKeyCode).foreach(key => state = state.release(key))
     def keyTyped(ev: KeyEvent): Unit = ()
     def clearPressRelease(): Unit = state = state.clearPressRelease()
     def getKeyboardInput(): KeyboardInput = state

--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -98,7 +98,7 @@ object AwtCanvas {
 
     frame.setVisible(true)
     frame.addWindowListener(new WindowAdapter() {
-      override def windowClosing(e: WindowEvent) {
+      override def windowClosing(e: WindowEvent): Unit = {
         outerCanvas.destroy()
       }
     });

--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtKeyMapping.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtKeyMapping.scala
@@ -1,0 +1,73 @@
+package eu.joaocosta.minart.backend
+
+import java.awt.event.KeyEvent
+
+import eu.joaocosta.minart.core.KeyboardInput._
+
+object AwtKeyMapping extends KeyMapping[Int] {
+  protected final val mappings: Map[Int, Key] = Map(
+    KeyEvent.VK_A -> Key.A,
+    KeyEvent.VK_B -> Key.B,
+    KeyEvent.VK_C -> Key.C,
+    KeyEvent.VK_D -> Key.D,
+    KeyEvent.VK_E -> Key.E,
+    KeyEvent.VK_F -> Key.F,
+    KeyEvent.VK_G -> Key.G,
+    KeyEvent.VK_H -> Key.H,
+    KeyEvent.VK_I -> Key.I,
+    KeyEvent.VK_J -> Key.J,
+    KeyEvent.VK_K -> Key.K,
+    KeyEvent.VK_L -> Key.L,
+    KeyEvent.VK_M -> Key.M,
+    KeyEvent.VK_N -> Key.N,
+    KeyEvent.VK_O -> Key.O,
+    KeyEvent.VK_P -> Key.P,
+    KeyEvent.VK_Q -> Key.Q,
+    KeyEvent.VK_R -> Key.R,
+    KeyEvent.VK_S -> Key.S,
+    KeyEvent.VK_T -> Key.T,
+    KeyEvent.VK_U -> Key.U,
+    KeyEvent.VK_V -> Key.V,
+    KeyEvent.VK_W -> Key.W,
+    KeyEvent.VK_X -> Key.X,
+    KeyEvent.VK_Y -> Key.Y,
+    KeyEvent.VK_Z -> Key.Z,
+
+    KeyEvent.VK_0 -> Key.Digit0,
+    KeyEvent.VK_1 -> Key.Digit1,
+    KeyEvent.VK_2 -> Key.Digit2,
+    KeyEvent.VK_3 -> Key.Digit3,
+    KeyEvent.VK_4 -> Key.Digit4,
+    KeyEvent.VK_5 -> Key.Digit5,
+    KeyEvent.VK_6 -> Key.Digit6,
+    KeyEvent.VK_7 -> Key.Digit7,
+    KeyEvent.VK_8 -> Key.Digit8,
+    KeyEvent.VK_9 -> Key.Digit9,
+
+    KeyEvent.VK_NUMPAD0 -> Key.NumPad0,
+    KeyEvent.VK_NUMPAD1 -> Key.NumPad1,
+    KeyEvent.VK_NUMPAD2 -> Key.NumPad2,
+    KeyEvent.VK_NUMPAD3 -> Key.NumPad3,
+    KeyEvent.VK_NUMPAD4 -> Key.NumPad4,
+    KeyEvent.VK_NUMPAD5 -> Key.NumPad5,
+    KeyEvent.VK_NUMPAD6 -> Key.NumPad6,
+    KeyEvent.VK_NUMPAD7 -> Key.NumPad7,
+    KeyEvent.VK_NUMPAD8 -> Key.NumPad8,
+    KeyEvent.VK_NUMPAD9 -> Key.NumPad9,
+
+    KeyEvent.VK_SPACE -> Key.Space,
+    KeyEvent.VK_TAB -> Key.Tab,
+    KeyEvent.VK_ENTER -> Key.Enter,
+    KeyEvent.VK_BACK_SPACE -> Key.Backspace,
+
+    KeyEvent.VK_SHIFT -> Key.Shift,
+    KeyEvent.VK_CONTROL -> Key.Ctrl,
+    KeyEvent.VK_ALT -> Key.Alt,
+    KeyEvent.VK_META -> Key.Meta,
+    KeyEvent.VK_WINDOWS -> Key.Meta,
+
+    KeyEvent.VK_UP -> Key.Up,
+    KeyEvent.VK_DOWN -> Key.Down,
+    KeyEvent.VK_LEFT -> Key.Left,
+    KeyEvent.VK_RIGHT -> Key.Right)
+}

--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -79,9 +79,9 @@ class SdlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
         destroy()
         return false
       } else if (event.type_ == SDL_KEYDOWN) {
-        SdlCanvas.convertKeyCode(event.key.keysym.sym).foreach(k => keyboardInput = keyboardInput.press(k))
+        SdlKeyMapping.getKey(event.key.keysym.sym).foreach(k => keyboardInput = keyboardInput.press(k))
       } else if (event.type_ == SDL_KEYUP) {
-        SdlCanvas.convertKeyCode(event.key.keysym.sym).foreach(k => keyboardInput = keyboardInput.release(k))
+        SdlKeyMapping.getKey(event.key.keysym.sym).foreach(k => keyboardInput = keyboardInput.release(k))
       }
     }
     true
@@ -105,14 +105,4 @@ class SdlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
   }
 
   def getKeyboardInput(): KeyboardInput = keyboardInput
-}
-
-object SdlCanvas {
-  private def convertKeyCode(code: SDL_Keycode): Option[KeyboardInput.Key] = code match {
-    case SDLK_UP => Some(Key.Up)
-    case SDLK_DOWN => Some(Key.Down)
-    case SDLK_LEFT => Some(Key.Left)
-    case SDLK_RIGHT => Some(Key.Right)
-    case _ => None
-  }
 }

--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlKeyMapping.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlKeyMapping.scala
@@ -1,0 +1,82 @@
+package eu.joaocosta.minart.backend
+
+import sdl2.SDL._
+import sdl2.Extras._
+
+import eu.joaocosta.minart.core.KeyboardInput._
+
+object SdlKeyMapping extends KeyMapping[SDL_Keycode] {
+  protected final val mappings: Map[Int, Key] = Map(
+    SDLK_a -> Key.A,
+    SDLK_b -> Key.B,
+    SDLK_c -> Key.C,
+    SDLK_d -> Key.D,
+    SDLK_e -> Key.E,
+    SDLK_f -> Key.F,
+    SDLK_g -> Key.G,
+    SDLK_h -> Key.H,
+    SDLK_i -> Key.I,
+    SDLK_j -> Key.J,
+    SDLK_k -> Key.K,
+    SDLK_l -> Key.L,
+    SDLK_m -> Key.M,
+    SDLK_n -> Key.N,
+    SDLK_o -> Key.O,
+    SDLK_p -> Key.P,
+    SDLK_q -> Key.Q,
+    SDLK_r -> Key.R,
+    SDLK_s -> Key.S,
+    SDLK_t -> Key.T,
+    SDLK_u -> Key.U,
+    SDLK_v -> Key.V,
+    SDLK_w -> Key.W,
+    SDLK_x -> Key.X,
+    SDLK_y -> Key.Y,
+    SDLK_z -> Key.Z,
+
+    SDLK_0 -> Key.Digit0,
+    SDLK_1 -> Key.Digit1,
+    SDLK_2 -> Key.Digit2,
+    SDLK_3 -> Key.Digit3,
+    SDLK_4 -> Key.Digit4,
+    SDLK_5 -> Key.Digit5,
+    SDLK_6 -> Key.Digit6,
+    SDLK_7 -> Key.Digit7,
+    SDLK_8 -> Key.Digit8,
+    SDLK_9 -> Key.Digit9,
+
+    SDLK_KP_0 -> Key.NumPad0,
+    SDLK_KP_1 -> Key.NumPad1,
+    SDLK_KP_2 -> Key.NumPad2,
+    SDLK_KP_3 -> Key.NumPad3,
+    SDLK_KP_4 -> Key.NumPad4,
+    SDLK_KP_5 -> Key.NumPad5,
+    SDLK_KP_6 -> Key.NumPad6,
+    SDLK_KP_7 -> Key.NumPad7,
+    SDLK_KP_8 -> Key.NumPad8,
+    SDLK_KP_9 -> Key.NumPad9,
+
+    SDLK_SPACE -> Key.Space,
+    SDLK_KP_SPACE -> Key.Space,
+    SDLK_TAB -> Key.Tab,
+    SDLK_KP_TAB -> Key.Tab,
+    SDLK_RETURN -> Key.Enter,
+    SDLK_RETURN2 -> Key.Enter,
+    SDLK_KP_ENTER -> Key.Enter,
+    SDLK_BACKSPACE -> Key.Backspace,
+    SDLK_KP_BACKSPACE -> Key.Backspace,
+
+    SDLK_LSHIFT -> Key.Shift,
+    SDLK_RSHIFT -> Key.Shift,
+    SDLK_LCTRL -> Key.Ctrl,
+    SDLK_RCTRL -> Key.Ctrl,
+    SDLK_LALT -> Key.Alt,
+    SDLK_RALT -> Key.Alt,
+    SDLK_LGUI -> Key.Meta,
+    SDLK_RGUI -> Key.Meta,
+
+    SDLK_UP -> Key.Up,
+    SDLK_DOWN -> Key.Down,
+    SDLK_LEFT -> Key.Left,
+    SDLK_RIGHT -> Key.Right)
+}

--- a/core/shared/src/main/scala/eu/joaocosta/minart/core/KeyboardInput.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/core/KeyboardInput.scala
@@ -11,8 +11,73 @@ case class KeyboardInput(keysDown: Set[Key], keysPressed: Set[Key], keysReleased
 }
 
 object KeyboardInput {
+
+  trait KeyMapping[A] {
+    protected def mappings: Map[A, Key]
+    def getKey(keyCode: A): Option[Key] = mappings.get(keyCode)
+  }
+
   sealed trait Key
   object Key {
+    final case object A extends Key
+    final case object B extends Key
+    final case object C extends Key
+    final case object D extends Key
+    final case object E extends Key
+    final case object F extends Key
+    final case object G extends Key
+    final case object H extends Key
+    final case object I extends Key
+    final case object J extends Key
+    final case object K extends Key
+    final case object L extends Key
+    final case object M extends Key
+    final case object N extends Key
+    final case object O extends Key
+    final case object P extends Key
+    final case object Q extends Key
+    final case object R extends Key
+    final case object S extends Key
+    final case object T extends Key
+    final case object U extends Key
+    final case object V extends Key
+    final case object W extends Key
+    final case object X extends Key
+    final case object Y extends Key
+    final case object Z extends Key
+
+    final case object Digit0 extends Key
+    final case object Digit1 extends Key
+    final case object Digit2 extends Key
+    final case object Digit3 extends Key
+    final case object Digit4 extends Key
+    final case object Digit5 extends Key
+    final case object Digit6 extends Key
+    final case object Digit7 extends Key
+    final case object Digit8 extends Key
+    final case object Digit9 extends Key
+
+    final case object NumPad0 extends Key
+    final case object NumPad1 extends Key
+    final case object NumPad2 extends Key
+    final case object NumPad3 extends Key
+    final case object NumPad4 extends Key
+    final case object NumPad5 extends Key
+    final case object NumPad6 extends Key
+    final case object NumPad7 extends Key
+    final case object NumPad8 extends Key
+    final case object NumPad9 extends Key
+
+    final case object Space extends Key
+    final case object Tab extends Key
+    final case object Enter extends Key
+    final case object Backspace extends Key
+
+    final case object Shift extends Key
+    final case object Ctrl extends Key
+    final case object Alt extends Key
+    final case object Meta extends Key
+
     final case object Up extends Key
     final case object Down extends Key
     final case object Left extends Key


### PR DESCRIPTION
Cleans up the keyboard code, extracting some of the common logic into a `KeyboardMapping` interface, and adds support for some of the more common keys.

While not all keys are supported, I think that this subset should be more that enough for most generative art projects. More keys can later be added when the project is in a more mature state.

Fix #2 