### PR TITLE
Improved blitting performance

### DIFF
--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
@@ -59,6 +59,6 @@ final class BufferedImageSurface(val bufferedImage: BufferedImage) extends Surfa
         )
         g.dispose()
       case _ =>
-        super.blit(that)(x, y, cx, cy, cw, ch)
+        super.blit(that, mask)(x, y, cx, cy, cw, ch)
     }
 }

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
@@ -39,10 +39,11 @@ final class BufferedImageSurface(val bufferedImage: BufferedImage) extends Surfa
   }
 
   override def blit(
-      that: Surface
+      that: Surface,
+      mask: Option[Color] = None
   )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit =
     that match {
-      case img: BufferedImageSurface =>
+      case img: BufferedImageSurface if mask.isEmpty =>
         val g = bufferedImage.createGraphics()
         g.drawImage(
           img.bufferedImage,

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
@@ -73,7 +73,7 @@ final class SdlSurface(val data: Ptr[SDL_Surface]) extends Surface.MutableSurfac
       val dstRect = stackalloc[SDL_Rect]().init(x, y, cw, ch)
       SDL_UpperBlit(img.data, srcRect, this.data, dstRect)
     case _ =>
-      super.blit(that)(x, y, cx, cy, cw, ch)
+      super.blit(that, mask)(x, y, cx, cy, cw, ch)
   }
 
   def close(): Unit = {

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
@@ -65,9 +65,10 @@ final class SdlSurface(val data: Ptr[SDL_Surface]) extends Surface.MutableSurfac
   }
 
   override def blit(
-      that: Surface
+      that: Surface,
+      mask: Option[Color] = None
   )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit = that match {
-    case img: SdlSurface =>
+    case img: SdlSurface if mask.isEmpty =>
       val srcRect = stackalloc[SDL_Rect]().init(cx, cy, cw, ch)
       val dstRect = stackalloc[SDL_Rect]().init(x, y, cw, ch)
       SDL_UpperBlit(img.data, srcRect, this.data, dstRect)

--- a/backend/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/backend/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -57,4 +57,18 @@ trait MutableSurfaceTests extends BasicTestSuite {
     surface.blit(source)(0, 0, 0, 0, -1, -1)
     surface.blit(source)(0, 0, 0, 0, 2 * source.width, 2 * source.height)
   }
+
+  test("Combine a surface with a surface view without blowing up") {
+    val source = surface.toRamSurface().view
+
+    surface.blit(source)(0, 0)
+    surface.blit(source)(-1, -1)
+    surface.blit(source)(1, 1)
+
+    surface.blit(source)(0, 0, 1, 1)
+    surface.blit(source)(0, 0, -1, -1)
+
+    surface.blit(source)(0, 0, 0, 0, -1, -1)
+    surface.blit(source)(0, 0, 0, 0, 2 * source.width, 2 * source.height)
+  }
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
@@ -57,6 +57,51 @@ object Surface {
       */
     def fill(color: Color): Unit
 
+    private def unsafeBlit(
+        that: Surface,
+        mask: Option[Color],
+        x: Int,
+        y: Int,
+        cx: Int,
+        cy: Int,
+        minX: Int,
+        minY: Int,
+        maxX: Int,
+        maxY: Int
+    ): Unit = {
+      val thatPixels = that.getPixels()
+      var dy         = minY
+      mask match {
+        case None =>
+          while (dy < maxY) {
+            val line  = thatPixels(dy + cy)
+            val destY = dy + y
+            var dx    = minX
+            while (dx < maxX) {
+              val destX = dx + x
+              val color = line(dx + cx)
+              putPixel(destX, destY, color)
+              dx += 1
+            }
+            dy += 1
+          }
+        case Some(maskColor) =>
+          while (dy < maxY) {
+            val line  = thatPixels(dy + cy)
+            val destY = dy + y
+            var dx    = minX
+            while (dx < maxX) {
+              val destX = dx + x
+              val color = line(dx + cx)
+              if (color != maskColor) putPixel(destX, destY, color)
+              putPixel(destX, destY, color)
+              dx += 1
+            }
+            dy += 1
+          }
+      }
+    }
+
     /** Draws a surface on top of this surface.
       *
       * @param that surface to draw
@@ -88,38 +133,7 @@ object Surface {
         val maxX = math.min(clampCw, this.width - x)
         val maxY = math.min(clampCh, this.height - y)
 
-        val thatPixels = that.getPixels()
-
-        var dy = minY
-        mask match {
-          case None =>
-            while (dy < maxY) {
-              val line  = thatPixels(dy + cy)
-              val destY = dy + y
-              var dx    = minX
-              while (dx < maxX) {
-                val destX = dx + x
-                val color = line(dx + cx)
-                putPixel(destX, destY, color)
-                dx += 1
-              }
-              dy += 1
-            }
-          case Some(maskColor) =>
-            while (dy < maxY) {
-              val line  = thatPixels(dy + cy)
-              val destY = dy + y
-              var dx    = minX
-              while (dx < maxX) {
-                val destX = dx + x
-                val color = line(dx + cx)
-                if (color != maskColor) putPixel(destX, destY, color)
-                putPixel(destX, destY, color)
-                dx += 1
-              }
-              dy += 1
-            }
-        }
+        unsafeBlit(that, mask, x, y, cx, cy, minX, minY, maxX, maxY)
       }
     }
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
@@ -60,6 +60,7 @@ object Surface {
     /** Draws a surface on top of this surface.
       *
       * @param that surface to draw
+      * @param mask color to use as a mask (pixels with this color won't be merged)
       * @param x leftmost pixel on the destination surface
       * @param y topmost pixel on the destination surface
       * @param cx leftmost pixel on the source surface
@@ -68,7 +69,8 @@ object Surface {
       * @param ch clip height of the source surface
       */
     def blit(
-        that: Surface
+        that: Surface,
+        mask: Option[Color] = None
     )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit = {
       // Handle clips with a negative origin
       if (cx < 0) blit(that)(x - cx, y, 0, cy, cw + cx, ch)
@@ -89,17 +91,34 @@ object Surface {
         val thatPixels = that.getPixels()
 
         var dy = minY
-        while (dy < maxY) {
-          val line  = thatPixels(dy + cy)
-          val destY = dy + y
-          var dx    = minX
-          while (dx < maxX) {
-            val destX = dx + x
-            val color = line(dx + cx)
-            putPixel(destX, destY, color)
-            dx += 1
-          }
-          dy += 1
+        mask match {
+          case None =>
+            while (dy < maxY) {
+              val line  = thatPixels(dy + cy)
+              val destY = dy + y
+              var dx    = minX
+              while (dx < maxX) {
+                val destX = dx + x
+                val color = line(dx + cx)
+                putPixel(destX, destY, color)
+                dx += 1
+              }
+              dy += 1
+            }
+          case Some(maskColor) =>
+            while (dy < maxY) {
+              val line  = thatPixels(dy + cy)
+              val destY = dy + y
+              var dx    = minX
+              while (dx < maxX) {
+                val destX = dx + x
+                val color = line(dx + cx)
+                if (color != maskColor) putPixel(destX, destY, color)
+                putPixel(destX, destY, color)
+                dx += 1
+              }
+              dy += 1
+            }
         }
       }
     }
@@ -115,42 +134,12 @@ object Surface {
       * @param cw clip width of the source surface
       * @param ch clip height of the source surface
       */
+    @deprecated("Use blit instead")
     def blitWithMask(
         that: Surface,
         mask: Color
     )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit = {
-      // Handle clips with a negative origin
-      if (cx < 0) blitWithMask(that, mask)(x - cx, y, 0, cy, cw + cx, ch)
-      else if (cy < 0) blitWithMask(that, mask)(x, y - cy, cx, 0, cw, ch + cy)
-      else {
-        // Where can we start reading the source (handle cases where x or y are negative)
-        val minX = math.max(0, -x)
-        val minY = math.max(0, -y)
-
-        // How far can we read from the source (adjusts cw/ch to cx/cy)
-        val clampCw = math.max(0, math.min(cw, that.width - cx))
-        val clampCh = math.max(0, math.min(ch, that.height - cy))
-
-        // How far can we read from the source (handle cases where x or y are positive)
-        val maxX = math.min(clampCw, this.width - x)
-        val maxY = math.min(clampCh, this.height - y)
-
-        val thatPixels = that.getPixels()
-
-        var dy = minY
-        while (dy < maxY) {
-          val line  = thatPixels(dy + cy)
-          val destY = dy + y
-          var dx    = minX
-          while (dx < maxX) {
-            val destX = dx + x
-            val color = line(dx + cx)
-            if (color != mask) putPixel(destX, destY, color)
-            dx += 1
-          }
-          dy += 1
-        }
-      }
+      blit(that, Some(mask))(x, y, cx, cy, cw, ch)
     }
   }
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
@@ -133,7 +133,11 @@ object Surface {
         val maxX = math.min(clampCw, this.width - x)
         val maxY = math.min(clampCh, this.height - y)
 
-        unsafeBlit(that, mask, x, y, cx, cy, minX, minY, maxX, maxY)
+        if (that.isInstanceOf[SurfaceView]) {
+          unsafeBlit(that.view.clip(cx, cy, clampCw, clampCh), mask, x, y, 0, 0, 0, 0, clampCw, clampCh)
+        } else {
+          unsafeBlit(that, mask, x, y, cx, cy, minX, minY, maxX, maxY)
+        }
       }
     }
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceBackedCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceBackedCanvas.scala
@@ -19,13 +19,8 @@ trait SurfaceBackedCanvas extends LowLevelCanvas {
     surface.fill(color)
 
   override def blit(
-      that: Surface
+      that: Surface,
+      mask: Option[Color] = None
   )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit =
     surface.blit(that)(x, y, cx, cy, cw, ch)
-
-  override def blitWithMask(
-      that: Surface,
-      mask: Color
-  )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit =
-    surface.blitWithMask(that, mask)(x, y, cx, cy, cw, ch)
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceBackedCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceBackedCanvas.scala
@@ -22,5 +22,5 @@ trait SurfaceBackedCanvas extends LowLevelCanvas {
       that: Surface,
       mask: Option[Color] = None
   )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit =
-    surface.blit(that)(x, y, cx, cy, cw, ch)
+    surface.blit(that, mask)(x, y, cx, cy, cw, ch)
 }

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -57,4 +57,18 @@ trait MutableSurfaceTests extends BasicTestSuite {
     surface.blit(source)(0, 0, 0, 0, -1, -1)
     surface.blit(source)(0, 0, 0, 0, 2 * source.width, 2 * source.height)
   }
+
+  test("Combine a surface with a surface view without blowing up") {
+    val source = surface.toRamSurface().view
+
+    surface.blit(source)(0, 0)
+    surface.blit(source)(-1, -1)
+    surface.blit(source)(1, 1)
+
+    surface.blit(source)(0, 0, 1, 1)
+    surface.blit(source)(0, 0, -1, -1)
+
+    surface.blit(source)(0, 0, 0, 0, -1, -1)
+    surface.blit(source)(0, 0, 0, 0, 2 * source.width, 2 * source.height)
+  }
 }

--- a/examples/blitting/shared/src/main/scala/eu/joaocosta/minart/examples/Blitting.scala
+++ b/examples/blitting/shared/src/main/scala/eu/joaocosta/minart/examples/Blitting.scala
@@ -32,7 +32,7 @@ object Blitting {
         (canvas, state) => {
           renderBackground(canvas)
           canvas.blit(image)(state, state, 4, 4, 8, 8)
-          canvas.blitWithMask(image, Color(0, 0, 0))((128 - 16 - 1) - state, state, 4, 4, 8, 8)
+          canvas.blit(image, Some(Color(0, 0, 0)))((128 - 16 - 1) - state, state, 4, 4, 8, 8)
           canvas.redraw()
           (state + 1) % (128 - 16)
         },

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/MSurfaceIOOps.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/MSurfaceIOOps.scala
@@ -27,6 +27,7 @@ trait MSurfaceIOOps extends SurfaceIOOps {
   /** Draws a surface on top of this surface.
     *
     * @param that surface to draw
+    * @param mask color to use as a mask (pixels with this color won't be merged)
     * @param x leftmost pixel on the destination surface
     * @param y topmost pixel on the destination surface
     * @param cx leftmost pixel on the source surface
@@ -35,7 +36,8 @@ trait MSurfaceIOOps extends SurfaceIOOps {
     * @param ch clip height of the source surface
     */
   def blit(
-      that: Surface
+      that: Surface,
+      mask: Option[Color] = None
   )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): MSurfaceIO[Unit] =
     accessMSurface(_.blit(that)(x, y, cx, cy, cw, ch))
 
@@ -50,6 +52,7 @@ trait MSurfaceIOOps extends SurfaceIOOps {
     * @param cw clip width of the source surface
     * @param ch clip height of the source surface
     */
+  @deprecated("Use blit instead")
   def blitWithMask(
       that: Surface,
       mask: Color

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/MSurfaceIOOps.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/MSurfaceIOOps.scala
@@ -39,7 +39,7 @@ trait MSurfaceIOOps extends SurfaceIOOps {
       that: Surface,
       mask: Option[Color] = None
   )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): MSurfaceIO[Unit] =
-    accessMSurface(_.blit(that)(x, y, cx, cy, cw, ch))
+    accessMSurface(_.blit(that, mask)(x, y, cx, cy, cw, ch))
 
   /** Draws a surface on top of this surface and masks the pixels with a certain color.
     *


### PR DESCRIPTION
Improves blitting performance, especially for surface views.

Moving the hot loop to a private method (instead of a curryied method) also seems to have improved the performance for normal blitting, although I just checked for performance regressions.

This PR also deprecates `blitWithMask` (which might be removed before the final 0.4.0 release), as the logic is now all on a single blit function.
