### PR TITLE
Improve image loading performance

### DIFF
--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/BmpImageLoader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/BmpImageLoader.scala
@@ -5,6 +5,7 @@ import java.io.InputStream
 import scala.annotation.tailrec
 
 import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.graphics.image.helpers.LazyListHelpers._
 import eu.joaocosta.minart.graphics.image.helpers._
 
 /** Image loader for BMP files.

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/QoiImageLoader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/QoiImageLoader.scala
@@ -5,6 +5,7 @@ import java.io.InputStream
 import scala.annotation.tailrec
 
 import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.graphics.image.helpers.LazyListHelpers._
 import eu.joaocosta.minart.graphics.image.helpers._
 
 /** Image loader for QOI files.

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/QoiImageLoader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/QoiImageLoader.scala
@@ -5,7 +5,7 @@ import java.io.InputStream
 import scala.annotation.tailrec
 
 import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.graphics.image.helpers.LazyListHelpers._
+import eu.joaocosta.minart.graphics.image.helpers.IteratorHelpers._
 import eu.joaocosta.minart.graphics.image.helpers._
 
 /** Image loader for QOI files.
@@ -30,7 +30,7 @@ object QoiImageLoader extends ImageLoader {
       colorspace: Byte
   )
   object Header {
-    def fromBytes(bytes: LazyList[Int]): ParseResult[Header] = (
+    def fromBytes(bytes: Iterator[Int]): ParseResult[Header] = (
       for {
         magic    <- readString(4).validate(supportedFormats, m => s"Unsupported format: $m")
         width    <- readBENumber(4)
@@ -95,7 +95,7 @@ object QoiImageLoader extends ImageLoader {
           State.pure(OpRun(run + 1))
       }
 
-    def loadOps(bytes: LazyList[Int]): LazyList[Either[String, Op]] =
+    def loadOps(bytes: Iterator[Int]): LazyList[Either[String, Op]] =
       if (bytes.isEmpty) LazyList.empty
       else
         fromBytes.run(bytes) match {
@@ -175,7 +175,7 @@ object QoiImageLoader extends ImageLoader {
   }
 
   def loadImage(is: InputStream): Either[String, RamSurface] = {
-    val stream: LazyList[Int] = LazyList.continually(is.read()).takeWhile(_ != -1)
+    val stream: Iterator[Int] = Iterator.continually(is.read()).takeWhile(_ != -1)
     Header.fromBytes(stream).flatMap { case (data, header) =>
       asSurface(Op.loadOps(data), header)
     }

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/helpers/State.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/helpers/State.scala
@@ -9,7 +9,8 @@ sealed trait State[S, +E, +A] {
   def validate[EE >: E](test: A => Boolean, failure: A => EE): State[S, EE, A] =
     flatMap(x => if (test(x)) State.pure(x) else State.error(failure(x)))
   def collect[EE >: E, B](f: PartialFunction[A, B], failure: A => EE): State[S, EE, B] = {
-    val pf = f.andThen(State.pure[S, B]).orElse((x: A) => State.error[S, EE](failure(x)))
+    val pf =
+      f.andThen((x: B) => State.pure[S, B](x)).orElse[A, State[S, EE, B]]((x: A) => State.error[S, EE](failure(x)))
     flatMap(pf)
   }
   def modify(f: S => S): State[S, E, A] =

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/helpers/package.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/helpers/package.scala
@@ -56,10 +56,6 @@ package object helpers {
   }
 
   object IteratorHelpers extends HelpersF[Iterator] {
-    private def nextOption(it: Iterator[Int]): Option[Int] =
-      if (it.hasNext) Some(it.next())
-      else None
-
     def skipBytes(n: Int): ParseState[Nothing, Unit] =
       State.modify { bytes =>
         var count = n
@@ -71,7 +67,7 @@ package object helpers {
       }
 
     val readByte: ParseState[String, Option[Int]] = State { bytes =>
-      (bytes, nextOption(bytes))
+      bytes -> bytes.nextOption()
     }
 
     def readBytes(n: Int): ParseState[Nothing, Array[Int]] = State { bytes =>
@@ -86,10 +82,10 @@ package object helpers {
 
     def readWhile(p: Int => Boolean): ParseState[Nothing, List[Int]] = State { bytes =>
       val buffer = List.newBuilder[Int]
-      var head   = nextOption(bytes)
+      var head   = bytes.nextOption()
       while (head.exists(p)) {
         buffer += head.get
-        head = nextOption(bytes)
+        head = bytes.nextOption()
       }
       (head.iterator ++ bytes) -> buffer.result()
     }

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/helpers/package.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/helpers/package.scala
@@ -6,34 +6,72 @@ package eu.joaocosta.minart.graphics.image
   */
 package object helpers {
 
-  type ParseResult[T]   = Either[String, (LazyList[Int], T)]
-  type ParseState[E, T] = State[LazyList[Int], E, T]
+  object LazyListHelpers {
+    type ParseResult[T]   = Either[String, (LazyList[Int], T)]
+    type ParseState[E, T] = State[LazyList[Int], E, T]
 
-  /** Skip N Bytes */
-  def skipBytes(n: Int): ParseState[Nothing, Unit] =
-    State.modify(_.drop(n))
+    /** Skip N Bytes */
+    def skipBytes(n: Int): ParseState[Nothing, Unit] =
+      State.modify(_.drop(n))
 
-  /** Read 1 Byte */
-  val readByte: ParseState[String, Option[Int]] = State { bytes =>
-    bytes.tail -> bytes.headOption
+    /** Read 1 Byte */
+    val readByte: ParseState[String, Option[Int]] = State { bytes =>
+      bytes.tail -> bytes.headOption
+    }
+
+    /** Read N Byte */
+    def readBytes(n: Int): ParseState[Nothing, Array[Int]] = State { bytes =>
+      bytes.drop(n) -> bytes.take(n).toArray
+    }
+
+    /** Read a String from N Bytes */
+    def readString(n: Int): ParseState[Nothing, String] =
+      readBytes(n).map { bytes => bytes.map(_.toChar).mkString("") }
+
+    /** Read a Integer N Bytes (Little Endian) */
+    def readLENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
+      bytes.zipWithIndex.map { case (num, idx) => num.toInt << (idx * 8) }.sum
+    }
+
+    /** Read a Integer N Bytes (Big Endian) */
+    def readBENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
+      bytes.reverse.zipWithIndex.map { case (num, idx) => num.toInt << (idx * 8) }.sum
+    }
   }
 
