### PR TITLE
Simplify loop organization

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsLoopRunner.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsLoopRunner.scala
@@ -4,7 +4,6 @@ import scala.scalajs.js.{isUndefined, timers}
 
 import org.scalajs.dom
 
-import eu.joaocosta.minart.runtime.Loop._
 import eu.joaocosta.minart.runtime._
 
 /** Loop runner for the JavaScript backend.
@@ -17,13 +16,13 @@ object JsLoopRunner extends LoopRunner {
       terminateWhen: S => Boolean,
       frequency: LoopFrequency,
       cleanup: () => Unit
-  ): StatefulLoop[S] = {
+  ): Loop[S] = {
     val iterationMillis = frequency match {
       case LoopFrequency.Uncapped         => 0
       case LoopFrequency.LoopDuration(ms) => ms
     }
-    new StatefulLoop[S] {
-      def apply(initialState: S) = {
+    new Loop[S] {
+      def run(initialState: S) = {
         def finiteLoopAux(state: S): Unit = {
           val startTime = System.currentTimeMillis()
           val newState  = operation(state)
@@ -39,7 +38,7 @@ object JsLoopRunner extends LoopRunner {
     }
   }
 
-  def singleRun(operation: () => Unit, cleanup: () => Unit): StatelessLoop = new StatelessLoop {
-    def apply() = operation()
+  def singleRun(operation: () => Unit, cleanup: () => Unit): Loop[Unit] = new Loop[Unit] {
+    def run(initialState: Unit) = operation()
   }
 }

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlLoopRunner.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlLoopRunner.scala
@@ -7,7 +7,6 @@ import scala.scalanative.unsigned._
 import sdl2.Extras._
 import sdl2.SDL._
 
-import eu.joaocosta.minart.runtime.Loop._
 import eu.joaocosta.minart.runtime._
 
 /** Loop Runner for the native backend, backed by SDL.
@@ -18,32 +17,32 @@ object SdlLoopRunner extends LoopRunner {
       terminateWhen: S => Boolean,
       frequency: LoopFrequency,
       cleanup: () => Unit
-  ): StatefulLoop[S] = {
+  ): Loop[S] = {
     val iterationMillis = frequency match {
       case LoopFrequency.Uncapped         => 0
       case LoopFrequency.LoopDuration(ms) => ms
     }
-    new StatefulLoop[S] {
-      def apply(initialState: S) = {
-        @tailrec
-        def finiteLoopAux(state: S): Unit = {
-          val startTime = SDL_GetTicks()
-          val newState  = operation(state)
-          if (!terminateWhen(newState)) {
-            val endTime  = SDL_GetTicks()
-            val waitTime = iterationMillis - (endTime - startTime).toInt
-            if (waitTime > 0) SDL_Delay(waitTime.toUInt)
-            finiteLoopAux(newState)
-          } else ()
-        }
+    @tailrec
+    def finiteLoopAux(state: S): Unit = {
+      val startTime = SDL_GetTicks()
+      val newState  = operation(state)
+      if (!terminateWhen(newState)) {
+        val endTime  = SDL_GetTicks()
+        val waitTime = iterationMillis - (endTime - startTime).toInt
+        if (waitTime > 0) SDL_Delay(waitTime.toUInt)
+        finiteLoopAux(newState)
+      } else ()
+    }
+    new Loop[S] {
+      def run(initialState: S) = {
         finiteLoopAux(initialState)
         cleanup()
       }
     }
   }
 
-  def singleRun(operation: () => Unit, cleanup: () => Unit): StatelessLoop = new StatelessLoop {
-    def apply() = {
+  def singleRun(operation: () => Unit, cleanup: () => Unit): Loop[Unit] = new Loop[Unit] {
+    def run(initialState: Unit) = {
       operation()
       var quit  = false
       val event = stackalloc[SDL_Event]()

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/ImpureRenderLoop.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/ImpureRenderLoop.scala
@@ -13,12 +13,14 @@ object ImpureRenderLoop extends RenderLoop[Function1, Function2] {
     new StatefulRenderLoop[S] {
       def apply(runner: LoopRunner, canvasManager: CanvasManager, canvasSettings: Canvas.Settings, initialState: S) = {
         val canvas = canvasManager.init(canvasSettings)
-        runner.finiteLoop(
-          (state: S) => renderFrame(canvas, state),
-          (newState: S) => terminateWhen(newState) || !canvas.isCreated(),
-          frameRate,
-          () => if (canvas.isCreated()) canvas.close()
-        )(initialState)
+        runner
+          .finiteLoop(
+            (state: S) => renderFrame(canvas, state),
+            (newState: S) => terminateWhen(newState) || !canvas.isCreated(),
+            frameRate,
+            () => if (canvas.isCreated()) canvas.close()
+          )
+          .run(initialState)
       }
     }
   }
@@ -38,7 +40,7 @@ object ImpureRenderLoop extends RenderLoop[Function1, Function2] {
   def singleFrame(renderFrame: Canvas => Unit): StatelessRenderLoop = new StatelessRenderLoop {
     def apply(runner: LoopRunner, canvasManager: CanvasManager, canvasSettings: Canvas.Settings): Unit = {
       val canvas = canvasManager.init(canvasSettings)
-      runner.singleRun(() => renderFrame(canvas), () => if (canvas.isCreated()) canvas.close())()
+      runner.singleRun(() => renderFrame(canvas), () => if (canvas.isCreated()) canvas.close()).run()
     }
   }
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RenderLoop.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RenderLoop.scala
@@ -65,7 +65,7 @@ trait RenderLoop[S] { self =>
 
 object RenderLoop {
 
-  /** The `RenderLoop` contains a set of helpful methods to implement basic render
+  /** Contains a set of helpful methods to implement basic render
     * loops in a platform agonstic way.
     *
     * @tparam F1 effect type for stateless loops
@@ -73,13 +73,12 @@ object RenderLoop {
     */
   trait Builder[F1[-_, +_], F2[-_, -_, +_]] {
 
-    /** Creates a render loop that terminates when a certain condition is reached.
+    /** Creates a render loop that keeps and updates a state on every iteration,
+      *  terminating when a certain condition is reached.
       *
-      * Each loop iteration receives and passes an updated state.
-      *
-      * @param renderFrame Operation to render the frame and update the state
-      * @param frameRate Frame rate limit
-      * @param terminateWhen Loop termination check
+      * @param renderFrame operation to render the frame and update the state
+      * @param frameRate frame rate limit
+      * @param terminateWhen loop termination check
       */
     def statefulRenderLoop[S](
         renderFrame: F2[Canvas, S, S],
@@ -87,19 +86,19 @@ object RenderLoop {
         terminateWhen: S => Boolean = (s: S) => false
     ): RenderLoop[S]
 
-    /** Creates a render loop that never terminates.
+    /** Creates a render loop that keeps no state.
       *
-      * @param renderFrame Operation to render the frame
-      * @param frameRate Frame rate limit
+      * @param renderFrame operation to render the frame
+      * @param frameRate frame rate limit
       */
     def statelessRenderLoop(
         renderFrame: F1[Canvas, Unit],
         frameRate: LoopFrequency
     ): RenderLoop[Unit]
 
-    /** Renders a single frame
+    /** Renders a single frame.
       *
-      * @param renderFrame Operation to render the frame and update the state
+      * @param renderFrame operation to render the frame and update the state
       */
     def singleFrame(renderFrame: F1[Canvas, Unit]): RenderLoop[Unit]
   }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/Loop.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/Loop.scala
@@ -1,37 +1,26 @@
 package eu.joaocosta.minart.runtime
 
-/** Provides abstractions for a loop that can be executed */
-object Loop {
+/** Provides abstractions for a loop that can be executed, keeping a state on every iteration.
+  *
+  * @tparam S State
+  */
+trait Loop[S] { self =>
 
-  /** Render loop that does not store any state.
+  /** Runs this loop
     */
-  trait StatelessLoop extends StatefulLoop[Unit] {
+  final def run()(implicit ev: Unit =:= S): Unit = run(ev(()))
 
-    /** Runs this loop
-      */
-    def apply(): Unit
-    def apply(initialState: Unit): Unit                          = apply()
-    override def withInitialState(initialState: Unit): this.type = this
-  }
-
-  /** Loop that keeps an internal state that is passed to every iteration.
+  /** Runs this loop.
     *
-    * @tparam S State
+    * @param initalState initial loop state
     */
-  trait StatefulLoop[S] { self =>
+  def run(initialState: S): Unit
 
-    /** Runs this loop.
-      *
-      * @param initalState initial loop state
-      */
-    def apply(initialState: S): Unit
-
-    /** Converts this loop to a stateless loop, with a predefined initial state.
-      *
-      * @param initalState initial loop state
-      */
-    def withInitialState(initialState: S): StatelessLoop = new StatelessLoop {
-      def apply(): Unit = self.apply(initialState)
-    }
+  /** Converts this loop to a stateless loop, with a predefined initial state.
+    *
+    * @param initalState initial loop state
+    */
+  final def withInitialState(state: S): Loop[Unit] = new Loop[Unit] {
+    def run(initialState: Unit): Unit = self.run(state)
   }
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/Loop.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/Loop.scala
@@ -6,15 +6,15 @@ package eu.joaocosta.minart.runtime
   */
 trait Loop[S] { self =>
 
-  /** Runs this loop
-    */
-  final def run()(implicit ev: Unit =:= S): Unit = run(ev(()))
-
   /** Runs this loop.
     *
     * @param initalState initial loop state
     */
   def run(initialState: S): Unit
+
+  /** Runs this loop
+    */
+  final def run()(implicit ev: Unit =:= S): Unit = run(ev(()))
 
   /** Converts this loop to a stateless loop, with a predefined initial state.
     *

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/LoopRunner.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/LoopRunner.scala
@@ -1,7 +1,7 @@
 package eu.joaocosta.minart.runtime
 
 import eu.joaocosta.minart.backend.defaults._
-import eu.joaocosta.minart.runtime.Loop._
+import eu.joaocosta.minart.runtime.Loop
 
 /** Abstraction that allows to run loops at a certain frequency in a platforrm agnostic way.
   *
@@ -23,14 +23,14 @@ trait LoopRunner {
       terminateWhen: S => Boolean,
       frequency: LoopFrequency,
       cleanup: () => Unit
-  ): StatefulLoop[S]
+  ): Loop[S]
 
   /** Runs a single operation.
     *
     * @param operation operation to perform
     * @param cleanup cleanup procedure to run when the operation is finished
     */
-  def singleRun(operation: () => Unit, cleanup: () => Unit): StatelessLoop
+  def singleRun(operation: () => Unit, cleanup: () => Unit): Loop[Unit]
 }
 
 object LoopRunner {

--- a/examples/blitting/shared/src/main/scala/eu/joaocosta/minart/examples/Blitting.scala
+++ b/examples/blitting/shared/src/main/scala/eu/joaocosta/minart/examples/Blitting.scala
@@ -28,7 +28,7 @@ object Blitting {
 
   def main(args: Array[String]): Unit = {
     ImpureRenderLoop
-      .infiniteRenderLoop[Int](
+      .statefulRenderLoop[Int](
         (canvas, state) => {
           renderBackground(canvas)
           canvas.blit(image)(state, state, 4, 4, 8, 8)
@@ -37,6 +37,7 @@ object Blitting {
           (state + 1) % (128 - 16)
         },
         LoopFrequency.hz60
-      )(canvasSettings, 0)
+      )
+      .run(canvasSettings, 0)
   }
 }

--- a/examples/colorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/ColorSquare.scala
+++ b/examples/colorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/ColorSquare.scala
@@ -18,6 +18,7 @@ object ColorSquare {
           c.putPixel(x, y, color)
         }
         c.redraw()
-      })(canvasSettings)
+      })
+      .run(canvasSettings)
   }
 }

