### PR TITLE
Improve build definition

### DIFF
--- a/.github/workflows/compile_test.yml
+++ b/.github/workflows/compile_test.yml
@@ -35,7 +35,7 @@ jobs:
         path: ~/.sbt
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
     - name: Compile Native
-      run: sbt -Dsbt.color=always ++2.11.2 rootNative/compile
+      run: sbt -Dsbt.color=always ++2.11.12 rootNative/compile
     - name: Compile JVM
       run: sbt -Dsbt.color=always ++rootJVM/compile  ++examplesJVM/compile
     - name: Compile JS
@@ -76,4 +76,4 @@ jobs:
         path: ~/.sbt
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
     - name: Run tests
-      run: sbt -Dsbt.color=always ++$SCALA_VERSION root$PLATFORM/test:compile root$PLATFORM/test
+      run: sbt -Dsbt.color=always ++$SCALA_VERSION $PROJECT/test:compile $PROJECT/test

--- a/.github/workflows/compile_test.yml
+++ b/.github/workflows/compile_test.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   compile-lib:
-    name: Compile library (Scala ${{ matrix.scala }} - ${{ matrix.platform }})
+    name: Compile library
     runs-on: ubuntu-latest
 
     strategy:
@@ -44,10 +44,10 @@ jobs:
       with:
         path: ~/.sbt
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
-    - name: Compile
+    - name: Compile (Scala ${{ matrix.scala }} - ${{ matrix.platform }})
       run: sbt -Dsbt.color=always ++$SCALA_VERSION $PROJECT/compile
   compile-examples:
-    name: Compile examples (Scala ${{ matrix.scala }})
+    name: Compile examples
     runs-on: ubuntu-latest
 
     strategy:
@@ -79,10 +79,10 @@ jobs:
       with:
         path: ~/.sbt
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
-    - name: Compile examples
+    - name: Compile examples (Scala ${{ matrix.scala }})
       run: sbt -Dsbt.color=always ++$SCALA_VERSION examples/compile
   test:
-    name: Unit tests (Scala ${{ matrix.scala }} - ${{ matrix.platform }})
+    name: Unit tests
     runs-on: ubuntu-latest
 
     strategy:
@@ -116,5 +116,5 @@ jobs:
       with:
         path: ~/.sbt
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
-    - name: Run tests
+    - name: Run tests (Scala ${{ matrix.scala }} - ${{ matrix.platform }})
       run: sbt -Dsbt.color=always ++$SCALA_VERSION $PROJECT/test:compile $PROJECT/test

--- a/.github/workflows/compile_test.yml
+++ b/.github/workflows/compile_test.yml
@@ -7,11 +7,21 @@ env:
 
 jobs:
   compile-lib:
