### PR TITLE
Split render loops into pure and impure render loops

### DIFF
--- a/core/js/src/main/scala/eu/joaocosta/minart/backend/JsRenderLoop.scala
+++ b/core/js/src/main/scala/eu/joaocosta/minart/backend/JsRenderLoop.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.timers
 
 import eu.joaocosta.minart.core._
 
-object JsRenderLoop extends RenderLoop.ImpureRenderLoop {
+object JsRenderLoop extends ImpureRenderLoop {
   def finiteRenderLoop[S](
     canvasManager: CanvasManager,
     initialState: S,

--- a/core/js/src/main/scala/eu/joaocosta/minart/backend/JsRenderLoop.scala
+++ b/core/js/src/main/scala/eu/joaocosta/minart/backend/JsRenderLoop.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.timers
 
 import eu.joaocosta.minart.core._
 
-object JsRenderLoop extends RenderLoop {
+object JsRenderLoop extends RenderLoop.ImpureRenderLoop {
   def finiteRenderLoop[S](
     canvasManager: CanvasManager,
     initialState: S,

--- a/core/js/src/test/scala/eu/joaocosta/minart/backend/JsRenderLoopSpec.scala
+++ b/core/js/src/test/scala/eu/joaocosta/minart/backend/JsRenderLoopSpec.scala
@@ -3,7 +3,7 @@ package eu.joaocosta.minart.backend
 import eu.joaocosta.minart.core._
 
 class JsRenderLoopSpec extends RenderLoopTests {
-  lazy val renderLoop: RenderLoop = JsRenderLoop
+  lazy val renderLoop: RenderLoop.ImpureRenderLoop = JsRenderLoop
   lazy val renderLoopName: String = "JsRenderLoop"
   override lazy val testLoop: Boolean = false
 }

--- a/core/js/src/test/scala/eu/joaocosta/minart/backend/JsRenderLoopSpec.scala
+++ b/core/js/src/test/scala/eu/joaocosta/minart/backend/JsRenderLoopSpec.scala
@@ -1,9 +1,10 @@
 package eu.joaocosta.minart.backend
 
+import eu.joaocosta.minart.backend._
 import eu.joaocosta.minart.core._
 
 class JsRenderLoopSpec extends RenderLoopTests {
-  lazy val renderLoop: RenderLoop.ImpureRenderLoop = JsRenderLoop
+  lazy val renderLoop: ImpureRenderLoop = JsRenderLoop
   lazy val renderLoopName: String = "JsRenderLoop"
   override lazy val testLoop: Boolean = false
 }

--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaRenderLoop.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaRenderLoop.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration.FiniteDuration
 
 import eu.joaocosta.minart.core._
 
-object JavaRenderLoop extends RenderLoop.ImpureRenderLoop {
+object JavaRenderLoop extends ImpureRenderLoop {
   def finiteRenderLoop[S](
     canvasManager: CanvasManager,
     initialState: S,

--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaRenderLoop.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaRenderLoop.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration.FiniteDuration
 
 import eu.joaocosta.minart.core._
 
-object JavaRenderLoop extends RenderLoop {
+object JavaRenderLoop extends RenderLoop.ImpureRenderLoop {
   def finiteRenderLoop[S](
     canvasManager: CanvasManager,
     initialState: S,

--- a/core/jvm/src/test/scala/eu/joaocosta/minart/backend/JavaRenderLoopSpec.scala
+++ b/core/jvm/src/test/scala/eu/joaocosta/minart/backend/JavaRenderLoopSpec.scala
@@ -1,8 +1,9 @@
 package eu.joaocosta.minart.backend
 
+import eu.joaocosta.minart.backend._
 import eu.joaocosta.minart.core._
 
 class JavaRenderLoopSpec extends RenderLoopTests {
-  lazy val renderLoop: RenderLoop.ImpureRenderLoop = JavaRenderLoop
+  lazy val renderLoop: ImpureRenderLoop = JavaRenderLoop
   lazy val renderLoopName: String = "JavaRenderLoop"
 }

--- a/core/jvm/src/test/scala/eu/joaocosta/minart/backend/JavaRenderLoopSpec.scala
+++ b/core/jvm/src/test/scala/eu/joaocosta/minart/backend/JavaRenderLoopSpec.scala
@@ -3,6 +3,6 @@ package eu.joaocosta.minart.backend
 import eu.joaocosta.minart.core._
 
 class JavaRenderLoopSpec extends RenderLoopTests {
-  lazy val renderLoop: RenderLoop = JavaRenderLoop
+  lazy val renderLoop: RenderLoop.ImpureRenderLoop = JavaRenderLoop
   lazy val renderLoopName: String = "JavaRenderLoop"
 }

--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlRenderLoop.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlRenderLoop.scala
@@ -9,7 +9,7 @@ import sdl2.SDL._
 
 import eu.joaocosta.minart.core._
 
-object SdlRenderLoop extends RenderLoop.ImpureRenderLoop {
+object SdlRenderLoop extends ImpureRenderLoop {
   def finiteRenderLoop[S](
     canvasManager: CanvasManager,
     initialState: S,

--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlRenderLoop.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlRenderLoop.scala
@@ -9,7 +9,7 @@ import sdl2.SDL._
 
 import eu.joaocosta.minart.core._
 
-object SdlRenderLoop extends RenderLoop {
+object SdlRenderLoop extends RenderLoop.ImpureRenderLoop {
   def finiteRenderLoop[S](
     canvasManager: CanvasManager,
     initialState: S,

--- a/core/shared/src/main/scala/eu/joaocosta/minart/backend/ImpureRenderLoop.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/backend/ImpureRenderLoop.scala
@@ -1,0 +1,27 @@
+package eu.joaocosta.minart.backend
+
+import eu.joaocosta.minart.core._
+import eu.joaocosta.minart.backend.defaults.DefaultBackend
+
+trait ImpureRenderLoop extends RenderLoop[Function1, Function2] {
+  def infiniteRenderLoop[S](
+    canvasManager: CanvasManager,
+    initialState: S,
+    renderFrame: (Canvas, S) => S,
+    frameRate: FrameRate): Unit =
+    finiteRenderLoop(canvasManager, initialState, renderFrame, (_: S) => false, frameRate)
+
+  def infiniteRenderLoop(
+    canvasManager: CanvasManager,
+    renderFrame: Canvas => Unit,
+    frameRate: FrameRate): Unit =
+    infiniteRenderLoop(canvasManager, (), (c: Canvas, _: Unit) => renderFrame(c), frameRate)
+}
+
+object ImpureRenderLoop {
+  /**
+   * Returns an [[ImpureRenderLoop]] for the default backend for the target platform.
+   */
+  def default()(implicit d: DefaultBackend[Any, ImpureRenderLoop]): ImpureRenderLoop =
+    d.defaultValue(())
+}

--- a/core/shared/src/main/scala/eu/joaocosta/minart/core/RenderLoop.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/core/RenderLoop.scala
@@ -6,7 +6,7 @@ import eu.joaocosta.minart.backend.defaults.DefaultBackend
  * The `RenderLoop` contains a set of helpful methods to implement basic render
  * loops in a platform agonstic way.
  */
-trait RenderLoop {
+trait RenderLoop[F1[-_, +_], F2[-_, -_, +_]] {
 
   /**
    * Creates a render loop that terminates when a certain condition is reached.
@@ -22,7 +22,7 @@ trait RenderLoop {
   def finiteRenderLoop[S](
     canvasManager: CanvasManager,
     initialState: S,
-    renderFrame: (Canvas, S) => S,
+    renderFrame: F2[Canvas, S, S],
     terminateWhen: S => Boolean,
     frameRate: FrameRate): Unit
 
@@ -39,9 +39,8 @@ trait RenderLoop {
   def infiniteRenderLoop[S](
     canvasManager: CanvasManager,
     initialState: S,
-    renderFrame: (Canvas, S) => S,
-    frameRate: FrameRate): Unit =
-    finiteRenderLoop(canvasManager, initialState, renderFrame, (_: S) => false, frameRate)
+    renderFrame: F2[Canvas, S, S],
+    frameRate: FrameRate): Unit
 
   /**
    * Creates a render loop that never terminates.
@@ -52,9 +51,8 @@ trait RenderLoop {
    */
   def infiniteRenderLoop(
     canvasManager: CanvasManager,
-    renderFrame: Canvas => Unit,
-    frameRate: FrameRate): Unit =
-    infiniteRenderLoop(canvasManager, (), (c: Canvas, _: Unit) => renderFrame(c), frameRate)
+    renderFrame: F1[Canvas, Unit],
+    frameRate: FrameRate): Unit
 
   /**
    * Renders a single frame
@@ -64,13 +62,30 @@ trait RenderLoop {
    */
   def singleFrame(
     canvasManager: CanvasManager,
-    renderFrame: Canvas => Unit): Unit
+    renderFrame: F1[Canvas, Unit]): Unit
 }
 
 object RenderLoop {
+
+  trait ImpureRenderLoop extends RenderLoop[Function1, Function2] {
+    def infiniteRenderLoop[S](
+      canvasManager: CanvasManager,
+      initialState: S,
+      renderFrame: (Canvas, S) => S,
+      frameRate: FrameRate): Unit =
+      finiteRenderLoop(canvasManager, initialState, renderFrame, (_: S) => false, frameRate)
+
+    def infiniteRenderLoop(
+      canvasManager: CanvasManager,
+      renderFrame: Canvas => Unit,
+      frameRate: FrameRate): Unit =
+      infiniteRenderLoop(canvasManager, (), (c: Canvas, _: Unit) => renderFrame(c), frameRate)
+
+  }
+
   /**
    * Returns [[RenderLoop]] for the default backend for the target platform.
    */
-  def default()(implicit d: DefaultBackend[Any, RenderLoop]): RenderLoop =
+  def default()(implicit d: DefaultBackend[Any, ImpureRenderLoop]): ImpureRenderLoop =
     d.defaultValue(())
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/core/RenderLoop.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/core/RenderLoop.scala
@@ -66,26 +66,9 @@ trait RenderLoop[F1[-_, +_], F2[-_, -_, +_]] {
 }
 
 object RenderLoop {
-
-  trait ImpureRenderLoop extends RenderLoop[Function1, Function2] {
-    def infiniteRenderLoop[S](
-      canvasManager: CanvasManager,
-      initialState: S,
-      renderFrame: (Canvas, S) => S,
-      frameRate: FrameRate): Unit =
-      finiteRenderLoop(canvasManager, initialState, renderFrame, (_: S) => false, frameRate)
-
-    def infiniteRenderLoop(
-      canvasManager: CanvasManager,
-      renderFrame: Canvas => Unit,
-      frameRate: FrameRate): Unit =
-      infiniteRenderLoop(canvasManager, (), (c: Canvas, _: Unit) => renderFrame(c), frameRate)
-
-  }
-
   /**
-   * Returns [[RenderLoop]] for the default backend for the target platform.
+   * Returns a [[RenderLoop]] for the default backend for the target platform.
    */
-  def default()(implicit d: DefaultBackend[Any, ImpureRenderLoop]): ImpureRenderLoop =
+  def default()(implicit d: DefaultBackend[Any, RenderLoop[Function1, Function2]]): RenderLoop[Function1, Function2] =
     d.defaultValue(())
 }

--- a/core/shared/src/test/scala/eu/joaocosta/minart/core/RenderLoopTests.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/core/RenderLoopTests.scala
@@ -2,11 +2,11 @@ package eu.joaocosta.minart.core
 
 import org.specs2.mutable._
 
-import eu.joaocosta.minart.backend.PpmCanvas
+import eu.joaocosta.minart.backend._
 
 trait RenderLoopTests extends Specification {
 
-  def renderLoop: RenderLoop.ImpureRenderLoop
+  def renderLoop: ImpureRenderLoop
   def renderLoopName: String
   def testLoop: Boolean = true
 

--- a/core/shared/src/test/scala/eu/joaocosta/minart/core/RenderLoopTests.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/core/RenderLoopTests.scala
@@ -6,7 +6,7 @@ import eu.joaocosta.minart.backend.PpmCanvas
 
 trait RenderLoopTests extends Specification {
 
-  def renderLoop: RenderLoop
+  def renderLoop: RenderLoop.ImpureRenderLoop
   def renderLoopName: String
   def testLoop: Boolean = true
 

--- a/examples/purecolorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/PureColorSquare.scala
+++ b/examples/purecolorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/PureColorSquare.scala
@@ -5,7 +5,7 @@ import eu.joaocosta.minart.pure._
 
 object PureColorSquare extends MinartApp {
   type State = Unit
-  val renderLoop = RenderLoop.default()
+  val renderLoop = PureRenderLoop.default()
   val canvasSettings = Canvas.Settings(
     width = 128,
     height = 128,

--- a/examples/purecolorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/PureColorSquare.scala
+++ b/examples/purecolorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/PureColorSquare.scala
@@ -2,6 +2,7 @@ package eu.joaocosta.minart.examples
 
 import eu.joaocosta.minart.core._
 import eu.joaocosta.minart.pure._
+import eu.joaocosta.minart.pure.backend._
 
 object PureColorSquare extends MinartApp {
   type State = Unit

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/pure/MinartApp.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/pure/MinartApp.scala
@@ -6,7 +6,7 @@ import eu.joaocosta.minart.core._
 trait MinartApp {
   type State
   def canvasManager: CanvasManager
-  def renderLoop: RenderLoop
+  def renderLoop: PureRenderLoop
   def initialState: State
   def renderFrame: State => CanvasIO[State]
   def terminateWhen: State => Boolean
@@ -16,7 +16,7 @@ trait MinartApp {
     renderLoop.finiteRenderLoop[State](
       canvasManager,
       initialState,
-      (canvas, state) => renderFrame(state).run(canvas),
+      renderFrame,
       terminateWhen,
       frameRate)
   }

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/pure/MinartApp.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/pure/MinartApp.scala
@@ -1,6 +1,7 @@
 package eu.joaocosta.minart.pure
 
 import eu.joaocosta.minart.core._
+import eu.joaocosta.minart.pure.backend._
 
 /** Entrypoint for pure Minart applications. */
 trait MinartApp {

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/pure/PureRenderLoop.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/pure/PureRenderLoop.scala
@@ -1,0 +1,57 @@
+package eu.joaocosta.minart.pure
+
+import eu.joaocosta.minart.core._
+import eu.joaocosta.minart.backend.defaults.DefaultBackend
+
+class PureRenderLoop(impureRenderLoop: RenderLoop.ImpureRenderLoop) extends RenderLoop[RIO, PureRenderLoop.StateCanvasIO] {
+
+  def finiteRenderLoop[S](
+    canvasManager: CanvasManager,
+    initialState: S,
+    renderFrame: S => CanvasIO[S],
+    terminateWhen: S => Boolean,
+    frameRate: FrameRate): Unit =
+    impureRenderLoop.finiteRenderLoop[S](
+      canvasManager,
+      initialState,
+      (canvas, state) => renderFrame(state).run(canvas),
+      terminateWhen,
+      frameRate)
+
+  def infiniteRenderLoop[S](
+    canvasManager: CanvasManager,
+    initialState: S,
+    renderFrame: S => CanvasIO[S],
+    frameRate: FrameRate): Unit =
+    impureRenderLoop.infiniteRenderLoop[S](
+      canvasManager,
+      initialState,
+      (canvas, state) => renderFrame(state).run(canvas),
+      frameRate)
+
+  def infiniteRenderLoop(
+    canvasManager: CanvasManager,
+    renderFrame: CanvasIO[Unit],
+    frameRate: FrameRate): Unit =
+    impureRenderLoop.infiniteRenderLoop(
+      canvasManager,
+      canvas => renderFrame.run(canvas),
+      frameRate)
+
+  def singleFrame(
+    canvasManager: CanvasManager,
+    renderFrame: CanvasIO[Unit]): Unit =
+    impureRenderLoop.singleFrame(
+      canvasManager,
+      canvas => renderFrame.run(canvas))
+}
+
+object PureRenderLoop {
+  type StateCanvasIO[-Canvas, -State, +A] = Function1[State, RIO[Canvas, A]]
+
+  /**
+   * Returns [[PureRenderLoop]] for the default backend for the target platform.
+   */
+  def default()(implicit d: DefaultBackend[Any, RenderLoop.ImpureRenderLoop]): PureRenderLoop =
+    new PureRenderLoop(d.defaultValue(()))
+}

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/pure/backend/PureRenderLoop.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/pure/backend/PureRenderLoop.scala
@@ -1,9 +1,11 @@
-package eu.joaocosta.minart.pure
+package eu.joaocosta.minart.pure.backend
 
-import eu.joaocosta.minart.core._
+import eu.joaocosta.minart.backend.ImpureRenderLoop
 import eu.joaocosta.minart.backend.defaults.DefaultBackend
+import eu.joaocosta.minart.core._
+import eu.joaocosta.minart.pure._
 
-class PureRenderLoop(impureRenderLoop: RenderLoop.ImpureRenderLoop) extends RenderLoop[RIO, PureRenderLoop.StateCanvasIO] {
+class PureRenderLoop(impureRenderLoop: ImpureRenderLoop) extends RenderLoop[RIO, PureRenderLoop.StateCanvasIO] {
 
   def finiteRenderLoop[S](
     canvasManager: CanvasManager,
@@ -52,6 +54,6 @@ object PureRenderLoop {
   /**
    * Returns [[PureRenderLoop]] for the default backend for the target platform.
    */
-  def default()(implicit d: DefaultBackend[Any, RenderLoop.ImpureRenderLoop]): PureRenderLoop =
+  def default()(implicit d: DefaultBackend[Any, ImpureRenderLoop]): PureRenderLoop =
     new PureRenderLoop(d.defaultValue(()))
 }


### PR DESCRIPTION
Adds an effect to the `RenderLoop` so that it can be split into pure and impure loops.

This is a step towards #18 (it should now be easier to plug custom effects and not use `MinartApp`), #19 (I wonder if this could be achieved simply by making the effect a Future) and #45 (to potentially allow the usage of pure operations on a live coding environment)