### PR TITLE
Remove on pull_request from CI flow

### DIFF
--- a/.github/workflows/compile_test.yml
+++ b/.github/workflows/compile_test.yml
@@ -1,6 +1,6 @@
 name: Compile and Test
 
-on: [push, pull_request]
+on: [push]
 
 env:
   CI: true # disables SBT super shell which has problems with CI environments


### PR DESCRIPTION
I don't think this is needed. It was only doubling the CI work.