### PR TITLE
Wrap rendering operations inside a try-catch

### DIFF
--- a/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
+++ b/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
@@ -90,9 +90,10 @@ class HtmlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
     buffer.data(baseAddr + 2) = c.b
   }
 
-  def putPixel(x: Int, y: Int, color: Color): Unit =
+  def putPixel(x: Int, y: Int, color: Color): Unit = try {
     if (settings.scale == 1) putPixelUnscaled(x, y, color)
     else putPixelScaled(x, y, color)
+  } catch { case _: Throwable => () }
 
   def getBackbufferPixel(x: Int, y: Int): Color = {
     val baseAddr = 4 * (y * settings.scale * settings.scaledWidth + (x * settings.scale))

--- a/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
+++ b/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
@@ -124,10 +124,10 @@ class HtmlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
       }
     }
     if (resources.contains(Canvas.Resource.Keyboard)) {
-      keyboardInput = keyboardInput.clearPressRelease
+      keyboardInput = keyboardInput.clearPressRelease()
     }
     if (resources.contains(Canvas.Resource.Pointer)) {
-      pointerInput = pointerInput.clearPressRelease
+      pointerInput = pointerInput.clearPressRelease()
     }
   }
 

--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -61,9 +61,10 @@ class AwtCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
         y * settings.scaledWidth + x % settings.scaledWidth,
         c.argb)
 
-  def putPixel(x: Int, y: Int, color: Color): Unit =
+  def putPixel(x: Int, y: Int, color: Color): Unit = try {
     if (settings.scale == 1) putPixelUnscaled(x, y, color)
     else putPixelScaled(x, y, color)
+  } catch { case _: Throwable => () }
 
   def getBackbufferPixel(x: Int, y: Int): Color = {
     Color.fromRGB(javaCanvas.imagePixels.getElem(y * settings.scale * settings.scaledWidth + (x * settings.scale)))
@@ -92,12 +93,12 @@ class AwtCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
     }
   }
 
-  def redraw(): Unit = {
+  def redraw(): Unit = try {
     val g = javaCanvas.buffStrategy.getDrawGraphics()
     g.drawImage(javaCanvas.image, 0, 0, settings.scaledWidth, settings.scaledHeight, javaCanvas)
     g.dispose()
     javaCanvas.buffStrategy.show()
-  }
+  } catch { case _: Throwable => () }
 
   def getKeyboardInput(): KeyboardInput = keyListener.getKeyboardInput()
   def getPointerInput(): PointerInput = mouseListener.getPointerInput()

--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -66,9 +66,10 @@ class SdlCanvas(val settings: Canvas.Settings) extends LowLevelCanvas {
     surface.pixels(baseAddr + 2) = c.r.toByte
   }
 
-  def putPixel(x: Int, y: Int, color: Color): Unit =
+  def putPixel(x: Int, y: Int, color: Color): Unit = try {
     if (settings.scale == 1) putPixelUnscaled(x, y, color)
     else putPixelScaled(x, y, color)
+  } catch { case _: Throwable => () }
 
   def getBackbufferPixel(x: Int, y: Int): Color = {
     // Assuming a BGRA surface

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/pure/CanvasIO.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/pure/CanvasIO.scala
@@ -53,7 +53,7 @@ object CanvasIO {
    * This operation can be perfomance intensive, so it might be worthwile
    * to implement this operation on the application code.
    */
-  val getBackbuffer: CanvasIO[Vector[Vector[Color]]] = accessCanvas(_.getBackbuffer)
+  val getBackbuffer: CanvasIO[Vector[Vector[Color]]] = accessCanvas(_.getBackbuffer())
 
   /** Gets the current keyboard input. */
   val getKeyboardInput: CanvasIO[KeyboardInput] = accessCanvas(_.getKeyboardInput())


### PR DESCRIPTION
Wraps the put pixel operations inside a try catch block that swallows all exceptions.

This doesn't seem to have a performance impact on valid operations and is a nice step towards #45, where a bad `putPixel` call should not blow everything up.

I also wrapped the `AwtCanvas#redaw` operation, which should stop throwing exceptions when the canvas is closed.