### PR TITLE
Make clear operation more granular

### DIFF
--- a/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
+++ b/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
@@ -43,9 +43,14 @@ class HtmlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
     Color(imgData(0), imgData(1), imgData(2))
   }
 
-  def clear(): Unit = {
-    ctxBuff.fillStyle = clearColorStr
-    ctxBuff.fillRect(0, 0, settings.scaledWidth, settings.scaledHeight)
+  def clear(resources: Set[Canvas.Resource]): Unit = {
+    if (resources.contains(Canvas.Resource.Backbuffer)) {
+      ctxBuff.fillStyle = clearColorStr
+      ctxBuff.fillRect(0, 0, settings.scaledWidth, settings.scaledHeight)
+    }
+    if (resources.contains(Canvas.Resource.Keyboard)) {
+      keyboardInput = keyboardInput.clearPressRelease
+    }
   }
 
   def redraw(): Unit = {

--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -64,9 +64,13 @@ class AwtCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
     unpack(javaCanvas.imagePixels.getElem(y * settings.scale * settings.scaledWidth + (x * settings.scale) % settings.scaledWidth))
   }
 
-  def clear(): Unit = {
-    for { i <- (0 until (settings.scaledWidth * settings.scaledWidth)) } javaCanvas.imagePixels.setElem(i, packedClearColor)
-    keyListener.clearPressRelease()
+  def clear(resources: Set[Canvas.Resource]): Unit = {
+    if (resources.contains(Canvas.Resource.Backbuffer)) {
+      for { i <- (0 until (settings.scaledWidth * settings.scaledWidth)) } javaCanvas.imagePixels.setElem(i, packedClearColor)
+    }
+    if (resources.contains(Canvas.Resource.Keyboard)) {
+      keyListener.clearPressRelease()
+    }
   }
 
   def redraw(): Unit = {

--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -87,9 +87,12 @@ class SdlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
     true
   }
 
-  def clear(): Unit = {
-    keyboardInput = keyboardInput.clearPressRelease()
-    if (handleEvents()) {
+  def clear(resources: Set[Canvas.Resource]): Unit = {
+    if (resources.contains(Canvas.Resource.Keyboard)) {
+      keyboardInput = keyboardInput.clearPressRelease()
+    }
+    val keepGoing = handleEvents()
+    if (resources.contains(Canvas.Resource.Backbuffer) && keepGoing) {
       SDL_SetRenderDrawColor(
         renderer,
         ubyteClearR,

--- a/core/shared/src/main/scala/eu/joaocosta/minart/backend/PpmCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/backend/PpmCanvas.scala
@@ -14,7 +14,11 @@ class PpmCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
 
   def getBackbufferPixel(x: Int, y: Int): Color = buffer(y)(x)
 
-  def clear(): Unit = buffer.foreach(_.transform(_ => settings.clearColor))
+  def clear(resources: Set[Canvas.Resource]): Unit = {
+    if (resources.contains(Canvas.Resource.Backbuffer)) {
+      buffer.foreach(_.transform(_ => settings.clearColor))
+    }
+  }
 
   def redraw(): Unit = {
     println("P3")

--- a/core/shared/src/main/scala/eu/joaocosta/minart/core/Canvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/core/Canvas.scala
@@ -37,9 +37,9 @@ trait Canvas {
   def getBackbufferPixel(x: Int, y: Int): Color
 
   /**
-   * Clears the backbuffer
+   * Clears resources, such as the backbuffer and keyboard inputs
    */
-  def clear(): Unit
+  def clear(resources: Set[Canvas.Resource] = Set(Canvas.Resource.Backbuffer, Canvas.Resource.Keyboard)): Unit
 
   /**
    * Flips buffers and redraws the screen
@@ -55,6 +55,13 @@ trait Canvas {
 }
 
 object Canvas {
+
+  sealed trait Resource
+  object Resource {
+    case object Backbuffer extends Resource
+    case object Keyboard extends Resource
+  }
+
   /**
    * The canvas settings.
    *


### PR DESCRIPTION
Adds a new parameter to the `clear` operation, so that some resources (e.g. backbuffer) can be cleared without clearing others (e.g. keyboard input).

Fix #11 