-    name: Compile Lib
+    name: Compile library (Scala ${{ matrix.scala }} - ${{ matrix.platform }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: true
+      matrix:
+        scala: [2.11.12, 2.12.10, 2.13.1]
+        platform: [JVM, JS]
+        include:
+          - scala: 2.11.12
+          - platform: Native
+
+    env:
+      SCALA_VERSION: ${{ matrix.scala }}
+      PROJECT: root${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v2
@@ -34,12 +44,8 @@ jobs:
       with:
         path: ~/.sbt
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
-    - name: Compile Native
-      run: sbt -Dsbt.color=always ++2.11.12 rootNative/compile
-    - name: Compile JVM
-      run: sbt -Dsbt.color=always ++rootJVM/compile
-    - name: Compile JS
-      run: sbt -Dsbt.color=always ++rootJS/compile
+    - name: Compile
+      run: sbt -Dsbt.color=always ++$SCALA_VERSION $PROJECT/compile
   compile-examples:
     name: Compile examples (Scala ${{ matrix.scala }})
     runs-on: ubuntu-latest
@@ -83,7 +89,7 @@ jobs:
       fail-fast: true
       matrix:
         scala: [2.11.12, 2.12.10, 2.13.1]
-        platform: ["JVM", "JS"]
+        platform: [JVM, JS]
 
     env:
       SCALA_VERSION: ${{ matrix.scala }}

--- a/.github/workflows/compile_test.yml
+++ b/.github/workflows/compile_test.yml
@@ -6,17 +6,12 @@ env:
   CI: true # disables SBT super shell which has problems with CI environments
 
 jobs:
-  build:
-    name: Scala ${{ matrix.scala }}
+  compile-lib:
+    name: Compile Lib
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: true
-      matrix:
-        scala: [2.11.12, 2.12.10, 2.13.1]
-
-    env:
-      SCALA_VERSION: ${{ matrix.scala }}
 
     steps:
     - uses: actions/checkout@v2
@@ -39,7 +34,46 @@ jobs:
       with:
         path: ~/.sbt
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
-    - name: Compile
-      run: sbt -Dsbt.color=always ++$SCALA_VERSION compile
+    - name: Compile Native
+      run: sbt -Dsbt.color=always ++2.11.2 rootNative/compile
+    - name: Compile JVM
+      run: sbt -Dsbt.color=always ++rootJVM/compile  ++examplesJVM/compile
+    - name: Compile JS
+      run: sbt -Dsbt.color=always ++rootJS/compile ++examplesJS/compile
+  test:
+    name: Unit tests (Scala ${{ matrix.scala }} - ${{ matrix.platform }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        scala: [2.11.12, 2.12.10, 2.13.1]
+        platform: ["JVM", "JS"]
+
+    env:
+      SCALA_VERSION: ${{ matrix.scala }}
+      PROJECT: root${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8 and SBT
+      uses: olafurpg/setup-scala@v7
+      with:
+        java-version: openjdk@1.8
+    - name: Cache Coursier
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/coursier
+        key: ${{ runner.os }}-coursier-${{ hashFiles('**/*.sbt') }}
+    - name: Cache SBT ivy cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.ivy2/cache
+        key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}
+    - name: Cache SBT
+      uses: actions/cache@v1
+      with:
+        path: ~/.sbt
+        key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
     - name: Run tests
-      run: sbt -Dsbt.color=always ++$SCALA_VERSION test:compile test
+      run: sbt -Dsbt.color=always ++$SCALA_VERSION root$PLATFORM/test:compile root$PLATFORM/test

--- a/.github/workflows/compile_test.yml
+++ b/.github/workflows/compile_test.yml
@@ -17,7 +17,7 @@ jobs:
         platform: [JVM, JS]
         include:
           - scala: 2.11.12
-          - platform: Native
+            platform: Native
 
     env:
       SCALA_VERSION: ${{ matrix.scala }}

--- a/.github/workflows/compile_test.yml
+++ b/.github/workflows/compile_test.yml
@@ -37,9 +37,44 @@ jobs:
     - name: Compile Native
       run: sbt -Dsbt.color=always ++2.11.12 rootNative/compile
     - name: Compile JVM
-      run: sbt -Dsbt.color=always ++rootJVM/compile  ++examplesJVM/compile
+      run: sbt -Dsbt.color=always ++rootJVM/compile
     - name: Compile JS
-      run: sbt -Dsbt.color=always ++rootJS/compile ++examplesJS/compile
+      run: sbt -Dsbt.color=always ++rootJS/compile
+  compile-examples:
+    name: Compile examples (Scala ${{ matrix.scala }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        scala: [2.11.12, 2.12.10, 2.13.1]
+
+    env:
+      SCALA_VERSION: ${{ matrix.scala }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8 and SBT
+      uses: olafurpg/setup-scala@v7
+      with:
+        java-version: openjdk@1.8
+    - name: Cache Coursier
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/coursier
+        key: ${{ runner.os }}-coursier-${{ hashFiles('**/*.sbt') }}
+    - name: Cache SBT ivy cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.ivy2/cache
+        key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}
+    - name: Cache SBT
+      uses: actions/cache@v1
+      with:
+        path: ~/.sbt
+        key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+    - name: Compile examples
+      run: sbt -Dsbt.color=always ++$SCALA_VERSION examples/compile
   test:
     name: Unit tests (Scala ${{ matrix.scala }} - ${{ matrix.platform }})
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -88,75 +88,47 @@ lazy val pure =
 
 lazy val examples = (project in file("examples"))
     .dependsOn(
-      examples_colorSquare.jvm,     examples_colorSquare.js,     /*examples_colorSquare.native,*/
-      examples_pureColorSquare.jvm, examples_pureColorSquare.js, /*examples_pureColorSquare.native,*/
-      examples_fire.jvm,            examples_fire.js,            /*examples_fire.native,*/
-      examples_snake.jvm,           examples_snake.js,           /*examples_snake.native,*/
-      examples_mousePointer.jvm,    examples_mousePointer.js/*,    examples_mousePointer.native*/)
+      `examples-colorSquare`.jvm,     `examples-colorSquare`.js,
+      `examples-pureColorSquare`.jvm, `examples-pureColorSquare`.js,
+      `examples-fire`.jvm,            `examples-fire`.js,           
+      `examples-snake`.jvm,           `examples-snake`.js,          
+      `examples-mousePointer`.jvm,    `examples-mousePointer`.js)
     .settings(sharedSettings)
     .settings(name := "minart-examples")
     .settings(noPublishSettings)
     .aggregate(
-      examples_colorSquare.jvm,     examples_colorSquare.js,     /*examples_colorSquare.native,*/
-      examples_pureColorSquare.jvm, examples_pureColorSquare.js, /*examples_pureColorSquare.native,*/
-      examples_fire.jvm,            examples_fire.js,            /*examples_fire.native,*/
-      examples_snake.jvm,           examples_snake.js,           /*examples_snake.native,*/
-      examples_mousePointer.jvm,    examples_mousePointer.js/*,    examples_mousePointer.native*/)
+      `examples-colorSquare`.jvm,     `examples-colorSquare`.js,
+      `examples-pureColorSquare`.jvm, `examples-pureColorSquare`.js,
+      `examples-fire`.jvm,            `examples-fire`.js,           
+      `examples-snake`.jvm,           `examples-snake`.js,          
+      `examples-mousePointer`.jvm,    `examples-mousePointer`.js)
 
-lazy val examples_colorSquare =
-  crossProject(JVMPlatform, JSPlatform, NativePlatform)
-    .in(file("examples/colorsquare"))
+def example(project: sbtcrossproject.CrossProject.Builder, exampleName: String) = {
+    project
+    .in(file(s"examples/${exampleName}"))
     .dependsOn(core)
     .settings(sharedSettings)
-    .settings(name := "minart-examples-colorsquare")
+    .settings(name := s"minart-examples-${exampleName}")
     .settings(noPublishSettings)
     .jsSettings(jsSettings)
     .jsSettings(scalaJSUseMainModuleInitializer := true)
     .nativeSettings(nativeSettings)
+}
 
-lazy val examples_pureColorSquare =
-  crossProject(JVMPlatform, JSPlatform, NativePlatform)
-    .in(file("examples/purecolorsquare"))
-    .dependsOn(core, pure)
-    .settings(sharedSettings)
-    .settings(name := "minart-examples-purecolorsquare")
-    .settings(noPublishSettings)
-    .jsSettings(jsSettings)
-    .jsSettings(scalaJSUseMainModuleInitializer := true)
-    .nativeSettings(nativeSettings)
+lazy val `examples-colorSquare` =
+  example(crossProject(JVMPlatform, JSPlatform, NativePlatform), "colorsquare")
 
-lazy val examples_fire =
-  crossProject(JVMPlatform, JSPlatform, NativePlatform)
-    .in(file("examples/fire"))
-    .dependsOn(core)
-    .settings(sharedSettings)
-    .settings(name := "minart-examples-fire")
-    .settings(noPublishSettings)
-    .jsSettings(jsSettings)
-    .jsSettings(scalaJSUseMainModuleInitializer := true)
-    .nativeSettings(nativeSettings)
+lazy val `examples-pureColorSquare` =
+  example(crossProject(JVMPlatform, JSPlatform, NativePlatform), "purecolorsquare").dependsOn(pure)
 
-lazy val examples_snake =
-  crossProject(JVMPlatform, JSPlatform, NativePlatform)
-    .in(file("examples/snake"))
-    .dependsOn(core)
-    .settings(sharedSettings)
-    .settings(name := "minart-examples-snake")
-    .settings(noPublishSettings)
-    .jsSettings(jsSettings)
-    .jsSettings(scalaJSUseMainModuleInitializer := true)
-    .nativeSettings(nativeSettings)
+lazy val `examples-fire` =
+  example(crossProject(JVMPlatform, JSPlatform, NativePlatform), "fire")
 
-lazy val examples_mousePointer =
-  crossProject(JVMPlatform, JSPlatform, NativePlatform)
-    .in(file("examples/mousepointer"))
-    .dependsOn(core)
-    .settings(sharedSettings)
-    .settings(name := "minart-examples-mousepointer")
-    .settings(noPublishSettings)
-    .jsSettings(jsSettings)
-    .jsSettings(scalaJSUseMainModuleInitializer := true)
-    .nativeSettings(nativeSettings)
+lazy val `examples-snake` =
+  example(crossProject(JVMPlatform, JSPlatform, NativePlatform), "snake")
+
+lazy val `examples-mousePointer` =
+  example(crossProject(JVMPlatform, JSPlatform, NativePlatform), "mousepointer")
 
 releaseCrossBuild := true
 releaseTagComment := s"Release ${(version in ThisBuild).value}"

--- a/build.sbt
+++ b/build.sbt
@@ -87,12 +87,6 @@ lazy val pure =
     .nativeSettings(nativeSettings)
 
 lazy val examples = (project in file("examples"))
-    .dependsOn(
-      `examples-colorSquare`.jvm,     `examples-colorSquare`.js,
-      `examples-pureColorSquare`.jvm, `examples-pureColorSquare`.js,
-      `examples-fire`.jvm,            `examples-fire`.js,           
-      `examples-snake`.jvm,           `examples-snake`.js,          
-      `examples-mousePointer`.jvm,    `examples-mousePointer`.js)
     .settings(sharedSettings)
     .settings(name := "minart-examples")
     .settings(noPublishSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -28,23 +28,11 @@ val testSettings = Seq(
   scalacOptions in Test ++= Seq("-Yrangepos")
 )
 
-val jsSettings = Seq(
-  libraryDependencies ++= Seq(
-    "org.scala-js" %%% "scalajs-dom" % "1.0.0"
-  )
-)
-
-val nativeSettings = Seq(
-  scalaVersion := "2.11.12",
-  crossScalaVersions := Seq("2.11.12"),
-  libraryDependencies ++= Seq(
-    "com.regblanc" %%% "native-sdl2" % "0.1"
-  ),
+val noTestSettings = Seq(
   libraryDependencies --= Seq(
     "org.specs2" %%% "specs2-core" % "4.8.3" % Test
   ),
-  nativeLinkStubs := true,
-  nativeMode := "release"
+  test := (())
 )
 
 val publishSettings = Seq(
@@ -61,12 +49,33 @@ val noPublishSettings = Seq(
   publishTo := None
 )
 
-lazy val root = (project in file("."))
+val jsSettings = Seq(
+  libraryDependencies ++= Seq(
+    "org.scala-js" %%% "scalajs-dom" % "1.0.0"
+  )
+)
+
+val nativeSettings = Seq(
+  scalaVersion := "2.11.12",
+  crossScalaVersions := Seq("2.11.12"),
+  libraryDependencies ++= Seq(
+    "com.regblanc" %%% "native-sdl2" % "0.1"
+  ),
+  nativeLinkStubs := true,
+  nativeMode := "release"
+) ++ noPublishSettings ++ noTestSettings
+
+
+lazy val root =
+  crossProject(JVMPlatform, JSPlatform, NativePlatform)
+  .in(file("."))
   .settings(sharedSettings)
   .settings(name := "minart")
   .settings(publishSettings)
-  .dependsOn(core.jvm, core.js, pure.jvm, pure.js)
-  .aggregate(core.jvm, core.js, pure.jvm, pure.js)
+  .jsSettings(jsSettings)
+  .nativeSettings(nativeSettings)
+  .dependsOn(core, pure)
+  .aggregate(core, pure)
 
 lazy val core =
   crossProject(JVMPlatform, JSPlatform, NativePlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -102,8 +102,8 @@ lazy val examples = (project in file("examples"))
     .aggregate(
       `examples-colorSquare`.jvm,     `examples-colorSquare`.js,
       `examples-pureColorSquare`.jvm, `examples-pureColorSquare`.js,
-      `examples-fire`.jvm,            `examples-fire`.js,           
-      `examples-snake`.jvm,           `examples-snake`.js,          
+      `examples-fire`.jvm,            `examples-fire`.js,
+      `examples-snake`.jvm,           `examples-snake`.js,
       `examples-mousePointer`.jvm,    `examples-mousePointer`.js)
 
 def example(project: sbtcrossproject.CrossProject.Builder, exampleName: String) = {


### PR DESCRIPTION
Another cleanup of the build definition. I believe this fixes the problems with the `minart` package.

It also improves a bit the handling of scala-native subprojects, although it's still not ideal.