-  /** Read N Byte */
-  def readBytes(n: Int): ParseState[Nothing, Array[Int]] = State { bytes =>
-    bytes.drop(n) -> bytes.take(n).toArray
+  object IteratorHelpers {
+    type ParseResult[T]   = Either[String, (Iterator[Int], T)]
+    type ParseState[E, T] = State[Iterator[Int], E, T]
+
+    /** Skip N Bytes */
+    def skipBytes(n: Int): ParseState[Nothing, Unit] =
+      State.modify { s => s.drop(n); s.isEmpty; s }
+
+    /** Read 1 Byte */
+    val readByte: ParseState[String, Option[Int]] = State { bytes =>
+      val hd = bytes.nextOption
+      bytes -> hd
+    }
+
+    /** Read N Byte */
+    def readBytes(n: Int): ParseState[Nothing, Array[Int]] = State { bytes =>
+      val hd = bytes.take(n).toArray
+      bytes -> hd
+    }
+
+    /** Read a String from N Bytes */
+    def readString(n: Int): ParseState[Nothing, String] =
+      readBytes(n).map { bytes => bytes.map(_.toChar).mkString("") }
+
+    /** Read a Integer N Bytes (Little Endian) */
+    def readLENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
+      bytes.zipWithIndex.map { case (num, idx) => num.toInt << (idx * 8) }.sum
+    }
+
+    /** Read a Integer N Bytes (Big Endian) */
+    def readBENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
+      bytes.reverse.zipWithIndex.map { case (num, idx) => num.toInt << (idx * 8) }.sum
+    }
   }
 
