### PR TITLE
Avoid boxing on the AwtCanvas

### DIFF
--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -65,11 +65,9 @@ class AwtCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
         y * settings.scaledWidth + x % settings.scaledWidth,
         pack(c.r, c.g, c.b))
 
-  private[this] val _putPixel =
-    if (settings.scale == 1) { (x: Int, y: Int, c: Color) => putPixelUnscaled(x, y, c) }
-    else { (x: Int, y: Int, c: Color) => putPixelScaled(x, y, c) }
-
-  def putPixel(x: Int, y: Int, color: Color): Unit = _putPixel(x, y, color)
+  def putPixel(x: Int, y: Int, color: Color): Unit =
+    if (settings.scale == 1) putPixelUnscaled(x, y, color)
+    else putPixelScaled(x, y, color)
 
   def getBackbufferPixel(x: Int, y: Int): Color = {
     unpack(javaCanvas.imagePixels.getElem(y * settings.scale * settings.scaledWidth + (x * settings.scale)))


### PR DESCRIPTION
Turns out that one of my "optimizations" on the `AwtCanvas#putPixel` was actually making everything slower.

Since the internal `_putPixel` was a `Function3` (which, unlike `Function2`, is not specialized), this forced the integers to be boxed on all `putPixel` operaitons 🤦 

This change made one of my test codebases go from 40 to 60 FPSs (it's actually capped at 60, so it might be even better).

I'm keeping the `_putPixel` in scala-native for a while, although I should revise that in the future (I'll perform some benchmarks and optimizations once I update to 0.4.x).