### PR TITLE
Fix NPE when closing native apps

### DIFF
--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -27,12 +27,14 @@ class SdlCanvas() extends SurfaceBackedCanvas {
   private[this] var keyboardInput: KeyboardInput = KeyboardInput(Set(), Set(), Set())
   private[this] var pointerInput: PointerInput   = PointerInput(None, Nil, Nil, false)
   private[this] var rawPointerPos: (Int, Int)    = _
-  private[this] def cleanPointerPos: Option[PointerInput.Position] = Option(rawPointerPos).map { case (x, y) =>
-    PointerInput.Position(
-      (x - extendedSettings.canvasX) / settings.scale,
-      (y - extendedSettings.canvasY) / settings.scale
-    )
-  }
+  private[this] def cleanPointerPos: Option[PointerInput.Position] = if (isCreated())
+    Option(rawPointerPos).map { case (x, y) =>
+      PointerInput.Position(
+        (x - extendedSettings.canvasX) / settings.scale,
+        (y - extendedSettings.canvasY) / settings.scale
+      )
+    }
+  else None
 
   private[this] def handleEvents(): Boolean = {
     val event              = stackalloc[SDL_Event]()


### PR DESCRIPTION
Native apps capturing the mouse pointer could sometimes throw an NPE when closed.

While not a huge problem, this is slightly cleaner.