### PR TITLE
Avoid repeated allocations on traverse and foreach

### DIFF
--- a/pure/shared/src/main/scala/eu/joaocosta/minart/pure/CanvasIO.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/pure/CanvasIO.scala
@@ -74,17 +74,17 @@ object CanvasIO {
 
   /** Converts an `Iterable[CanvasIO[A]]` into a `CanvasIO[List[A]]`. */
   def sequence[A](it: Iterable[CanvasIO[A]]): CanvasIO[List[A]] =
-    accessCanvas(canvas => it.map(_.run(canvas)).toList)
+    RIO.sequence[Canvas, A](it)
 
   /** Converts an `Iterable[CanvasIO[A]]` into a `CanvasIO[Unit]`. */
   def sequence_(it: Iterable[CanvasIO[Any]]): CanvasIO[Unit] =
-    accessCanvas(canvas => it.foreach(_.run(canvas)))
+    RIO.sequence_[Canvas](it)
 
   /** Converts an `Iterable[A]` into a `CanvasIO[List[B]]` by applying an operation to each element. */
   def traverse[A, B](it: Iterable[A])(f: A => CanvasIO[B]): CanvasIO[List[B]] =
-    sequence(it.map(f))
+    RIO.traverse[Canvas, A, B](it)(f)
 
   /** Applies an operation to each element of a `Iterable[A]` and discards the result. */
   def foreach[A](it: Iterable[A])(f: A => CanvasIO[Any]): CanvasIO[Unit] =
-    sequence_(it.map(f))
+    RIO.foreach[Canvas, A](it)(f)
 }

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/pure/RIO.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/pure/RIO.scala
@@ -68,9 +68,9 @@ object RIO {
 
   /** Converts an `Iterable[A]` into a `RIO[R, List[B]]` by applying an operation to each element. */
   def traverse[R, A, B](it: Iterable[A])(f: A => RIO[R, B]): RIO[R, List[B]] =
-    sequence(it.map(f))
+    access(res => it.map(x => f(x).run(res)).toList)
 
   /** Applies an operation to each element of a `Iterable[A]` and discards the result. */
   def foreach[R, A](it: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
-    sequence_(it.map(f))
+    access(res => it.foreach(x => f(x).run(res)))
 }


### PR DESCRIPTION
Avoids some allocations on `traverse` and `foreach`

This is particularly useful so that if you write something like `CanvasIO.foreach(allPixels){case (x, y) => CanvasIO.putPixel(x, y, color(x, y))}` you don't allocate a new collection with a bunch of CanvasIO objects.