--- a/examples/fire/shared/src/main/scala/eu/joaocosta/minart/examples/Fire.scala
+++ b/examples/fire/shared/src/main/scala/eu/joaocosta/minart/examples/Fire.scala
@@ -27,7 +27,7 @@ object Fire {
     }
 
     ImpureRenderLoop
-      .infiniteRenderLoop(
+      .statelessRenderLoop(
         canvas => {
           val keys = canvas.getKeyboardInput()
           if (keys.isDown(KeyboardInput.Key.Up)) temperatureMod = math.min(temperatureMod + 0.1, 1.0)
@@ -61,6 +61,7 @@ object Fire {
           canvas.redraw()
         },
         LoopFrequency.hz60
-      )(canvasSettings)
+      )
+      .run(canvasSettings)
   }
 }

--- a/examples/image/shared/src/main/scala/eu/joaocosta/minart/examples/Image.scala
+++ b/examples/image/shared/src/main/scala/eu/joaocosta/minart/examples/Image.scala
@@ -14,6 +14,7 @@ object Image {
       .singleFrame(canvas => {
         canvas.blit(bitmap)(0, 0)
         canvas.redraw()
-      })(canvasSettings)
+      })
+      .run(canvasSettings)
   }
 }

--- a/examples/mousepointer/shared/src/main/scala/eu/joaocosta/minart/examples/MousePointer.scala
+++ b/examples/mousepointer/shared/src/main/scala/eu/joaocosta/minart/examples/MousePointer.scala
@@ -9,7 +9,7 @@ object MousePointer {
 
   def main(args: Array[String]): Unit = {
     ImpureRenderLoop
-      .infiniteRenderLoop(
+      .statelessRenderLoop(
         c => {
           c.clear()
           val mouse = c.getPointerInput()
@@ -20,6 +20,7 @@ object MousePointer {
           c.redraw()
         },
         LoopFrequency.Uncapped
-      )(canvasSettings)
+      )
+      .run(canvasSettings)
   }
 }

--- a/examples/settings/shared/src/main/scala/eu/joaocosta/minart/examples/Settings.scala
+++ b/examples/settings/shared/src/main/scala/eu/joaocosta/minart/examples/Settings.scala
@@ -12,7 +12,7 @@ object Settings {
 
   def main(args: Array[String]): Unit = {
     ImpureRenderLoop
-      .infiniteRenderLoop(
+      .statelessRenderLoop(
         c => {
           val keyboardInput = c.getKeyboardInput()
           c.clear()
@@ -29,6 +29,7 @@ object Settings {
           c.redraw()
         },
         LoopFrequency.Uncapped
-      )(settingsA)
+      )
+      .run(settingsA)
   }
 }

--- a/examples/snake/shared/src/main/scala/eu/joaocosta/minart/examples/Snake.scala
+++ b/examples/snake/shared/src/main/scala/eu/joaocosta/minart/examples/Snake.scala
@@ -64,7 +64,7 @@ object Snake {
     val initialState = GameState(Vector.fill(canvasSettings.height)(Vector.fill(canvasSettings.width)(0)))
 
     ImpureRenderLoop
-      .infiniteRenderLoop[GameState](
+      .statefulRenderLoop[GameState](
         (c, state) => {
           c.clear()
 
@@ -82,7 +82,8 @@ object Snake {
           else state.updateSnakeDir(c.getKeyboardInput()).nextState
         },
         LoopFrequency.fromHz(15)
-      )(
+      )
+      .run(
         canvasSettings,
         initialState
       )

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/PureRenderLoop.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/PureRenderLoop.scala
@@ -1,41 +1,30 @@
 package eu.joaocosta.minart.graphics.pure
 
-import eu.joaocosta.minart.graphics.RenderLoop._
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.runtime._
 import eu.joaocosta.minart.runtime.pure._
 
-object PureRenderLoop extends RenderLoop[RIO, StateCanvasIO] {
-  def finiteRenderLoop[S](
+object PureRenderLoop extends RenderLoop.Builder[RIO, StateCanvasIO] {
+  def statefulRenderLoop[S](
       renderFrame: S => CanvasIO[S],
-      terminateWhen: S => Boolean,
-      frameRate: LoopFrequency
-  ): StatefulRenderLoop[S] =
-    ImpureRenderLoop.finiteRenderLoop[S](
+      frameRate: LoopFrequency,
+      terminateWhen: S => Boolean = (_: S) => false
+  ): RenderLoop[S] =
+    ImpureRenderLoop.statefulRenderLoop[S](
       (canvas, state) => renderFrame(state).run(canvas),
-      terminateWhen,
-      frameRate
+      frameRate,
+      terminateWhen
     )
 
-  def infiniteRenderLoop[S](
-      renderFrame: S => CanvasIO[S],
-      frameRate: LoopFrequency
-  ): StatefulRenderLoop[S] =
-    ImpureRenderLoop
-      .infiniteRenderLoop[S](
-        (canvas, state) => renderFrame(state).run(canvas),
-        frameRate
-      )
-
-  def infiniteRenderLoop(
+  def statelessRenderLoop(
       renderFrame: CanvasIO[Unit],
       frameRate: LoopFrequency
-  ): StatelessRenderLoop =
-    ImpureRenderLoop.infiniteRenderLoop(
+  ): RenderLoop[Unit] =
+    ImpureRenderLoop.statelessRenderLoop(
       canvas => renderFrame.run(canvas),
       frameRate
     )
 
-  def singleFrame(renderFrame: CanvasIO[Unit]): StatelessRenderLoop =
+  def singleFrame(renderFrame: CanvasIO[Unit]): RenderLoop[Unit] =
     ImpureRenderLoop.singleFrame(canvas => renderFrame.run(canvas))
 }

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/runtime/pure/MinartApp.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/runtime/pure/MinartApp.scala
@@ -17,7 +17,8 @@ trait MinartApp {
 
   def main(args: Array[String]): Unit = {
     PureRenderLoop
-      .finiteRenderLoop[State](renderFrame, terminateWhen, frameRate)(
+      .statefulRenderLoop[State](renderFrame, frameRate, terminateWhen)
+      .run(
         loopRunner,
         canvasManager,
         canvasSettings,


### PR DESCRIPTION
Simplifies the way `Loop`/`LoopRunner`/`RenderLoop`s are structured

Now there's a `RenderLoop.Builder` and `RenderLoop` is analogous to `Loop`.

This also removes the `Stateful`/`Stateless` distinctions and simplifies the `RenderLoop.Builder` operations.