### PR TITLE
0.3.0-RC1 surface fixes

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
@@ -63,22 +63,31 @@ object Surface {
     def blit(
         that: Surface
     )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit = {
-      val minYClip   = -y
-      val minXClip   = -x
-      val maxYClip   = this.height - y
-      val maxXClip   = this.width - x
-      val yRange     = (math.max(0, minYClip) until math.min(ch, maxYClip))
-      val xRange     = (math.max(0, minXClip) until math.min(cw, maxXClip))
+      val minYClip = -y
+      val minXClip = -x
+      val maxYClip = this.height - y
+      val maxXClip = this.width - x
+
+      val minY = math.max(0, minYClip)
+      val maxY = math.min(ch, maxYClip)
+      val minX = math.max(0, minXClip)
+      val maxX = math.min(cw, maxXClip)
+
       val thatPixels = that.getPixels()
-      for {
-        dy <- yRange
-        sourceY = dy + cy
-        destY   = dy + y
-        dx <- xRange
-        sourceX = dx + cx
-        destX   = dx + x
-        color   = thatPixels(sourceY)(sourceX)
-      } putPixel(destX, destY, color)
+
+      var dy = minY
+      while (dy < maxY) {
+        val line  = thatPixels(dy + cy)
+        val destY = dy + y
+        var dx    = minX
+        while (dx < maxX) {
+          val destX = dx + x
+          val color = line(dx + cx)
+          putPixel(destX, destY, color)
+          dx += 1
+        }
+        dy += 1
+      }
     }
 
     /** Draws a surface on top of this surface and masks the pixels with a certain color.
@@ -96,23 +105,31 @@ object Surface {
         that: Surface,
         mask: Color
     )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit = {
-      val minYClip   = -y
-      val minXClip   = -x
-      val maxYClip   = this.height - y
-      val maxXClip   = this.width - x
-      val yRange     = (math.max(0, minYClip) until math.min(ch, maxYClip))
-      val xRange     = (math.max(0, minXClip) until math.min(cw, maxXClip))
+      val minYClip = -y
+      val minXClip = -x
+      val maxYClip = this.height - y
+      val maxXClip = this.width - x
+
+      val minY = math.max(0, minYClip)
+      val maxY = math.min(ch, maxYClip)
+      val minX = math.max(0, minXClip)
+      val maxX = math.min(cw, maxXClip)
+
       val thatPixels = that.getPixels()
-      for {
-        dy <- yRange
-        sourceY = dy + cy
-        destY   = dy + y
-        dx <- xRange
-        sourceX = dx + cx
-        destX   = dx + x
-        color   = thatPixels(sourceY)(sourceX)
-        if color != mask
-      } putPixel(destX, destY, color)
+
+      var dy = minY
+      while (dy < maxY) {
+        val line  = thatPixels(dy + cy)
+        val destY = dy + y
+        var dx    = minX
+        while (dx < maxX) {
+          val destX = dx + x
+          val color = line(dx + cx)
+          if (color != mask) putPixel(destX, destY, color)
+          dx += 1
+        }
+        dy += 1
+      }
     }
   }
 }

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/MSurfaceIOOps.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/MSurfaceIOOps.scala
@@ -56,7 +56,8 @@ trait MSurfaceIOOps extends SurfaceIOOps {
   def blitWithMask(
       that: Surface,
       mask: Color
-  )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit = accessMSurface(
-    _.blitWithMask(that, mask)(x, y, cx, cy, cw, ch)
-  )
+  )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): MSurfaceIO[Unit] =
+    accessMSurface(
+      _.blitWithMask(that, mask)(x, y, cx, cy, cw, ch)
+    )
 }


### PR DESCRIPTION
Fixes some bugs with surfaces in 0.3.0-RC1

- Fixes the type of MSurfaceIO.biltWithMask
- Reduces the number of allocations during blitting