### PR TITLE
Check SDL canvas before handling events

### DIFF
--- a/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/core/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -36,7 +36,7 @@ class SdlCanvas() extends SurfaceBackedCanvas {
 
   private[this] def handleEvents(): Boolean = {
     val event              = stackalloc[SDL_Event]
-    var keepGoing: Boolean = true
+    var keepGoing: Boolean = isCreated()
     while (keepGoing && SDL_PollEvent(event) != 0) {
       event.type_ match {
         case SDL_KEYDOWN =>
@@ -119,8 +119,7 @@ class SdlCanvas() extends SurfaceBackedCanvas {
     if (resources.contains(Canvas.Resource.Pointer)) {
       pointerInput = pointerInput.clearPressRelease()
     }
-    val keepGoing = handleEvents()
-    if (resources.contains(Canvas.Resource.Backbuffer) && keepGoing) {
+    if (handleEvents() && resources.contains(Canvas.Resource.Backbuffer)) {
       surface.fill(settings.clearColor)
     }
   }


### PR DESCRIPTION
The SDL canvas internal `handleEvents` operation was not checking if the canvas was created, so when called twice it could destoy the canvas and then return that the canvas existed in the second call.