### PR TITLE
Improve SdlCanvas performance

### DIFF
--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -61,11 +61,9 @@ class SdlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
     SDL_RenderDrawPoint(renderer, x, y)
   }
 
-  private[this] val _putPixel =
-    if (settings.scale == 1) { (x: Int, y: Int, c: Color) => putPixelUnscaled(x, y, c) }
-    else { (x: Int, y: Int, c: Color) => putPixelScaled(x, y, c) }
-
-  def putPixel(x: Int, y: Int, color: Color): Unit = _putPixel(x, y, color)
+  def putPixel(x: Int, y: Int, color: Color): Unit =
+    if (settings.scale == 1) putPixelUnscaled(x, y, color)
+    else putPixelScaled(x, y, color)
 
   def getBackbufferPixel(x: Int, y: Int): Color = {
     // Assuming a BGRA surface


### PR DESCRIPTION
Same fix as #30, although the performance gains were a bit smaller.

I changed my mind regarding waiting for Scala Native 0.4.x, since that release might still take some time.