### PR TITLE
Simplify DefaultBackend logic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,8 +30,10 @@ val sharedSettings = Seq(
   ),
   autoAPIMappings := true,
   scalacOptions ++= Seq(
-    "-unchecked",
-    "-deprecation"
+    "-deprecation",
+    "-feature",
+    "-language:higherKinds",
+    "-unchecked"
     ),
   scalafmtOnCompile := true,
   semanticdbEnabled := true,

--- a/core/shared/src/main/scala/eu/joaocosta/minart/backend/default/DefaultBackend.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/backend/default/DefaultBackend.scala
@@ -1,7 +1,7 @@
 package eu.joaocosta.minart.backend.defaults
 
 /** Typeclass to fetch an implicit default backend (e.g. Canvas or RenderLoop) for a cetain platform.
-  * This is used to power the `Backend.default()` implementations.
+  * This is used to power the `Backend.apply()` implementations.
   * Ideally, an end user of the library should not need to implement this.
   */
 trait DefaultBackend[-A, +B] {
@@ -10,6 +10,8 @@ trait DefaultBackend[-A, +B] {
 }
 
 object DefaultBackend {
+  def apply[A, B](implicit backend: DefaultBackend[A, B]) = backend
+
   def fromFunction[A, B](f: A => B): DefaultBackend[A, B] = new DefaultBackend[A, B] {
     def defaultValue(params: A): B = f(params)
   }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Canvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Canvas.scala
@@ -75,16 +75,12 @@ trait Canvas {
 
 object Canvas {
 
-  implicit def defaultCanvas(implicit d: DefaultBackend[Any, CanvasManager]): DefaultBackend[Canvas.Settings, Canvas] =
-    DefaultBackend.fromFunction((settings) => d.defaultValue().init(settings))
-
-  /** Returns [[Canvas]] for the default backend for the target platform.
+  /** Returns a new [[Canvas]] for the default backend for the target platform.
     *
     * @return [[Canvas]] using the default backend for the target platform
     */
-  def default(settings: Canvas.Settings)(implicit d: DefaultBackend[Any, CanvasManager]): Canvas = {
-    d.defaultValue().init(settings)
-  }
+  def create(settings: Canvas.Settings): Canvas =
+    CanvasManager().init(settings)
 
   /** A system resource used by the Canvas.
     */

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/CanvasManager.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/CanvasManager.scala
@@ -24,16 +24,10 @@ object CanvasManager {
     }
   }
 
-  implicit def defaultCanvasManager(implicit
-      d: DefaultBackend[Any, LowLevelCanvas]
-  ): DefaultBackend[Any, CanvasManager] = DefaultBackend.fromConstant(
-    CanvasManager(() => d.defaultValue())
-  )
-
   /** Returns [[CanvasManager]] for the default backend for the target platform.
     *
     * @return [[CanvasManager]] using the default backend for the target platform
     */
-  def default()(implicit d: DefaultBackend[Any, CanvasManager]): CanvasManager =
-    d.defaultValue()
+  def apply(): CanvasManager =
+    CanvasManager(() => LowLevelCanvas.create())
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/LowLevelCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/LowLevelCanvas.scala
@@ -44,12 +44,12 @@ trait LowLevelCanvas extends Canvas {
 
 object LowLevelCanvas {
 
-  /** Returns [[LowLevelCanvas]] for the default backend for the target platform.
+  /** Returns a new [[LowLevelCanvas]] for the default backend for the target platform.
     *
     * @return [[LowLevelCanvas]] using the default backend for the target platform
     */
-  def default()(implicit d: DefaultBackend[Any, LowLevelCanvas]): LowLevelCanvas =
-    d.defaultValue()
+  def create(): LowLevelCanvas =
+    DefaultBackend[Any, LowLevelCanvas].defaultValue()
 
   /** Internal data structure containing canvas settings and precomputed values.
     */

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RenderLoop.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RenderLoop.scala
@@ -66,10 +66,7 @@ object RenderLoop {
 
   trait StatelessRenderLoop extends StatefulRenderLoop[Unit] {
     def apply(runner: LoopRunner, canvasManager: CanvasManager, canvasSettings: Canvas.Settings): Unit
-    def apply(canvasSettings: Canvas.Settings)(implicit
-        runner: DefaultBackend[Any, LoopRunner],
-        canvasManager: DefaultBackend[Any, CanvasManager]
-    ): Unit = apply(runner.defaultValue(()), canvasManager.defaultValue(()), canvasSettings)
+    def apply(canvasSettings: Canvas.Settings): Unit = apply(LoopRunner(), CanvasManager(), canvasSettings)
     def apply(
         runner: LoopRunner,
         canvasManager: CanvasManager,
@@ -82,10 +79,8 @@ object RenderLoop {
 
   trait StatefulRenderLoop[S] { self =>
     def apply(runner: LoopRunner, canvasManager: CanvasManager, canvasSettings: Canvas.Settings, initialState: S): Unit
-    def apply(canvasSettings: Canvas.Settings, initialState: S)(implicit
-        runner: DefaultBackend[Any, LoopRunner],
-        canvasManager: DefaultBackend[Any, CanvasManager]
-    ): Unit = apply(runner.defaultValue(()), canvasManager.defaultValue(()), canvasSettings, initialState)
+    def apply(canvasSettings: Canvas.Settings, initialState: S): Unit =
+      apply(LoopRunner(), CanvasManager(), canvasSettings, initialState)
     def withInitialState(initialState: S): StatelessRenderLoop = new StatelessRenderLoop {
       def apply(runner: LoopRunner, canvasManager: CanvasManager, canvasSettings: Canvas.Settings): Unit =
         self.apply(runner, canvasManager, canvasSettings, initialState)

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/LoopRunner.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/LoopRunner.scala
@@ -15,6 +15,6 @@ trait LoopRunner {
 }
 
 object LoopRunner {
-  def default()(implicit d: DefaultBackend[Any, LoopRunner]): LoopRunner =
-    d.defaultValue(())
+  def apply(): LoopRunner =
+    DefaultBackend[Any, LoopRunner].defaultValue()
 }

--- a/examples/purecolorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/PureColorSquare.scala
+++ b/examples/purecolorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/PureColorSquare.scala
@@ -7,9 +7,9 @@ import eu.joaocosta.minart.runtime.pure._
 
 object PureColorSquare extends MinartApp {
   type State = Unit
-  val loopRunner     = LoopRunner.default()
+  val loopRunner     = LoopRunner()
   val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = 4)
-  val canvasManager  = CanvasManager.default()
+  val canvasManager  = CanvasManager()
   val initialState   = ()
   val frameRate      = LoopFrequency.Uncapped
   val terminateWhen  = (_: State) => false


### PR DESCRIPTION
Removes most of the implicit logic from the `DefaultBackend` and replaces the `default()` methods with either `apply()` (no side effects) or `create()` potential side-effects.

This seems like a saner default, since it was probably a bad idea to try to override the default backends anyway. It's better to just pass everything explicitly if needed.