### PR TITLE
Use a Color instead of an Int on RamSurface

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/backend/PpmCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/backend/PpmCanvas.scala
@@ -37,7 +37,7 @@ class PpmCanvas() extends SurfaceBackedCanvas {
       line  <- surface.data
       _     <- pixelSize
       color <- line
-      Color(r, g, b) = Color.fromRGB(color)
+      Color(r, g, b) = color
       _ <- pixelSize
     } println(s"$r $g $b")
   }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
@@ -6,30 +6,29 @@ import eu.joaocosta.minart.graphics.Surface._
   *
   * @param data the raw data that backs this surface
   */
-class RamSurface(val data: Vector[Array[Int]]) extends MutableSurface {
+class RamSurface(val data: Vector[Array[Color]]) extends MutableSurface {
   val width  = data.headOption.map(_.size).getOrElse(0)
   val height = data.size
 
   def this(colors: Seq[Seq[Color]]) =
-    this(colors.map(_.map(_.argb).toArray).toVector)
+    this(colors.map(_.toArray).toVector)
 
   def getPixel(x: Int, y: Int): Option[Color] =
-    if (x >= 0 && y >= 0 && x < width && y < height) Some(Color.fromRGB(data(y)(x)))
+    if (x >= 0 && y >= 0 && x < width && y < height) Some(data(y)(x))
     else None
 
-  def getPixels(): Vector[Array[Color]] =
-    data.map(_.map(Color.fromRGB))
+  def getPixels(): Vector[Array[Color]] = data
 
   def putPixel(x: Int, y: Int, color: Color): Unit =
     if (x >= 0 && y >= 0 && x < width && y < height)
-      data(y)(x) = color.argb
+      data(y)(x) = color
 
   def fill(color: Color): Unit = {
     var y = 0
     while (y < height) {
       var x = 0
       while (x < width) {
-        data(y)(x) = color.argb
+        data(y)(x) = color
         x += 1
       }
       y += 1

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/RamSurfaceSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/RamSurfaceSpec.scala
@@ -6,7 +6,6 @@ import eu.joaocosta.minart.backend._
 import eu.joaocosta.minart.runtime._
 
 object RamSurfaceSpec extends MutableSurfaceTests {
-
-  lazy val surface = new RamSurface(Vector.fill(64)(Array.fill(48)(0)))
+  lazy val surface = new RamSurface(Vector.fill(64)(Array.fill(48)(Color(0, 0, 0))))
 
 }

--- a/examples/blitting/shared/src/main/scala/eu/joaocosta/minart/examples/Blitting.scala
+++ b/examples/blitting/shared/src/main/scala/eu/joaocosta/minart/examples/Blitting.scala
@@ -9,10 +9,10 @@ object Blitting {
   val image = new RamSurface(
     (0 until 16).map { y =>
       (0 until 16).map { x =>
-        if ((x + y) < 16) Color(0, 0, 0).argb
-        else Color((16 * x.toDouble).toInt, (16 * y.toDouble).toInt, 255).argb
-      }.toArray
-    }.toVector
+        if ((x + y) < 16) Color(0, 0, 0)
+        else Color((16 * x.toDouble).toInt, (16 * y.toDouble).toInt, 255)
+      }
+    }
   )
 
   def renderBackground(canvas: Canvas): Unit =


### PR DESCRIPTION
This change simplifies the code and has a huge speed boost on scala.js

I used a Int because in the past I noticed some memory problems in scala-native, but I'm not being able to reproduce them now (the memory usage was the same on my tests).

Nevertheless, the performance differences seem significant enough that, if memory problems show up in the future, it might be worth to have a `RamSurface` and a `CompressedRamSurface`, and then let the application make the trade off.