### PR TITLE
Trigger CI on PRs

### DIFF
--- a/.github/workflows/compile_test.yml
+++ b/.github/workflows/compile_test.yml
@@ -1,6 +1,6 @@
 name: Compile and Test
 
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: true # disables SBT super shell which has problems with CI environments


### PR DESCRIPTION
Turns out that the CI was only being triggered on pushes and not PRs. This had the side effect of not starting the tests on scala steward PRs.