### PR TITLE
Fix AWT Rendering on Linux

### DIFF
--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -144,7 +144,7 @@ object AwtCanvas {
     override def getPreferredSize(): Dimension =
       new Dimension(scaledWidth, scaledHeight)
 
-    val frame = new JFrame()
+    val frame = new JFrame("Minart")
     frame.add(this)
     frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE)
     frame.pack()

--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -148,7 +148,6 @@ object AwtCanvas {
     frame.add(this)
     frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE)
     frame.pack()
-    frame.setResizable(false)
     GraphicsEnvironment
       .getLocalGraphicsEnvironment()
       .getScreenDevices()
@@ -163,6 +162,7 @@ object AwtCanvas {
     override def repaint() = outerCanvas.redraw()
 
     frame.setVisible(true)
+    frame.setResizable(false)
     frame.addWindowListener(new WindowAdapter() {
       override def windowClosing(e: WindowEvent): Unit = {
         outerCanvas.destroy()

--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -129,8 +129,8 @@ class AwtCanvas() extends LowLevelCanvas {
       extendedSettings.scaledHeight,
       javaCanvas
     )
-    g.dispose()
     javaCanvas.buffStrategy.show()
+    g.dispose()
   } catch { case _: Throwable => () }
 
   def getKeyboardInput(): KeyboardInput = keyListener.getKeyboardInput()


### PR DESCRIPTION
Related to #93. Fixes the canvas misalignment and it seems to heavily reduce the probability of getting a blank screen.

I'll leave the issue open, since I seem to still be getting a blank screen ~10% of the time on the color square example (the other examples seem to be working fine).