### PR TITLE
Reduce memory pressure

### DIFF
--- a/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
+++ b/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
@@ -66,10 +66,15 @@ class HtmlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
 
   private[this] val buffer = ctx.getImageData(0, 0, settings.scaledWidth, settings.scaledHeight)
 
+  private[this] val allPixels = (0 until 4 * (settings.scaledHeight * settings.scaledWidth) by 4)
+  private[this] val pixelSize = (0 until settings.scale)
+  private[this] val lines = (0 until settings.height)
+  private[this] val columns = (0 until settings.width)
+
   private[this] def putPixelScaled(x: Int, y: Int, c: Color): Unit =
-    (0 until settings.scale).foreach { dy =>
+    pixelSize.foreach { dy =>
       val lineBase = (y * settings.scale + dy) * settings.scaledWidth
-      (0 until settings.scale).foreach { dx =>
+      pixelSize.foreach { dx =>
         val baseAddr = 4 * (lineBase + (x * settings.scale + dx))
         buffer.data(baseAddr + 0) = c.r
         buffer.data(baseAddr + 1) = c.g
@@ -99,9 +104,9 @@ class HtmlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
 
   def getBackbuffer(): Vector[Vector[Color]] = {
     val imgData = buffer.data
-    (0 until settings.height).map { y =>
+    lines.map { y =>
       val lineBase = y * settings.scale * settings.scaledWidth
-      (0 until settings.width).map { x =>
+      columns.map { x =>
         val baseAddr = 4 * (lineBase + (x * settings.scale))
         Color(imgData(baseAddr).toShort, imgData(baseAddr + 1).toShort, imgData(baseAddr + 2).toShort)
       }.toVector
@@ -110,7 +115,7 @@ class HtmlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
 
   def clear(resources: Set[Canvas.Resource]): Unit = {
     if (resources.contains(Canvas.Resource.Backbuffer)) {
-      for (i <- (0 until (4 * settings.scaledHeight * settings.scaledWidth)) by 4) {
+      allPixels.foreach { i =>
         buffer.data(i + 0) = settings.clearColor.r
         buffer.data(i + 1) = settings.clearColor.g
         buffer.data(i + 2) = settings.clearColor.b

--- a/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
+++ b/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
@@ -92,9 +92,9 @@ class HtmlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
   def getBackbufferPixel(x: Int, y: Int): Color = {
     val baseAddr = 4 * (y * settings.scale * settings.scaledWidth + (x * settings.scale))
     Color(
-      buffer.data(baseAddr + 0).toInt,
-      buffer.data(baseAddr + 1).toInt,
-      buffer.data(baseAddr + 2).toInt)
+      buffer.data(baseAddr + 0).toShort,
+      buffer.data(baseAddr + 1).toShort,
+      buffer.data(baseAddr + 2).toShort)
   }
 
   def getBackbuffer(): Vector[Vector[Color]] = {
@@ -103,7 +103,7 @@ class HtmlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
       val lineBase = y * settings.scale * settings.scaledWidth
       (0 until settings.width).map { x =>
         val baseAddr = 4 * (lineBase + (x * settings.scale))
-        Color(imgData(baseAddr), imgData(baseAddr + 1), imgData(baseAddr + 2))
+        Color(imgData(baseAddr).toShort, imgData(baseAddr + 1).toShort, imgData(baseAddr + 2).toShort)
       }.toVector
     }.toVector
   }

--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -40,9 +40,9 @@ class AwtCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
 
   private[this] def unpack(c: Int): Color =
     Color(
-      r = (c & 0x00FF0000) >> 16,
-      g = (c & 0x0000FF00) >> 8,
-      b = (c & 0x000000FF))
+      r = ((c & 0x00FF0000) >> 16).toShort,
+      g = ((c & 0x0000FF00) >> 8).toShort,
+      b = ((c & 0x000000FF)).toShort)
 
   private[this] val packedClearColor = pack(settings.clearColor.r, settings.clearColor.g, settings.clearColor.b)
 

--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -41,19 +41,19 @@ class SdlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
   private[this] val ubyteClearG = settings.clearColor.g.toUByte
   private[this] val ubyteClearB = settings.clearColor.b.toUByte
 
+  private[this] val pixelSize = (0 until settings.scale)
+  private[this] val lines = (0 until settings.height)
+  private[this] val columns = (0 until settings.width)
+
   private[this] def putPixelScaled(x: Int, y: Int, c: Color): Unit = {
-    var dy = 0
-    while (dy < settings.scale) {
-      var dx = 0
+    pixelSize.foreach { dy =>
       val lineBase = (y * settings.scale + dy) * settings.scaledWidth
-      while (dx < settings.scale) {
+      pixelSize.foreach { dx =>
         val baseAddr = 4 * (lineBase + (x * settings.scale + dx))
         surface.pixels(baseAddr + 0) = c.b.toByte
         surface.pixels(baseAddr + 1) = c.g.toByte
         surface.pixels(baseAddr + 2) = c.r.toByte
-        dx = dx + 1
       }
-      dy = dy + 1
     }
   }
 
@@ -80,9 +80,9 @@ class SdlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
   }
 
   def getBackbuffer(): Vector[Vector[Color]] = {
-    (0 until settings.height).map { y =>
+    lines.map { y =>
       val lineBase = y * settings.scale * settings.scaledWidth
-      (0 until settings.width).map { x =>
+      columns.map { x =>
         val baseAddr = 4 * (lineBase + (x * settings.scale))
         Color(
           (surface.pixels(baseAddr + 2) & 0xFF).toShort,

--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -74,9 +74,9 @@ class SdlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
     // Assuming a BGRA surface
     val baseAddr = 4 * (y * settings.scale * settings.scaledWidth + (x * settings.scale))
     Color(
-      surface.pixels(baseAddr + 2).toInt & 0xFF,
-      surface.pixels(baseAddr + 1).toInt & 0xFF,
-      surface.pixels(baseAddr + 0).toInt & 0xFF)
+      (surface.pixels(baseAddr + 2) & 0xFF).toShort,
+      (surface.pixels(baseAddr + 1) & 0xFF).toShort,
+      (surface.pixels(baseAddr + 0) & 0xFF).toShort)
   }
 
   def getBackbuffer(): Vector[Vector[Color]] = {
@@ -85,9 +85,9 @@ class SdlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
       (0 until settings.width).map { x =>
         val baseAddr = 4 * (lineBase + (x * settings.scale))
         Color(
-          surface.pixels(baseAddr + 2).toInt & 0xFF,
-          surface.pixels(baseAddr + 1).toInt & 0xFF,
-          surface.pixels(baseAddr + 0).toInt & 0xFF)
+          (surface.pixels(baseAddr + 2) & 0xFF).toShort,
+          (surface.pixels(baseAddr + 1) & 0xFF).toShort,
+          (surface.pixels(baseAddr + 0) & 0xFF).toShort)
       }.toVector
     }.toVector
   }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/core/Color.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/core/Color.scala
@@ -1,4 +1,4 @@
 package eu.joaocosta.minart.core
 
 /** RGB Color */
-final case class Color(r: Int, g: Int, b: Int)
+final case class Color(r: Short, g: Short, b: Short)

--- a/examples/colorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/ColorSquare.scala
+++ b/examples/colorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/ColorSquare.scala
@@ -15,7 +15,7 @@ object ColorSquare {
         x <- (0 until c.settings.width)
         y <- (0 until c.settings.height)
       } {
-        val color = Color((255 * x.toDouble / c.settings.width).toInt, (255 * y.toDouble / c.settings.height).toInt, 255)
+        val color = Color((255 * x.toDouble / c.settings.width).toShort, (255 * y.toDouble / c.settings.height).toShort, 255)
         c.putPixel(x, y, color)
       }
       c.redraw()

--- a/examples/fire/shared/src/main/scala/eu/joaocosta/minart/examples/Fire.scala
+++ b/examples/fire/shared/src/main/scala/eu/joaocosta/minart/examples/Fire.scala
@@ -28,7 +28,7 @@ object Fire {
         }
       val randomLoss = 0.8 + (scala.util.Random.nextDouble() / 5)
       val temperature = ((neighbors.map(c => (c.r + c.g + c.b) / 3).sum / 3) * randomLoss).toInt
-      Color(math.min(255, temperature * 1.6 * temperatureMod).toInt, (temperature * 0.8 * temperatureMod).toInt, (temperature * 0.6 * temperatureMod).toInt)
+      Color(math.min(255, temperature * 1.6 * temperatureMod).toShort, (temperature * 0.8 * temperatureMod).toShort, (temperature * 0.6 * temperatureMod).toShort)
     }
 
     RenderLoop.default().infiniteRenderLoop(canvas, safeCanvas => {

--- a/examples/purecolorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/PureColorSquare.scala
+++ b/examples/purecolorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/PureColorSquare.scala
@@ -19,10 +19,9 @@ object PureColorSquare extends MinartApp {
       for {
         x <- (0 until settings.width)
         y <- (0 until settings.height)
-        r = (255 * x.toDouble / settings.width).toInt
-        g = (255 * y.toDouble / settings.height).toInt
-        b = 255
-      } yield CanvasIO.putPixel(x, y, Color(r, g, b))
+        r = (255 * x.toDouble / settings.width).toShort
+        g = (255 * y.toDouble / settings.height).toShort
+      } yield CanvasIO.putPixel(x, y, Color(r, g, 255))
     }.flatMap(CanvasIO.sequence)
       .andThen(CanvasIO.redraw)
   }

--- a/examples/snake/shared/src/main/scala/eu/joaocosta/minart/examples/Snake.scala
+++ b/examples/snake/shared/src/main/scala/eu/joaocosta/minart/examples/Snake.scala
@@ -73,7 +73,7 @@ object Snake {
           (line, y) <- state.board.zipWithIndex
           (value, x) <- line.zipWithIndex
           if (value > 0)
-        } c.putPixel(x, y, Color(0, 55 + (200 * value / state.snakeSize), 0))
+        } c.putPixel(x, y, Color(0, (55 + (200 * value / state.snakeSize)).toShort, 0))
 
         c.putPixel(state.snakeHead._1, state.snakeHead._2, Color(0, 255, 0))
         c.putPixel(state.applePos._1, state.applePos._2, Color(255, 0, 0))


### PR DESCRIPTION
While debugging [Hyper Loop Runner](https://github.com/JD557/HyperLoopRunner) I noticed that there were a lot of `Color` and `RangeExclusive` allocations.

This PR preallocates all ranges used by the `Canvas` and reduces the size of the `Color` object. This has actually showed some very nice performance improvements.