### PR TITLE
Add a pollFuture method to RIO/CanvasIO

### DIFF
--- a/pure/shared/src/main/scala/eu/joaocosta/minart/pure/CanvasIO.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/pure/CanvasIO.scala
@@ -1,5 +1,8 @@
 package eu.joaocosta.minart.pure
 
+import scala.concurrent.Future
+import scala.util.Try
+
 import eu.joaocosta.minart.core._
 
 /**
@@ -18,6 +21,9 @@ object CanvasIO {
 
   /** Store an unsafe canvas operation in a [[CanvasIO]]. */
   def accessCanvas[A](f: Canvas => A): CanvasIO[A] = RIO.access[Canvas, A](f)
+
+  /** Polls a future and optionally returns its result. */
+  def pollFuture[A](future: Future[A]): CanvasIO[Option[Try[A]]] = RIO.pollFuture(future)
 
   /** Fetches the canvas settings. */
   val getSettings: CanvasIO[Canvas.Settings] = accessCanvas(_.settings)

--- a/pure/shared/src/test/scala/eu/joaocosta/minart/pure/RIOSpec.scala
+++ b/pure/shared/src/test/scala/eu/joaocosta/minart/pure/RIOSpec.scala
@@ -1,5 +1,7 @@
 package eu.joaocosta.minart.pure
 
+import scala.concurrent._
+
 import org.specs2.mutable._
 
 import eu.joaocosta.minart.core._
@@ -16,6 +18,14 @@ class RIOSpec extends Specification {
       hasRun === false
       io.run(())
       hasRun === true
+    }
+
+    "allow polling Futures" in {
+      val promise = Promise[Int]
+      val io = RIO.pollFuture(promise.future)
+      io.run(()) === None
+      promise.complete(scala.util.Success(0))
+      io.run(()) === Some(scala.util.Success(0))
     }
 
     "provide a stack-safe map operation" in {


### PR DESCRIPTION
Working with scala.js libraries and CanvasIO can be painful, since a lot of them have to return futures.

This PR adds a `pollFuture` method, that can be useful to convert `Future`s into `RIO`s, with something like:

```scala
for {
  _ <- CanvasIO.clear()
  futureResult <- RIO.suspend(unsafeAsyncOperation) 
  ioResult = RIO.pollFuture(FutureResult) // Note: We don't want to flatMap this IO, we want to keep it around
  // Render stuff...
  _ <- CanvasIO.redraw
} yield ioResult // Store this new IO in the state, and poll it on each frame
```

One could also just store the `Future`s in the state, but I feel like this makes things "purer" and helps to simplify some for loops