### PR TITLE
Add a RIO.when operation

### DIFF
--- a/pure/shared/src/main/scala/eu/joaocosta/minart/pure/CanvasIO.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/pure/CanvasIO.scala
@@ -25,6 +25,10 @@ object CanvasIO {
   def fromCallback[A](operation: (Try[A] => Unit) => Unit): CanvasIO[Poll[A]] =
     RIO.fromCallback(operation)
 
+  /** Runs a computation only if the predicate is true, otherwise does nothing */
+  def when(predicate: Boolean)(io: => CanvasIO[Unit]): CanvasIO[Unit] =
+    RIO.when(predicate)(io)
+
   /** Fetches the canvas settings. */
   val getSettings: CanvasIO[Canvas.Settings] = accessCanvas(_.settings)
 

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/pure/RIO.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/pure/RIO.scala
@@ -71,6 +71,10 @@ object RIO {
     RIO.suspend(operation(promise.complete)).as(Poll.fromFuture(promise.future))
   }
 
+  /** Runs a computation only if the predicate is true, otherwise does nothing */
+  def when[R](predicate: Boolean)(io: => RIO[R, Unit]): RIO[R, Unit] =
+    if (predicate) io else RIO.noop
+
   /** Converts an `Iterable[RIO[R, A]]` into a `RIO[R, List[A]]`. */
   def sequence[R, A](it: Iterable[RIO[R, A]]): RIO[R, List[A]] =
     access(res => it.map(_.run(res)).toList)


### PR DESCRIPTION
Adds a new RIO/CanvasIO `when` operation.

Writing code like `if (foo) renderThing else CanvasIO.noop` is very common and looks ugly inside for-comprehensions. This should improve code like that.