### PR TITLE
Add Surface abstraction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -118,6 +118,7 @@ lazy val examples = (project in file("examples"))
   .settings(noPublishSettings)
   .aggregate(
     Seq(
+      `examples-blitting`.componentProjects,
       `examples-colorSquare`.componentProjects,
       `examples-fire`.componentProjects,
       `examples-mousePointer`.componentProjects,
@@ -139,6 +140,9 @@ def example(project: sbtcrossproject.CrossProject.Builder, exampleName: String) 
     .jsSettings(scalaJSUseMainModuleInitializer := true)
     .nativeSettings(nativeSettings)
 }
+
+lazy val `examples-blitting` =
+  example(crossProject(JVMPlatform, JSPlatform, NativePlatform), "blitting")
 
 lazy val `examples-colorSquare` =
   example(crossProject(JVMPlatform, JSPlatform, NativePlatform), "colorsquare")

--- a/core/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
+++ b/core/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
@@ -1,0 +1,51 @@
+package eu.joaocosta.minart.backend
+
+import org.scalajs.dom
+import org.scalajs.dom.raw.ImageData
+
+import eu.joaocosta.minart.graphics.{Color, Surface}
+
+final class ImageDataSurface(val data: ImageData) extends Surface.MutableSurface {
+
+  val width: Int        = data.width
+  val height: Int       = data.height
+  private val lines     = 0 until height
+  private val columns   = 0 until width
+  private val allPixels = 0 until height * width
+
+  def getPixel(x: Int, y: Int): Option[Color] = {
+    val baseAddr =
+      4 * (y * width + x)
+    try {
+      Some(Color(data.data(baseAddr + 0), data.data(baseAddr + 1), data.data(baseAddr + 2)))
+    } catch { case _: Throwable => None }
+  }
+
+  def getPixels(): Vector[Array[Color]] = {
+    val imgData = data.data
+    lines.map { y =>
+      val lineBase = y * width
+      columns.map { x =>
+        val baseAddr = 4 * (lineBase + x)
+        Color(imgData(baseAddr), imgData(baseAddr + 1), imgData(baseAddr + 2))
+      }.toArray
+    }.toVector
+  }
+
+  def putPixel(x: Int, y: Int, color: Color): Unit = try {
+    val lineBase = y * width
+    val baseAddr = 4 * (lineBase + x)
+    data.data(baseAddr + 0) = color.r
+    data.data(baseAddr + 1) = color.g
+    data.data(baseAddr + 2) = color.b
+  } catch { case _: Throwable => () }
+
+  def fill(color: Color): Unit =
+    allPixels.foreach { i =>
+      val base = 4 * i
+      data.data(base + 0) = color.r
+      data.data(base + 1) = color.g
+      data.data(base + 2) = color.b
+      data.data(base + 3) = 255
+    }
+}

--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -137,7 +137,7 @@ object AwtCanvas {
     frame.setResizable(false)
     frame.addWindowListener(new WindowAdapter() {
       override def windowClosing(e: WindowEvent): Unit = {
-        outerCanvas.destroy()
+        outerCanvas.close()
       }
     });
   }

--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -23,7 +23,7 @@ import eu.joaocosta.minart.input._
 
 /** A low level Canvas implementation that shows the image in an AWT/Swing window.
   */
-class AwtCanvas() extends LowLevelCanvas {
+class AwtCanvas() extends SurfaceBackedCanvas {
 
   def this(settings: Canvas.Settings) = {
     this()
@@ -31,6 +31,7 @@ class AwtCanvas() extends LowLevelCanvas {
   }
 
   private[this] var javaCanvas: AwtCanvas.InnerCanvas      = _
+  protected var surface: BufferedImageSurface              = _
   private[this] var keyListener: AwtCanvas.KeyListener     = _
   private[this] var mouseListener: AwtCanvas.MouseListener = _
 
@@ -44,6 +45,8 @@ class AwtCanvas() extends LowLevelCanvas {
   def changeSettings(newSettings: Canvas.Settings) = {
     if (extendedSettings == null || newSettings != settings) {
       extendedSettings = LowLevelCanvas.ExtendedSettings(newSettings)
+      val image = new BufferedImage(newSettings.width, newSettings.height, BufferedImage.TYPE_INT_ARGB)
+      surface = new BufferedImageSurface(image)
       if (javaCanvas != null) javaCanvas.frame.dispose()
       javaCanvas = new AwtCanvas.InnerCanvas(
         newSettings.width,
@@ -65,24 +68,7 @@ class AwtCanvas() extends LowLevelCanvas {
     }
   }
 
-  def putPixel(x: Int, y: Int, color: Color): Unit = try {
-    javaCanvas.imagePixels
-      .setElem(y * extendedSettings.settings.width + x, color.argb)
-  } catch { case _: Throwable => () }
-
-  def getBackbufferPixel(x: Int, y: Int): Color = {
-    Color.fromRGB(
-      javaCanvas.imagePixels.getElem(
-        y * extendedSettings.settings.width + x
-      )
-    )
-  }
-
-  def getBackbuffer(): Vector[Vector[Color]] = {
-    javaCanvas.imagePixels.getData().iterator.map(Color.fromRGB).grouped(settings.width).map(_.toVector).toVector
-  }
-
-  def clear(resources: Set[Canvas.Resource]): Unit = try {
+  def clear(resources: Set[Canvas.Resource]): Unit = {
     if (resources.contains(Canvas.Resource.Keyboard)) {
       keyListener.clearPressRelease()
     }
@@ -90,9 +76,9 @@ class AwtCanvas() extends LowLevelCanvas {
       mouseListener.clearPressRelease()
     }
     if (resources.contains(Canvas.Resource.Backbuffer)) {
-      extendedSettings.allPixels.foreach(i => javaCanvas.imagePixels.setElem(i, settings.clearColor.argb))
+      fill(settings.clearColor)
     }
-  } catch { case _: Throwable => () }
+  }
 
   def redraw(): Unit = try {
     val g = javaCanvas.buffStrategy.getDrawGraphics()
@@ -104,7 +90,7 @@ class AwtCanvas() extends LowLevelCanvas {
       javaCanvas.getHeight
     )
     g.drawImage(
-      javaCanvas.image,
+      surface.getBufferedImage(),
       extendedSettings.canvasX,
       extendedSettings.canvasY,
       extendedSettings.scaledWidth,
@@ -144,8 +130,6 @@ object AwtCanvas {
 
     this.createBufferStrategy(2)
     val buffStrategy = getBufferStrategy
-    val image        = new BufferedImage(unscaledWidth, unscaledHeight, BufferedImage.TYPE_INT_ARGB)
-    val imagePixels  = image.getRaster.getDataBuffer.asInstanceOf[DataBufferInt]
 
     override def repaint() = outerCanvas.redraw()
 

--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
@@ -1,0 +1,61 @@
+package eu.joaocosta.minart.backend
+
+import java.awt.image.{BufferedImage, DataBufferInt}
+
+import eu.joaocosta.minart.graphics.{Color, Surface}
+
+final class BufferedImageSurface(bufferedImage: BufferedImage) extends Surface.MutableSurface {
+  val width               = bufferedImage.getWidth()
+  val height              = bufferedImage.getHeight()
+  private val imagePixels = bufferedImage.getRaster.getDataBuffer.asInstanceOf[DataBufferInt]
+  private val allPixels   = 0 until height * width
+
+  def getPixel(x: Int, y: Int): Option[Color] = try {
+    Some(
+      Color.fromRGB(
+        imagePixels.getElem(
+          y * width + x
+        )
+      )
+    )
+  } catch { case _: Throwable => None }
+
+  def getPixels(): Vector[Array[Color]] = try {
+    imagePixels.getData().iterator.map(Color.fromRGB).grouped(width).map(_.toArray).toVector
+  } catch { case _: Throwable => Vector.empty }
+
+  def putPixel(x: Int, y: Int, color: Color): Unit = try {
+    imagePixels
+      .setElem(y * width + x, color.argb)
+  } catch { case _: Throwable => () }
+
+  def fill(color: Color): Unit = try {
+    allPixels.foreach(i => imagePixels.setElem(i, color.argb))
+  } catch { case _: Throwable => () }
+
+  def getBufferedImage(): BufferedImage = bufferedImage
+
+  override def blit(
+      that: Surface
+  )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit = try {
+    that match {
+      case img: BufferedImageSurface =>
+        val g = bufferedImage.getGraphics()
+        g.drawImage(
+          img.getBufferedImage(),
+          x,
+          y,
+          x + cw,
+          y + ch,
+          cx,
+          cy,
+          cx + cw,
+          cy + ch,
+          null
+        )
+        g.dispose()
+      case _ =>
+        super.blit(that)(x, y, cx, cy, cw, ch)
+    }
+  } catch { case _: Throwable => () }
+}

--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -82,7 +82,7 @@ class SdlCanvas() extends SurfaceBackedCanvas {
     while (keepGoing && SDL_PollEvent(event) != 0) {
       keepGoing = event.type_ match {
         case SDL_QUIT =>
-          destroy()
+          close()
           false
         case SDL_KEYDOWN =>
           SdlKeyMapping.getKey(event.key.keysym.sym).foreach(k => keyboardInput = keyboardInput.press(k))

--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -11,7 +11,7 @@ import eu.joaocosta.minart.input._
 
 /** A low level Canvas implementation that shows the image in a SDL Window.
   */
-class SdlCanvas() extends LowLevelCanvas {
+class SdlCanvas() extends SurfaceBackedCanvas {
 
   def this(settings: Canvas.Settings) = {
     this()
@@ -20,8 +20,7 @@ class SdlCanvas() extends LowLevelCanvas {
 
   private[this] var window: Ptr[SDL_Window]         = _
   private[this] var windowSurface: Ptr[SDL_Surface] = _
-  private[this] var surface: Ptr[SDL_Surface]       = _
-  private[this] var renderer: Ptr[SDL_Renderer]     = _
+  protected var surface: SdlSurface                 = _
   private[this] var keyboardInput: KeyboardInput    = KeyboardInput(Set(), Set(), Set())
   private[this] var rawMousePos: (Int, Int)         = _
   private[this] def cleanMousePos: Option[PointerInput.Position] = Option(rawMousePos).map { case (x, y) =>
@@ -59,9 +58,9 @@ class SdlCanvas() extends LowLevelCanvas {
       else SDL_WINDOW_SHOWN
     )
     windowSurface = SDL_GetWindowSurface(window)
-    surface =
+    surface = new SdlSurface(
       SDL_CreateRGBSurface(0.toUInt, newSettings.width, newSettings.height, 32, 0.toUInt, 0.toUInt, 0.toUInt, 0.toUInt)
-    renderer = SDL_CreateSoftwareRenderer(surface)
+    )
     keyboardInput = KeyboardInput(Set(), Set(), Set())
     extendedSettings = extendedSettings.copy(
       windowWidth = windowSurface.w,
@@ -74,42 +73,7 @@ class SdlCanvas() extends LowLevelCanvas {
       windowSurface.pixels(baseAddr + 2) = ubyteClearR.toByte
       windowSurface.pixels(baseAddr + 3) = 255.toByte
     }
-    SDL_SetRenderDrawColor(renderer, ubyteClearR, ubyteClearG, ubyteClearB, 0.toUByte)
     clear(Set(Canvas.Resource.Backbuffer))
-  }
-
-  def putPixel(x: Int, y: Int, color: Color): Unit = try {
-    // Assuming a BGRA surface
-    val lineBase = y * extendedSettings.settings.width
-    val baseAddr = 4 * (lineBase + x)
-    surface.pixels(baseAddr + 0) = color.b.toByte
-    surface.pixels(baseAddr + 1) = color.g.toByte
-    surface.pixels(baseAddr + 2) = color.r.toByte
-  } catch { case _: Throwable => () }
-
-  def getBackbufferPixel(x: Int, y: Int): Color = {
-    // Assuming a BGRA surface
-    val baseAddr =
-      4 * (y * extendedSettings.settings.width + x)
-    Color(
-      (surface.pixels(baseAddr + 2) & 0xff),
-      (surface.pixels(baseAddr + 1) & 0xff),
-      (surface.pixels(baseAddr + 0) & 0xff)
-    )
-  }
-
-  def getBackbuffer(): Vector[Vector[Color]] = {
-    extendedSettings.lines.map { y =>
-      val lineBase = y * extendedSettings.settings.width
-      extendedSettings.columns.map { x =>
-        val baseAddr = 4 * (lineBase + x)
-        Color(
-          (surface.pixels(baseAddr + 2) & 0xff),
-          (surface.pixels(baseAddr + 1) & 0xff),
-          (surface.pixels(baseAddr + 0) & 0xff)
-        )
-      }.toVector
-    }.toVector
   }
 
   private[this] def handleEvents(): Boolean = {
@@ -151,7 +115,7 @@ class SdlCanvas() extends LowLevelCanvas {
     }
     val keepGoing = handleEvents()
     if (resources.contains(Canvas.Resource.Backbuffer) && keepGoing) {
-      SDL_RenderClear(renderer)
+      fill(settings.clearColor)
     }
   }
 
@@ -163,7 +127,7 @@ class SdlCanvas() extends LowLevelCanvas {
         extendedSettings.scaledWidth,
         extendedSettings.scaledHeight
       )
-      SDL_UpperBlitScaled(surface, null, windowSurface, windowRect)
+      SDL_UpperBlitScaled(surface.data, null, windowSurface, windowRect)
       SDL_UpdateWindowSurface(window)
     }
   }

--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
@@ -8,7 +8,7 @@ import sdl2.SDL._
 
 import eu.joaocosta.minart.graphics.{Color, Surface}
 
-final class SdlSurface(val data: Ptr[SDL_Surface]) extends Surface.MutableSurface {
+final class SdlSurface(val data: Ptr[SDL_Surface]) extends Surface.MutableSurface with AutoCloseable {
 
   val width: Int        = data.w
   val height: Int       = data.h
@@ -68,5 +68,9 @@ final class SdlSurface(val data: Ptr[SDL_Surface]) extends Surface.MutableSurfac
       SDL_UpperBlit(img.data, srcRect, this.data, dstRect)
     case _ =>
       super.blit(that)(x, y, cx, cy, cw, ch)
+  }
+
+  def close(): Unit = {
+    SDL_FreeSurface(data)
   }
 }

--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
@@ -1,0 +1,72 @@
+package eu.joaocosta.minart.backend
+
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+
+import sdl2.Extras._
+import sdl2.SDL._
+
+import eu.joaocosta.minart.graphics.{Color, Surface}
+
+final class SdlSurface(val data: Ptr[SDL_Surface]) extends Surface.MutableSurface {
+
+  val width: Int        = data.w
+  val height: Int       = data.h
+  private val lines     = 0 until height
+  private val columns   = 0 until width
+  private val allPixels = 0 until height * width
+  private val renderer  = SDL_CreateSoftwareRenderer(data)
+
+  def getPixel(x: Int, y: Int): Option[Color] = try {
+    // Assuming a BGRA surface
+    val baseAddr =
+      4 * (y * width + x)
+    Some(
+      Color(
+        (data.pixels(baseAddr + 2) & 0xff),
+        (data.pixels(baseAddr + 1) & 0xff),
+        (data.pixels(baseAddr + 0) & 0xff)
+      )
+    )
+  } catch { case _: Throwable => None }
+
+  def getPixels(): Vector[Array[Color]] = {
+    lines.map { y =>
+      val lineBase = y * width
+      columns.map { x =>
+        val baseAddr = 4 * (lineBase + x)
+        Color(
+          (data.pixels(baseAddr + 2) & 0xff),
+          (data.pixels(baseAddr + 1) & 0xff),
+          (data.pixels(baseAddr + 0) & 0xff)
+        )
+      }.toArray
+    }.toVector
+  }
+
+  def putPixel(x: Int, y: Int, color: Color): Unit = try {
+    // Assuming a BGRA surface
+    val lineBase = y * width
+    val baseAddr = 4 * (lineBase + x)
+    data.pixels(baseAddr + 0) = color.b.toByte
+    data.pixels(baseAddr + 1) = color.g.toByte
+    data.pixels(baseAddr + 2) = color.r.toByte
+    data.pixels(baseAddr + 3) = 255.toByte
+  } catch { case _: Throwable => () }
+
+  def fill(color: Color): Unit = {
+    SDL_SetRenderDrawColor(renderer, color.r.toUByte, color.g.toUByte, color.b.toUByte, 0.toUByte)
+    SDL_RenderClear(renderer)
+  }
+
+  override def blit(
+      that: Surface
+  )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit = that match {
+    case img: SdlSurface =>
+      val srcRect = stackalloc[SDL_Rect].init(cx, cy, cw, ch)
+      val dstRect = stackalloc[SDL_Rect].init(x, y, cw, ch)
+      SDL_UpperBlit(img.data, srcRect, this.data, dstRect)
+    case _ =>
+      super.blit(that)(x, y, cx, cy, cw, ch)
+  }
+}

--- a/core/native/src/main/scala/sdl2/SDL.scala
+++ b/core/native/src/main/scala/sdl2/SDL.scala
@@ -440,6 +440,16 @@ object SDL {
   ): Ptr[SDL_Surface]                                                      = extern
   def SDL_LoadBMP_RW(src: Ptr[SDL_RWops], freesrc: CInt): Ptr[SDL_Surface] = extern
   def SDL_FreeSurface(surface: Ptr[SDL_Surface]): Unit                     = extern
+  def SDL_SetClipRect(
+      surface: Ptr[SDL_Surface],
+      rect: Ptr[SDL_Rect]
+  ): Int = extern
+  def SDL_UpperBlit(
+      src: Ptr[SDL_Surface],
+      srcrect: Ptr[SDL_Rect],
+      dst: Ptr[SDL_Surface],
+      dstrect: Ptr[SDL_Rect]
+  ): Int = extern
   def SDL_UpperBlitScaled(
       src: Ptr[SDL_Surface],
       srcrect: Ptr[SDL_Rect],

--- a/core/shared/src/main/scala/eu/joaocosta/minart/backend/PpmCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/backend/PpmCanvas.scala
@@ -6,34 +6,26 @@ import eu.joaocosta.minart.input._
 /** A low level Canvas implementation that outputs the image in the PPM format to the stdout.
   * This canvas doesn't support fetching the keyboard input.
   */
-class PpmCanvas() extends LowLevelCanvas {
+class PpmCanvas() extends SurfaceBackedCanvas {
 
   def this(settings: Canvas.Settings) = {
     this()
     this.init(settings)
   }
 
-  private[this] var buffer: Array[Array[Color]]  = _
+  protected var surface: RamSurface              = _
   private[this] val keyboardInput: KeyboardInput = KeyboardInput(Set(), Set(), Set())  // Keyboard input not supported
   private[this] val pointerInput: PointerInput   = PointerInput(None, Nil, Nil, false) // Pointer input not supported
 
   def unsafeInit(newSettings: Canvas.Settings): Unit = {
-    buffer = Array.fill(newSettings.height)(Array.fill(newSettings.width)(newSettings.clearColor))
+    surface = new RamSurface(Vector.fill(newSettings.height)(Vector.fill(newSettings.width)(newSettings.clearColor)))
     extendedSettings = LowLevelCanvas.ExtendedSettings(newSettings)
   }
   def unsafeDestroy(): Unit                        = ()
   def changeSettings(newSettings: Canvas.Settings) = init(newSettings)
 
-  def putPixel(x: Int, y: Int, color: Color): Unit = buffer(y)(x) = color
-
-  def getBackbufferPixel(x: Int, y: Int): Color = buffer(y)(x)
-
-  def getBackbuffer() = buffer.map(_.toVector).toVector
-
   def clear(resources: Set[Canvas.Resource]): Unit = {
-    if (resources.contains(Canvas.Resource.Backbuffer)) {
-      buffer.foreach(_.transform(_ => settings.clearColor))
-    }
+    if (resources.contains(Canvas.Resource.Backbuffer)) { fill(settings.clearColor) }
   }
 
   def redraw(): Unit = {
@@ -41,10 +33,11 @@ class PpmCanvas() extends LowLevelCanvas {
     println(s"${extendedSettings.scaledWidth} ${extendedSettings.scaledHeight}")
     println("255")
     for {
-      line           <- buffer
-      _              <- extendedSettings.pixelSize
-      Color(r, g, b) <- line
-      _              <- extendedSettings.pixelSize
+      line  <- surface.data
+      _     <- extendedSettings.pixelSize
+      color <- line
+      Color(r, g, b) = Color.fromRGB(color)
+      _ <- extendedSettings.pixelSize
     } println(s"$r $g $b")
   }
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Canvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Canvas.scala
@@ -11,7 +11,7 @@ import eu.joaocosta.minart.input._
   * There's also a `scale` variable that controls the integer scaling
   * and a `clearColor` that is applied to the whole canvas when it's cleared.
   */
-trait Canvas {
+trait Canvas extends Surface.MutableSurface {
 
   /** The settings applied to this canvas.
     */
@@ -23,13 +23,8 @@ trait Canvas {
     */
   def changeSettings(newSettings: Canvas.Settings): Unit
 
-  /** Puts a pixel in the back buffer with a certain color.
-    *
-    * @param x pixel x position
-    * @param y pixel y position
-    * @param color `Color` to apply to the pixel
-    */
-  def putPixel(x: Int, y: Int, color: Color): Unit
+  def width: Int  = settings.width
+  def height: Int = settings.height
 
   /** Gets the color from the backbuffer.
     * This operation can be perfomance intensive, so it might be worthwile
@@ -40,7 +35,9 @@ trait Canvas {
     * @param y pixel y position
     * @return pixel color
     */
-  def getBackbufferPixel(x: Int, y: Int): Color
+  @deprecated("use getPixel(x, y) instead")
+  def getBackbufferPixel(x: Int, y: Int): Color =
+    getPixel(x, y).get
 
   /** Returns the backbuffer.
     * This operation can be perfomance intensive, so it might be worthwile
@@ -48,7 +45,9 @@ trait Canvas {
     *
     * @return backbuffer
     */
-  def getBackbuffer(): Vector[Vector[Color]]
+  @deprecated("use getPixels() instead")
+  def getBackbuffer(): Vector[Vector[Color]] =
+    getPixels().map(_.toVector).toVector
 
   /** Clears resources, such as the backbuffer and keyboard inputs.
     *

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/ImpureRenderLoop.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/ImpureRenderLoop.scala
@@ -16,7 +16,7 @@ object ImpureRenderLoop extends RenderLoop[Function1, Function2] {
           (state: S) => renderFrame(canvas, state),
           (newState: S) => terminateWhen(newState) || !canvas.isCreated(),
           frameRate,
-          () => if (canvas.isCreated()) canvas.destroy()
+          () => if (canvas.isCreated()) canvas.close()
         )(initialState)
       }
     }
@@ -37,7 +37,7 @@ object ImpureRenderLoop extends RenderLoop[Function1, Function2] {
   def singleFrame(renderFrame: Canvas => Unit): StatelessRenderLoop = new StatelessRenderLoop {
     def apply(runner: LoopRunner, canvasManager: CanvasManager, canvasSettings: Canvas.Settings): Unit = {
       val canvas = canvasManager.init(canvasSettings)
-      runner.singleRun(() => renderFrame(canvas), () => if (canvas.isCreated()) canvas.destroy())()
+      runner.singleRun(() => renderFrame(canvas), () => if (canvas.isCreated()) canvas.close())()
     }
   }
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/LowLevelCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/LowLevelCanvas.scala
@@ -4,7 +4,7 @@ import eu.joaocosta.minart.backend.defaults.DefaultBackend
 
 /** A low-level version of a canvas that provides its own canvas manager.
   */
-trait LowLevelCanvas extends Canvas {
+trait LowLevelCanvas extends Canvas with AutoCloseable {
   protected[this] var extendedSettings: LowLevelCanvas.ExtendedSettings = _
   def settings: Canvas.Settings =
     if (extendedSettings == null) Canvas.Settings(0, 0)
@@ -25,7 +25,7 @@ trait LowLevelCanvas extends Canvas {
     */
   def init(settings: Canvas.Settings): Unit = {
     if (isCreated()) {
-      destroy()
+      close()
     }
     if (!isCreated()) {
       unsafeInit(settings)
@@ -34,9 +34,10 @@ trait LowLevelCanvas extends Canvas {
 
   /** Destroys the canvas window.
     *
-    * Calling any operation on this canvas after calling destroy has an undefined behavior.
+    * Calling any operation on this canvas after calling close without calling
+    * init() has an undefined behavior.
     */
-  def destroy(): Unit = if (isCreated()) {
+  def close(): Unit = if (isCreated()) {
     unsafeDestroy()
     extendedSettings = null
   }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
@@ -1,0 +1,35 @@
+package eu.joaocosta.minart.graphics
+
+import eu.joaocosta.minart.graphics.Surface._
+
+/** A Surface stored in RAM.
+  */
+class RamSurface(val data: Vector[Array[Int]]) extends MutableSurface {
+  val width  = data.headOption.map(_.size).getOrElse(0)
+  val height = data.size
+
+  def this(colors: Seq[Seq[Color]]) =
+    this(colors.map(_.map(_.argb).toArray).toVector)
+
+  private[this] val lines   = (0 until height)
+  private[this] val columns = (0 until width)
+
+  def getPixel(x: Int, y: Int): Option[Color] = {
+    if (x < 0 || y < 0 || x >= width || y >= height) None
+    else Some(Color.fromRGB(data(y)(x)))
+  }
+
+  def getPixels(): Vector[Array[Color]] =
+    data.map(_.map(Color.fromRGB))
+
+  def putPixel(x: Int, y: Int, color: Color): Unit =
+    if (x < 0 || y < 0 || x >= width || y >= height)
+      data(y)(x) = color.argb
+
+  def fill(color: Color): Unit =
+    for {
+      y <- lines
+      x <- columns
+    } data(y)(x) = color.argb
+
+}

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
@@ -1,0 +1,120 @@
+package eu.joaocosta.minart.graphics
+
+/** A Surface is an object that contains a set of pixels.
+  *
+  * Depending on the implementation, the surface might be stored in VRAM.
+  */
+trait Surface {
+
+  /** The surface width */
+  def width: Int
+
+  /** The surface height */
+  def height: Int
+
+  /** Gets the color from the this surface.
+    * This operation can be perfomance intensive, so it might be worthwile
+    * to either use `getPixels` to fetch multiple pixels at the same time or
+    * to implement this operation on the application code.
+    *
+    * @param x pixel x position
+    * @param y pixel y position
+    * @return pixel color
+    */
+  def getPixel(x: Int, y: Int): Option[Color]
+
+  /** Returns the pixels from thissurface.
+    * This operation can be perfomance intensive, so it might be worthwile
+    * to implement this operation on the application code.
+    *
+    * @return color matrix
+    */
+  def getPixels(): Vector[Array[Color]]
+}
+
+object Surface {
+
+  /** A surface that supports mutable operations.
+    */
+  trait MutableSurface extends Surface {
+
+    /** Put a pixel in the surface with a certain color.
+      *
+      * @param x pixel x position
+      * @param y pixel y position
+      * @param color `Color` to apply to the pixel
+      */
+    def putPixel(x: Int, y: Int, color: Color): Unit
+
+    /** Fill the surface with a certain color
+      *
+      * @param color `Color` to fill the surface with
+      */
+    def fill(color: Color): Unit
+
+    /** Draws a surface on top of this surface.
+      *
+      * @param that surface to draw
+      * @param x leftmost pixel on the destination surface
+      * @param y topmost pixel on the destination surface
+      * @param cx leftmost pixel on the source surface
+      * @param cy topmost pixel on the source surface
+      * @param cw clip width of the source surface
+      * @param ch clip height of the source surface
+      */
+    def blit(
+        that: Surface
+    )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit = {
+      val minYClip   = -y
+      val minXClip   = -x
+      val maxYClip   = this.height - y
+      val maxXClip   = this.width - x
+      val yRange     = (math.max(0, minYClip) until math.min(ch, maxYClip))
+      val xRange     = (math.max(0, minXClip) until math.min(cw, maxXClip))
+      val thatPixels = that.getPixels()
+      for {
+        dy <- yRange
+        sourceY = dy + cy
+        destY   = dy + y
+        dx <- xRange
+        sourceX = dx + cx
+        destX   = dx + x
+        color   = thatPixels(sourceY)(sourceX)
+      } putPixel(destX, destY, color)
+    }
+
+    /** Draws a surface on top of this surface and masks the pixels with a certain color.
+      *
+      * @param that surface to draw
+      * @param mask color to usa as a mask
+      * @param x leftmost pixel on the destination surface
+      * @param y topmost pixel on the destination surface
+      * @param cx leftmost pixel on the source surface
+      * @param cy topmost pixel on the source surface
+      * @param cw clip width of the source surface
+      * @param ch clip height of the source surface
+      */
+    def blitWithMask(
+        that: Surface,
+        mask: Color
+    )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit = {
+      val minYClip   = -y
+      val minXClip   = -x
+      val maxYClip   = this.height - y
+      val maxXClip   = this.width - x
+      val yRange     = (math.max(0, minYClip) until math.min(ch, maxYClip))
+      val xRange     = (math.max(0, minXClip) until math.min(cw, maxXClip))
+      val thatPixels = that.getPixels()
+      for {
+        dy <- yRange
+        sourceY = dy + cy
+        destY   = dy + y
+        dx <- xRange
+        sourceX = dx + cx
+        destX   = dx + x
+        color   = thatPixels(sourceY)(sourceX)
+        if color != mask
+      } putPixel(destX, destY, color)
+    }
+  }
+}

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceBackedCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceBackedCanvas.scala
@@ -1,0 +1,32 @@
+package eu.joaocosta.minart.graphics
+
+import eu.joaocosta.minart.backend.defaults.DefaultBackend
+import eu.joaocosta.minart.input._
+
+/** Canvas backed by a mutable surface.
+  */
+trait SurfaceBackedCanvas extends LowLevelCanvas {
+
+  protected def surface: Surface.MutableSurface
+
+  def putPixel(x: Int, y: Int, color: Color): Unit = try {
+    surface.putPixel(x, y, color)
+  } catch { case _: Throwable => () }
+
+  def getPixel(x: Int, y: Int): Option[Color] = try {
+    surface.getPixel(x, y)
+  } catch { case _: Throwable => None }
+
+  def getPixels(): Vector[Array[Color]] = try {
+    surface.getPixels()
+  } catch { case _: Throwable => Vector.empty }
+
+  def fill(color: Color): Unit = try {
+    surface.fill(color)
+  } catch { case _: Throwable => () }
+
+  override def blit(
+      that: Surface
+  )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit =
+    surface.blit(that)(x, y, cx, cy, cw, ch)
+}

--- a/examples/blitting/shared/src/main/scala/eu/joaocosta/minart/examples/Blitting.scala
+++ b/examples/blitting/shared/src/main/scala/eu/joaocosta/minart/examples/Blitting.scala
@@ -1,0 +1,42 @@
+package eu.joaocosta.minart.examples
+
+import eu.joaocosta.minart.backend.defaults._
+import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.runtime._
+
+object Blitting {
+  val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = 4)
+
+  val image = new RamSurface(
+    (0 until 16).map { y =>
+      (0 until 16).map { x =>
+        if ((x + y) < 16) Color(0, 0, 0).argb
+        else Color((16 * x.toDouble).toInt, (16 * y.toDouble).toInt, 255).argb
+      }.toArray
+    }.toVector
+  )
+
+  def renderBackground(canvas: Canvas): Unit =
+    for {
+      x <- (0 until canvas.settings.width)
+      y <- (0 until canvas.settings.height)
+    } {
+      val color =
+        Color((255 * x.toDouble / canvas.settings.width).toInt, (255 * y.toDouble / canvas.settings.height).toInt, 255)
+      canvas.putPixel(x, y, color)
+    }
+
+  def main(args: Array[String]): Unit = {
+    ImpureRenderLoop
+      .infiniteRenderLoop[Int](
+        (canvas, state) => {
+          renderBackground(canvas)
+          canvas.blit(image)(state, state, 4, 4, 8, 8)
+          canvas.blitWithMask(image, Color(0, 0, 0))((128 - 16 - 1) - state, state, 4, 4, 8, 8)
+          canvas.redraw()
+          (state + 1) % (128 - 16)
+        },
+        LoopFrequency.hz60
+      )(canvasSettings, 0)
+  }
+}


### PR DESCRIPTION
Adds a surface abstraction and a way to blit surfaces into other surfaces.
All canvas are surfaces as well (kind of like in SDL).

I think it might be possible to make it easier to use platform specific surface implementations, which should speed up the code. Unfortunately, I didn't really see any speed up in my initial tests, so I'm leaving this as is for now.

(Unfortunately, my local repo got corrupted before I could push the changes, so I lost the commit history).