### PR TITLE
Add pure surface operations

### DIFF
--- a/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/MSurfaceIOOps.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/MSurfaceIOOps.scala
@@ -1,0 +1,62 @@
+package eu.joaocosta.minart.graphics.pure
+
+import scala.util.Try
+
+import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.input._
+import eu.joaocosta.minart.runtime.pure._
+
+/** Representation of a mutable surface operation, with the common Monad operations.
+  */
+trait MSurfaceIOOps extends SurfaceIOOps {
+
+  /** Wrap mutable surface operations in a  [[MSurfaceIO]]. */
+  def accessMSurface[A](f: Surface.MutableSurface => A): MSurfaceIO[A] = RIO.access[Surface.MutableSurface, A](f)
+
+  /** Put a pixel in the surface with a certain color.
+    *
+    * @param x pixel x position
+    * @param y pixel y position
+    * @param color `Color` to apply to the pixel
+    */
+  def putPixel(x: Int, y: Int, color: Color): MSurfaceIO[Unit] = accessMSurface(_.putPixel(x, y, color))
+
+  /** Fill the surface with a certain color
+    *
+    * @param color `Color` to fill the surface with
+    */
+  def fill(color: Color): MSurfaceIO[Unit] = accessMSurface(_.fill(color))
+
+  /** Draws a surface on top of this surface.
+    *
+    * @param that surface to draw
+    * @param x leftmost pixel on the destination surface
+    * @param y topmost pixel on the destination surface
+    * @param cx leftmost pixel on the source surface
+    * @param cy topmost pixel on the source surface
+    * @param cw clip width of the source surface
+    * @param ch clip height of the source surface
+    */
+  def blit(
+      that: Surface
+  )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): MSurfaceIO[Unit] =
+    accessMSurface(_.blit(that)(x, y, cx, cy, cw, ch))
+
+  /** Draws a surface on top of this surface and masks the pixels with a certain color.
+    *
+    * @param that surface to draw
+    * @param mask color to usa as a mask
+    * @param x leftmost pixel on the destination surface
+    * @param y topmost pixel on the destination surface
+    * @param cx leftmost pixel on the source surface
+    * @param cy topmost pixel on the source surface
+    * @param cw clip width of the source surface
+    * @param ch clip height of the source surface
+    */
+  def blitWithMask(
+      that: Surface,
+      mask: Color
+  )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit = accessMSurface(
+    _.blitWithMask(that, mask)(x, y, cx, cy, cw, ch)
+  )
+}

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/SurfaceIOOps.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/SurfaceIOOps.scala
@@ -1,0 +1,33 @@
+package eu.joaocosta.minart.graphics.pure
+
+import scala.util.Try
+
+import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.input._
+import eu.joaocosta.minart.runtime.pure._
+
+/** Representation of a surface operation, with the common Monad operations.
+  */
+trait SurfaceIOOps {
+
+  /** Wrap surface operations in a  [[SurfaceIO]]. */
+  def accessSurface[A](f: Surface => A): SurfaceIO[A] = RIO.access[Surface, A](f)
+
+  /** Gets the color from the this surface.
+    * This operation can be perfomance intensive, so it might be worthwile
+    * to either use `getPixels` to fetch multiple pixels at the same time or
+    * to implement this operation on the application code.
+    *
+    * @param x pixel x position
+    * @param y pixel y position
+    */
+  def getPixel(x: Int, y: Int): SurfaceIO[Option[Color]] = accessSurface(_.getPixel(x, y))
+
+  /** Returns the pixels from this surface.
+    * This operation can be perfomance intensive, so it might be worthwile
+    * to implement this operation on the application code.
+    *
+    * @return color matrix
+    */
+  val getPixels: SurfaceIO[Vector[Array[Color]]] = accessSurface(_.getPixels())
+}

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/package.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/package.scala
@@ -1,9 +1,14 @@
 package eu.joaocosta.minart.graphics
 
