### PR TITLE
Add runtime platform detection

### DIFF
--- a/core/js/src/main/scala/eu/joaocosta/minart/backend/defaults/package.scala
+++ b/core/js/src/main/scala/eu/joaocosta/minart/backend/defaults/package.scala
@@ -1,9 +1,14 @@
 package eu.joaocosta.minart.backend
 
+import eu.joaocosta.minart.runtime.Platform
+
 package object defaults {
   implicit val defaultCanvas: DefaultBackend[Any, HtmlCanvas] =
     DefaultBackend.fromFunction((_) => new HtmlCanvas())
 
   implicit val defaultLoopRunner: DefaultBackend[Any, JsLoopRunner.type] =
     DefaultBackend.fromConstant(JsLoopRunner)
+
+  implicit val defaultPlatform: DefaultBackend[Any, Platform.JS.type] =
+    DefaultBackend.fromConstant(Platform.JS)
 }

--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/defaults/package.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/defaults/package.scala
@@ -1,9 +1,14 @@
 package eu.joaocosta.minart.backend
 
+import eu.joaocosta.minart.runtime.Platform
+
 package object defaults {
   implicit val defaultCanvas: DefaultBackend[Any, AwtCanvas] =
     DefaultBackend.fromFunction((_) => new AwtCanvas())
 
   implicit val defaultLoopRunner: DefaultBackend[Any, JavaLoopRunner.type] =
     DefaultBackend.fromConstant(JavaLoopRunner)
+
+  implicit val defaultPlatform: DefaultBackend[Any, Platform.JVM.type] =
+    DefaultBackend.fromConstant(Platform.JVM)
 }

--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/defaults/package.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/defaults/package.scala
@@ -1,9 +1,14 @@
 package eu.joaocosta.minart.backend
 
+import eu.joaocosta.minart.runtime.Platform
+
 package object defaults {
   implicit val defaultCanvas: DefaultBackend[Any, SdlCanvas] =
     DefaultBackend.fromFunction((_) => new SdlCanvas())
 
   implicit val defaultLoopRunner: DefaultBackend[Any, SdlLoopRunner.type] =
     DefaultBackend.fromConstant(SdlLoopRunner)
+
+  implicit val defaultPlatform: DefaultBackend[Any, Platform.Native.type] =
+    DefaultBackend.fromConstant(Platform.Native)
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/Platform.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/Platform.scala
@@ -1,0 +1,23 @@
+package eu.joaocosta.minart.runtime
+
+import eu.joaocosta.minart.backend.defaults.DefaultBackend
+
+/** Runtime representation of the runtime platform.
+  * In general, it is preferable to handle platform-specific code at compile
+  * time, but this can be helpful for small changes.
+  */
+sealed trait Platform
+
+object Platform {
+
+  /** Returns the current runtime plaform.
+    * In general, it is preferable to handle platform-specific code at compile
+    * time, but this can be helpful for small changes.
+    */
+  def apply()(implicit d: DefaultBackend[Any, Platform]): Platform =
+    d.defaultValue(())
+
+  case object JVM    extends Platform
+  case object JS     extends Platform
+  case object Native extends Platform
+}


### PR DESCRIPTION
Adds a way to detect the target platform (JVM, JS or Native) at runtime.

While this is usually discouraged, it can be helpful to handle small differences (e.g. change a keybinding between Native and JS versions) with minimal boilerplate.