### PR TITLE
Fix surface bound checks

### DIFF
--- a/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
+++ b/core/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
@@ -4,7 +4,7 @@ import scala.scalajs.js
 
 import org.scalajs.dom
 import org.scalajs.dom.html.{Canvas => JsCanvas}
-import org.scalajs.dom.{Event, ImageBitmap, KeyboardEvent, PointerEvent}
+import org.scalajs.dom.{CanvasRenderingContext2D, Event, ImageBitmap, KeyboardEvent, PointerEvent}
 
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.input._
@@ -38,7 +38,7 @@ class HtmlCanvas() extends SurfaceBackedCanvas {
 
   def unsafeInit(newSettings: Canvas.Settings): Unit = {
     canvas = dom.document.createElement("canvas").asInstanceOf[JsCanvas]
-    ctx = canvas.getContext("2d").asInstanceOf[dom.CanvasRenderingContext2D]
+    ctx = canvas.getContext("2d").asInstanceOf[CanvasRenderingContext2D]
     changeSettings(newSettings)
     dom.document.addEventListener[Event](
       "fullscreenchange",

--- a/core/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
+++ b/core/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
@@ -15,13 +15,11 @@ final class ImageDataSurface(val data: ImageData) extends Surface.MutableSurface
   private val lines   = 0 until height
   private val columns = 0 until width
 
-  def getPixel(x: Int, y: Int): Option[Color] = {
-    val baseAddr =
-      4 * (y * width + x)
-    try {
+  def getPixel(x: Int, y: Int): Option[Color] =
+    if (x >= 0 && y >= 0 && x < width && y < height) {
+      val baseAddr = 4 * (y * width + x)
       Some(Color(data.data(baseAddr + 0), data.data(baseAddr + 1), data.data(baseAddr + 2)))
-    } catch { case _: Throwable => None }
-  }
+    } else None
 
   def getPixels(): Vector[Array[Color]] = {
     val imgData = data.data
@@ -34,13 +32,14 @@ final class ImageDataSurface(val data: ImageData) extends Surface.MutableSurface
     }.toVector
   }
 
-  def putPixel(x: Int, y: Int, color: Color): Unit = try {
-    val lineBase = y * width
-    val baseAddr = 4 * (lineBase + x)
-    data.data(baseAddr + 0) = color.r
-    data.data(baseAddr + 1) = color.g
-    data.data(baseAddr + 2) = color.b
-  } catch { case _: Throwable => () }
+  def putPixel(x: Int, y: Int, color: Color): Unit =
+    if (x >= 0 && y >= 0 && x < width && y < height) {
+      val lineBase = y * width
+      val baseAddr = 4 * (lineBase + x)
+      data.data(baseAddr + 0) = color.r
+      data.data(baseAddr + 1) = color.g
+      data.data(baseAddr + 2) = color.b
+    }
 
   def fill(color: Color): Unit = {
     var base = 0

--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
@@ -11,39 +11,39 @@ final class BufferedImageSurface(val bufferedImage: BufferedImage) extends Surfa
   val height              = bufferedImage.getHeight()
   private val imagePixels = bufferedImage.getRaster.getDataBuffer.asInstanceOf[DataBufferInt]
 
-  def getPixel(x: Int, y: Int): Option[Color] = try {
-    Some(
-      Color.fromRGB(
-        imagePixels.getElem(
-          y * width + x
+  def getPixel(x: Int, y: Int): Option[Color] =
+    if (x >= 0 && y >= 0 && x < width && y < height)
+      Some(
+        Color.fromRGB(
+          imagePixels.getElem(
+            y * width + x
+          )
         )
       )
-    )
-  } catch { case _: Throwable => None }
+    else None
 
-  def getPixels(): Vector[Array[Color]] = try {
+  def getPixels(): Vector[Array[Color]] =
     imagePixels.getData().iterator.map(Color.fromRGB).grouped(width).map(_.toArray).toVector
-  } catch { case _: Throwable => Vector.empty }
 
-  def putPixel(x: Int, y: Int, color: Color): Unit = try {
-    imagePixels
-      .setElem(y * width + x, color.argb)
-  } catch { case _: Throwable => () }
+  def putPixel(x: Int, y: Int, color: Color): Unit =
+    if (x >= 0 && y >= 0 && x < width && y < height)
+      imagePixels
+        .setElem(y * width + x, color.argb)
 
-  def fill(color: Color): Unit = try {
+  def fill(color: Color): Unit = {
     var i = 0
     while (i < height * width) {
       imagePixels.setElem(i, color.argb)
       i += 1
     }
-  } catch { case _: Throwable => () }
+  }
 
   override def blit(
       that: Surface
-  )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit = try {
+  )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit =
     that match {
       case img: BufferedImageSurface =>
-        val g = bufferedImage.getGraphics()
+        val g = bufferedImage.createGraphics()
         g.drawImage(
           img.bufferedImage,
           x,
@@ -60,5 +60,4 @@ final class BufferedImageSurface(val bufferedImage: BufferedImage) extends Surfa
       case _ =>
         super.blit(that)(x, y, cx, cy, cw, ch)
     }
-  } catch { case _: Throwable => () }
 }

--- a/core/jvm/src/test/scala/eu/joaocosta/minart/graphics/BufferedImageSurfaceSpec.scala
+++ b/core/jvm/src/test/scala/eu/joaocosta/minart/graphics/BufferedImageSurfaceSpec.scala
@@ -1,0 +1,14 @@
+package eu.joaocosta.minart.graphics
+
+import java.awt.image.BufferedImage
+
+import verify._
+
+import eu.joaocosta.minart.backend._
+import eu.joaocosta.minart.runtime._
+
+object BufferedImageSurfaceSpec extends MutableSurfaceTests {
+  lazy val image   = new BufferedImage(64, 48, BufferedImage.TYPE_INT_ARGB)
+  lazy val surface = new BufferedImageSurface(image)
+
+}

--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
@@ -20,18 +20,19 @@ final class SdlSurface(val data: Ptr[SDL_Surface]) extends Surface.MutableSurfac
   private val columns  = 0 until width
   private val renderer = SDL_CreateSoftwareRenderer(data)
 
-  def getPixel(x: Int, y: Int): Option[Color] = try {
-    // Assuming a BGRA surface
-    val baseAddr =
-      4 * (y * width + x)
-    Some(
-      Color(
-        (data.pixels(baseAddr + 2) & 0xff),
-        (data.pixels(baseAddr + 1) & 0xff),
-        (data.pixels(baseAddr + 0) & 0xff)
+  def getPixel(x: Int, y: Int): Option[Color] =
+    if (data.pixels != null && x >= 0 && y >= 0 && x < width && y < height) {
+      // Assuming a BGRA surface
+      val baseAddr =
+        4 * (y * width + x)
+      Some(
+        Color(
+          (data.pixels(baseAddr + 2) & 0xff),
+          (data.pixels(baseAddr + 1) & 0xff),
+          (data.pixels(baseAddr + 0) & 0xff)
+        )
       )
-    )
-  } catch { case _: Throwable => None }
+    } else None
 
   def getPixels(): Vector[Array[Color]] = {
     lines.map { y =>
@@ -47,15 +48,16 @@ final class SdlSurface(val data: Ptr[SDL_Surface]) extends Surface.MutableSurfac
     }.toVector
   }
 
-  def putPixel(x: Int, y: Int, color: Color): Unit = try {
-    // Assuming a BGRA surface
-    val lineBase = y * width
-    val baseAddr = 4 * (lineBase + x)
-    data.pixels(baseAddr + 0) = color.b.toByte
-    data.pixels(baseAddr + 1) = color.g.toByte
-    data.pixels(baseAddr + 2) = color.r.toByte
-    data.pixels(baseAddr + 3) = 255.toByte
-  } catch { case _: Throwable => () }
+  def putPixel(x: Int, y: Int, color: Color): Unit =
+    if (data.pixels != null && x >= 0 && y >= 0 && x < width && y < height) {
+      // Assuming a BGRA surface
+      val lineBase = y * width
+      val baseAddr = 4 * (lineBase + x)
+      data.pixels(baseAddr + 0) = color.b.toByte
+      data.pixels(baseAddr + 1) = color.g.toByte
+      data.pixels(baseAddr + 2) = color.r.toByte
+      data.pixels(baseAddr + 3) = 255.toByte
+    }
 
   def fill(color: Color): Unit = {
     SDL_SetRenderDrawColor(renderer, color.r.toUByte, color.g.toUByte, color.b.toUByte, 0.toUByte)

--- a/core/native/src/test/scala/eu/joaocosta/minart/graphics/SdlSurfaceSpec.scala
+++ b/core/native/src/test/scala/eu/joaocosta/minart/graphics/SdlSurfaceSpec.scala
@@ -1,0 +1,17 @@
+package eu.joaocosta.minart.graphics
+
+import scala.scalanative.unsigned._
+
+import sdl2.Extras._
+import sdl2.SDL._
+import verify._
+
+import eu.joaocosta.minart.backend._
+import eu.joaocosta.minart.runtime._
+
+object SdlImageSurfaceSpec extends MutableSurfaceTests {
+  lazy val surface = new SdlSurface(
+    SDL_CreateRGBSurface(0.toUInt, 64, 48, 32, 0.toUInt, 0.toUInt, 0.toUInt, 0.toUInt)
+  )
+
+}

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
@@ -13,16 +13,15 @@ class RamSurface(val data: Vector[Array[Int]]) extends MutableSurface {
   def this(colors: Seq[Seq[Color]]) =
     this(colors.map(_.map(_.argb).toArray).toVector)
 
-  def getPixel(x: Int, y: Int): Option[Color] = {
-    if (x < 0 || y < 0 || x >= width || y >= height) None
-    else Some(Color.fromRGB(data(y)(x)))
-  }
+  def getPixel(x: Int, y: Int): Option[Color] =
+    if (x >= 0 && y >= 0 && x < width && y < height) Some(Color.fromRGB(data(y)(x)))
+    else None
 
   def getPixels(): Vector[Array[Color]] =
     data.map(_.map(Color.fromRGB))
 
   def putPixel(x: Int, y: Int, color: Color): Unit =
-    if (x < 0 || y < 0 || x >= width || y >= height)
+    if (x >= 0 && y >= 0 && x < width && y < height)
       data(y)(x) = color.argb
 
   def fill(color: Color): Unit = {

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceBackedCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceBackedCanvas.scala
@@ -6,21 +6,17 @@ trait SurfaceBackedCanvas extends LowLevelCanvas {
 
   protected def surface: Surface.MutableSurface
 
-  def putPixel(x: Int, y: Int, color: Color): Unit = try {
+  def putPixel(x: Int, y: Int, color: Color): Unit =
     surface.putPixel(x, y, color)
-  } catch { case _: Throwable => () }
 
-  def getPixel(x: Int, y: Int): Option[Color] = try {
+  def getPixel(x: Int, y: Int): Option[Color] =
     surface.getPixel(x, y)
-  } catch { case _: Throwable => None }
 
-  def getPixels(): Vector[Array[Color]] = try {
+  def getPixels(): Vector[Array[Color]] =
     surface.getPixels()
-  } catch { case _: Throwable => Vector.empty }
 
-  def fill(color: Color): Unit = try {
+  def fill(color: Color): Unit =
     surface.fill(color)
-  } catch { case _: Throwable => () }
 
   override def blit(
       that: Surface

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -1,0 +1,46 @@
+package eu.joaocosta.minart.graphics
+
+import verify._
+
+import eu.joaocosta.minart.backend._
+import eu.joaocosta.minart.runtime._
+
+trait MutableSurfaceTests extends BasicTestSuite {
+
+  def surface: Surface.MutableSurface
+
+  test("Return the correct number of pixels") {
+    val pixels = surface.getPixels()
+    assert(pixels.size == surface.height)
+    assert(pixels.forall(_.size == surface.width))
+  }
+
+  test("Write and read pixels in certain positions") {
+    surface.putPixel(0, 0, Color(1, 2, 3))
+    surface.putPixel(0, 1, Color(3, 2, 1))
+    surface.putPixel(1, 0, Color(2, 1, 3))
+    assert(surface.getPixel(0, 0) == Some(Color(1, 2, 3)))
+    assert(surface.getPixel(0, 1) == Some(Color(3, 2, 1)))
+    assert(surface.getPixel(1, 0) == Some(Color(2, 1, 3)))
+    assert(surface.getPixels()(0)(0) == Color(1, 2, 3))
+    assert(surface.getPixels()(1)(0) == Color(3, 2, 1))
+    assert(surface.getPixels()(0)(1) == Color(2, 1, 3))
+  }
+
+  test("Don't blow up when invalid positions are provided") {
+    surface.putPixel(-1, -1, Color(1, 2, 3))
+    surface.putPixel(surface.width, 0, Color(1, 2, 3))
+    surface.putPixel(0, surface.height, Color(1, 2, 3))
+
+    assert(surface.getPixel(-1, -1) == None)
+    assert(surface.getPixel(surface.width, 0) == None)
+    assert(surface.getPixel(0, surface.height) == None)
+  }
+
+  test("Fill the surface with a single color") {
+    surface.fill(Color(1, 2, 3))
+    assert(surface.getPixels().flatten.forall(_ == Color(1, 2, 3)))
+    surface.fill(Color(3, 2, 1))
+    assert(surface.getPixels().flatten.forall(_ == Color(3, 2, 1)))
+  }
+}

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/RamSurfaceSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/RamSurfaceSpec.scala
@@ -1,0 +1,12 @@
+package eu.joaocosta.minart.graphics
+
+import verify._
+
+import eu.joaocosta.minart.backend._
+import eu.joaocosta.minart.runtime._
+
+object RamSurfaceSpec extends MutableSurfaceTests {
+
+  lazy val surface = new RamSurface(Vector.fill(64)(Array.fill(48)(0)))
+
+}


### PR DESCRIPTION
- Uses bound checks instead of relying on try-catch on surface operations
- Fixes a bug in the `RamSurface`
- Adds unit tests to the Surface implementations

This should make the rendering more consistent between backends.
Incidentally, this also unlocks some scala-native optimizations and makes the render much faster.

Unfortunately, I couldn't write tests for the `ImageDataSurface`. I think node doesn't have an `ImageData` implementation.