### PR TITLE
Fix AWT Canvas init race condition

### DIFF
--- a/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/core/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -30,7 +30,7 @@ class AwtCanvas() extends SurfaceBackedCanvas {
   private[this] var javaCanvas: AwtCanvas.InnerCanvas = _
   protected var surface: BufferedImageSurface         = _
 
-  private[AwtCanvas] def javaRedraw(g: Graphics): Unit = {
+  private[AwtCanvas] def javaRedraw(g: Graphics): Unit = if (javaCanvas != null) {
     g.setColor(new JavaColor(settings.clearColor.rgb))
     g.fillRect(
       0,


### PR DESCRIPTION
There was a rare race condition on the AWT canvas where the first call to `paint` could happen before the object was correctly initialized.