-import eu.joaocosta.minart.runtime.pure.RIO
+import eu.joaocosta.minart.runtime.pure.{IOOps, RIO}
 
 package object pure {
+  type SurfaceIO[+A] = RIO[Surface, A]
+  object SurfaceIO extends SurfaceIOOps with IOOps[Surface]
+  type MSurfaceIO[+A] = RIO[Surface.MutableSurface, A]
+  object MSurfaceIO extends MSurfaceIOOps with IOOps[Surface.MutableSurface]
   type CanvasIO[+A] = RIO[Canvas, A]
+  object CanvasIO extends CanvasIOOps with IOOps[Canvas]
 
   type StateCanvasIO[-Canvas, -State, +A] = Function1[State, RIO[Canvas, A]]
 }

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/runtime/pure/IOOps.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/runtime/pure/IOOps.scala
@@ -1,0 +1,58 @@
+package eu.joaocosta.minart.runtime.pure
+
+import scala.util.Try
+
+/** Operations for an IO with a fixed R */
+trait IOOps[R] extends IOOps.IOBaseOps[R] {
+
+  /** Returns a operation that requires this resource. */
+  def access[A](f: R => A): RIO[R, A] = RIO.access[R, A](f)
+
+  /** Runs a computation only if the predicate is true, otherwise does nothing */
+  def when(predicate: Boolean)(io: => RIO[R, Unit]): RIO[R, Unit] =
+    RIO.when[R](predicate)(io)
+
+  /** Converts an `Iterable[RIO[R, A]]` into a `RIO[R, List[A]]`. */
+  def sequence[A](it: Iterable[RIO[R, A]]): RIO[R, List[A]] =
+    RIO.sequence[R, A](it)
+
+  /** Converts an `Iterable[RIO[R, A]]` into a `RIO[R, Unit]`. */
+  def sequence_(it: Iterable[RIO[R, Any]]): RIO[R, Unit] =
+    RIO.sequence_[R](it)
+
+  /** Converts an `Iterable[A]` into a `RIO[R, List[B]]` by applying an operation to each element. */
+  def traverse[A, B](it: Iterable[A])(f: A => RIO[R, B]): RIO[R, List[B]] =
+    RIO.traverse[R, A, B](it)(f)
+
+  /** Applies an operation to each element of a `Iterable[A]` and discards the result. */
+  def foreach[A](it: Iterable[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
+    RIO.foreach[R, A](it)(f)
+
+  /** Applies an operation to each element of a `Iterator[A]` and discards the result. */
+  def foreach[A](it: () => Iterator[A])(f: A => RIO[R, Any]): RIO[R, Unit] =
+    RIO.foreach[R, A](it)(f)
+}
+
+/** Basic IO operations to quicly create RIO type aliases
+  */
+object IOOps {
+
+  /** Basic operations for an IO with a fixed R */
+  trait IOBaseOps[R] {
+
+    /** An operation that does nothing. */
+    val noop: RIO[R, Unit] = RIO.Suspend[R, Unit](_ => ())
+
+    /** Lifts a value into a [[RIO]]. */
+    def pure[A](x: A): RIO[R, A] = RIO.Suspend[R, A](_ => x)
+
+    /** Suspends a computation into a [[RIO]]. */
+    def suspend[A](x: => A): RIO[R, A] = RIO.Suspend[R, A](_ => x)
+
+    /** Returns a [[Poll]] from a function that receives a callback */
+    def fromCallback[A](operation: (Try[A] => Unit) => Unit): RIO[R, Poll[A]] = {
+      val promise = scala.concurrent.Promise[A]()
+      RIO.suspend(operation(promise.complete)).as(Poll.fromFuture(promise.future))
+    }
+  }
+}


### PR DESCRIPTION
Adds surface operations to the pure package.

This PR adds a new `SurfaceIO` and `MSurfaceIO`, and refactors the code to make it slightly easier to introduce IO "newtypes".