### PR TITLE
Change Color to a value class with an Int

### DIFF
--- a/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
+++ b/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
@@ -97,9 +97,9 @@ class HtmlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
   def getBackbufferPixel(x: Int, y: Int): Color = {
     val baseAddr = 4 * (y * settings.scale * settings.scaledWidth + (x * settings.scale))
     Color(
-      buffer.data(baseAddr + 0).toShort,
-      buffer.data(baseAddr + 1).toShort,
-      buffer.data(baseAddr + 2).toShort)
+      buffer.data(baseAddr + 0),
+      buffer.data(baseAddr + 1),
+      buffer.data(baseAddr + 2))
   }
 
   def getBackbuffer(): Vector[Vector[Color]] = {
@@ -108,7 +108,7 @@ class HtmlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
       val lineBase = y * settings.scale * settings.scaledWidth
       columns.map { x =>
         val baseAddr = 4 * (lineBase + (x * settings.scale))
-        Color(imgData(baseAddr).toShort, imgData(baseAddr + 1).toShort, imgData(baseAddr + 2).toShort)
+        Color(imgData(baseAddr), imgData(baseAddr + 1), imgData(baseAddr + 2))
       }.toVector
     }.toVector
   }

--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -74,9 +74,9 @@ class SdlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
     // Assuming a BGRA surface
     val baseAddr = 4 * (y * settings.scale * settings.scaledWidth + (x * settings.scale))
     Color(
-      (surface.pixels(baseAddr + 2) & 0xFF).toShort,
-      (surface.pixels(baseAddr + 1) & 0xFF).toShort,
-      (surface.pixels(baseAddr + 0) & 0xFF).toShort)
+      (surface.pixels(baseAddr + 2) & 0xFF),
+      (surface.pixels(baseAddr + 1) & 0xFF),
+      (surface.pixels(baseAddr + 0) & 0xFF))
   }
 
   def getBackbuffer(): Vector[Vector[Color]] = {
@@ -85,9 +85,9 @@ class SdlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
       columns.map { x =>
         val baseAddr = 4 * (lineBase + (x * settings.scale))
         Color(
-          (surface.pixels(baseAddr + 2) & 0xFF).toShort,
-          (surface.pixels(baseAddr + 1) & 0xFF).toShort,
-          (surface.pixels(baseAddr + 0) & 0xFF).toShort)
+          (surface.pixels(baseAddr + 2) & 0xFF),
+          (surface.pixels(baseAddr + 1) & 0xFF),
+          (surface.pixels(baseAddr + 0) & 0xFF))
       }.toVector
     }.toVector
   }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/core/Color.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/core/Color.scala
@@ -1,4 +1,19 @@
 package eu.joaocosta.minart.core
 
 /** RGB Color */
-final case class Color(r: Short, g: Short, b: Short)
+final class Color private (val argb: Int) extends AnyVal {
+  @inline def r: Int = (argb & 0x00FF0000) >> 16
+  @inline def g: Int = (argb & 0x0000FF00) >> 8
+  @inline def b: Int = (argb & 0x000000FF)
+}
+
+object Color {
+  def apply(r: Int, g: Int, b: Int): Color =
+    new Color((255 << 24) | ((r & 255) << 16) | ((g & 255) << 8) | (b & 255))
+
+  def fromRGB(rgb: Int): Color =
+    new Color(0xFF000000 | rgb)
+
+  def unapply(color: Color): Some[(Int, Int, Int)] =
+    Some(color.r, color.g, color.b)
+}

--- a/examples/colorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/ColorSquare.scala
+++ b/examples/colorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/ColorSquare.scala
@@ -15,7 +15,7 @@ object ColorSquare {
         x <- (0 until c.settings.width)
         y <- (0 until c.settings.height)
       } {
-        val color = Color((255 * x.toDouble / c.settings.width).toShort, (255 * y.toDouble / c.settings.height).toShort, 255)
+        val color = Color((255 * x.toDouble / c.settings.width).toInt, (255 * y.toDouble / c.settings.height).toInt, 255)
         c.putPixel(x, y, color)
       }
       c.redraw()

--- a/examples/fire/shared/src/main/scala/eu/joaocosta/minart/examples/Fire.scala
+++ b/examples/fire/shared/src/main/scala/eu/joaocosta/minart/examples/Fire.scala
@@ -28,7 +28,7 @@ object Fire {
         }
       val randomLoss = 0.8 + (scala.util.Random.nextDouble() / 5)
       val temperature = ((neighbors.map(c => (c.r + c.g + c.b) / 3).sum / 3) * randomLoss).toInt
-      Color(math.min(255, temperature * 1.6 * temperatureMod).toShort, (temperature * 0.8 * temperatureMod).toShort, (temperature * 0.6 * temperatureMod).toShort)
+      Color(math.min(255, temperature * 1.6 * temperatureMod).toInt, (temperature * 0.8 * temperatureMod).toInt, (temperature * 0.6 * temperatureMod).toInt)
     }
 
     RenderLoop.default().infiniteRenderLoop(canvas, safeCanvas => {

--- a/examples/purecolorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/PureColorSquare.scala
+++ b/examples/purecolorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/PureColorSquare.scala
@@ -19,8 +19,8 @@ object PureColorSquare extends MinartApp {
       for {
         x <- (0 until settings.width)
         y <- (0 until settings.height)
-        r = (255 * x.toDouble / settings.width).toShort
-        g = (255 * y.toDouble / settings.height).toShort
+        r = (255 * x.toDouble / settings.width).toInt
+        g = (255 * y.toDouble / settings.height).toInt
       } yield CanvasIO.putPixel(x, y, Color(r, g, 255))
     }.flatMap(CanvasIO.sequence)
       .andThen(CanvasIO.redraw)

--- a/examples/snake/shared/src/main/scala/eu/joaocosta/minart/examples/Snake.scala
+++ b/examples/snake/shared/src/main/scala/eu/joaocosta/minart/examples/Snake.scala
@@ -73,7 +73,7 @@ object Snake {
           (line, y) <- state.board.zipWithIndex
           (value, x) <- line.zipWithIndex
           if (value > 0)
-        } c.putPixel(x, y, Color(0, (55 + (200 * value / state.snakeSize)).toShort, 0))
+        } c.putPixel(x, y, Color(0, (55 + (200 * value / state.snakeSize)), 0))
 
         c.putPixel(state.snakeHead._1, state.snakeHead._2, Color(0, 255, 0))
         c.putPixel(state.applePos._1, state.applePos._2, Color(255, 0, 0))


### PR DESCRIPTION
Followup to #41. This reduces the memory pressure even more.

While `AnyVal`s might sometimes box, having a boxed int is still better than 3 shorts.