-  /** Read a String from N Bytes */
-  def readString(n: Int): ParseState[Nothing, String] =
-    readBytes(n).map { bytes => bytes.map(_.toChar).mkString("") }
-
-  /** Read a Integer N Bytes (Little Endian) */
-  def readLENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
-    bytes.zipWithIndex.map { case (num, idx) => num.toInt << (idx * 8) }.sum
-  }
-
-  /** Read a Integer N Bytes (Big Endian) */
-  def readBENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
-    bytes.reverse.zipWithIndex.map { case (num, idx) => num.toInt << (idx * 8) }.sum
-  }
 }

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/helpers/package.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/helpers/package.scala
@@ -60,7 +60,7 @@ package object helpers {
       State.modify(_.drop(n))
 
     val readByte: ParseState[String, Option[Int]] = State { bytes =>
-      val hd = bytes.nextOption
+      val hd = bytes.nextOption()
       bytes -> hd
     }
 
@@ -71,10 +71,10 @@ package object helpers {
 
     def readWhile(p: Int => Boolean): ParseState[Nothing, List[Int]] = State { bytes =>
       val buffer = List.newBuilder[Int]
-      var head   = bytes.nextOption
+      var head   = bytes.nextOption()
       while (head.exists(p)) {
         buffer += head.get
-        head = bytes.nextOption
+        head = bytes.nextOption()
       }
       (head.iterator ++ bytes) -> buffer.result()
     }

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/helpers/package.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/helpers/package.scala
@@ -6,23 +6,18 @@ package eu.joaocosta.minart.graphics.image
   */
 package object helpers {
 
-  object LazyListHelpers {
-    type ParseResult[T]   = Either[String, (LazyList[Int], T)]
-    type ParseState[E, T] = State[LazyList[Int], E, T]
+  trait HelpersF[F[_]] {
+    type ParseResult[T]   = Either[String, (F[Int], T)]
+    type ParseState[E, T] = State[F[Int], E, T]
 
     /** Skip N Bytes */
-    def skipBytes(n: Int): ParseState[Nothing, Unit] =
-      State.modify(_.drop(n))
+    def skipBytes(n: Int): ParseState[Nothing, Unit]
 
     /** Read 1 Byte */
-    val readByte: ParseState[String, Option[Int]] = State { bytes =>
-      bytes.tail -> bytes.headOption
-    }
+    val readByte: ParseState[String, Option[Int]]
 
     /** Read N Byte */
-    def readBytes(n: Int): ParseState[Nothing, Array[Int]] = State { bytes =>
-      bytes.drop(n) -> bytes.take(n).toArray
-    }
+    def readBytes(n: Int): ParseState[Nothing, Array[Int]]
 
     /** Read a String from N Bytes */
     def readString(n: Int): ParseState[Nothing, String] =
@@ -39,38 +34,31 @@ package object helpers {
     }
   }
 
-  object IteratorHelpers {
-    type ParseResult[T]   = Either[String, (Iterator[Int], T)]
-    type ParseState[E, T] = State[Iterator[Int], E, T]
+  object LazyListHelpers extends HelpersF[LazyList] {
+    def skipBytes(n: Int): ParseState[Nothing, Unit] =
+      State.modify(_.drop(n))
 
-    /** Skip N Bytes */
+    val readByte: ParseState[String, Option[Int]] = State { bytes =>
+      bytes.tail -> bytes.headOption
+    }
+
+    def readBytes(n: Int): ParseState[Nothing, Array[Int]] = State { bytes =>
+      bytes.drop(n) -> bytes.take(n).toArray
+    }
+  }
+
+  object IteratorHelpers extends HelpersF[Iterator] {
     def skipBytes(n: Int): ParseState[Nothing, Unit] =
       State.modify { s => s.drop(n); s.isEmpty; s }
 
-    /** Read 1 Byte */
     val readByte: ParseState[String, Option[Int]] = State { bytes =>
       val hd = bytes.nextOption
       bytes -> hd
     }
 
-    /** Read N Byte */
     def readBytes(n: Int): ParseState[Nothing, Array[Int]] = State { bytes =>
       val hd = bytes.take(n).toArray
       bytes -> hd
-    }
-
-    /** Read a String from N Bytes */
-    def readString(n: Int): ParseState[Nothing, String] =
-      readBytes(n).map { bytes => bytes.map(_.toChar).mkString("") }
-
-    /** Read a Integer N Bytes (Little Endian) */
-    def readLENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
-      bytes.zipWithIndex.map { case (num, idx) => num.toInt << (idx * 8) }.sum
-    }
-
-    /** Read a Integer N Bytes (Big Endian) */
-    def readBENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
-      bytes.reverse.zipWithIndex.map { case (num, idx) => num.toInt << (idx * 8) }.sum
     }
   }
 

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageSpec.scala
@@ -22,7 +22,7 @@ object ImageSpec extends BasicTestSuite {
       assert(imageBin.isSuccess)
       assert(imageBin.get.width == 128)
       assert(imageBin.get.height == 128)
-      val imageTxt = Image.loadPpmImage(Resource("scala.ppm"))
+      val imageTxt = Image.loadPpmImage(Resource("scala2.ppm"))
       assert(imageTxt.isSuccess)
       assert(imageTxt.get.width == 128)
       assert(imageTxt.get.height == 128)


### PR DESCRIPTION
Uses iterators on most image loading code to reduce memory usage and improve performance.

The code could still use some cleanup, but this is good enough for now. Ideally, I think it might be a good idea to have the ImageLoaders only depend on an `F[_]` (which will probably always be iterator) and only use the helper methods, so that it's hard to mess anything in the implementation.