### PR TITLE
Avoid lambdas on Planes

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -4,52 +4,58 @@ package eu.joaocosta.minart.graphics
  *
  * Can be clipped to create a surface.
  */
-final class Plane private (unboxedGenerator: (Int, Int) => Int) {
-  def getPixel(x: Int, y: Int): Color = Color.fromRGB(unboxedGenerator(x, y))
+trait Plane { outer =>
+  def getPixel(x: Int, y: Int): Color
 
   /** Maps the colors from this plane. */
-  def map(f: Color => Color): Plane = Plane.fromFunction((x, y) => f(getPixel(x, y)))
+  final def map(f: Color => Color): Plane = new Plane {
+    def getPixel(x: Int, y: Int): Color = f(outer.getPixel(x, y))
+  }
 
   /** Contramaps the positions from this plane. */
-  def contramap(f: (Int, Int) => (Int, Int)): Plane = new Plane((x, y) => {
-    val res = f(x, y)
-    unboxedGenerator(res._1, res._2)
-  })
+  final def contramap(f: (Int, Int) => (Int, Int)): Plane = new Plane {
+    def getPixel(x: Int, y: Int): Color = {
+      val res = f(x, y)
+      outer.getPixel(res._1, res._2)
+    }
+  }
 
   /** Combines this plane with another by combining their colors with the given function. */
-  def zipWith(that: Plane, f: (Color, Color) => Color): Plane = Plane.fromFunction((x, y) => {
-    val c1 = this.getPixel(x, y)
-    val c2 = that.getPixel(x, y)
-    f(c1, c2)
-  })
+  final def zipWith(that: Plane, f: (Color, Color) => Color): Plane = new Plane {
+    def getPixel(x: Int, y: Int): Color = {
+      val c1 = outer.getPixel(x, y)
+      val c2 = that.getPixel(x, y)
+      f(c1, c2)
+    }
+  }
 
   /** Combines this plane with a surface by combining their colors with the given function. */
-  def zipWith(that: Surface, f: (Color, Color) => Color): SurfaceView = SurfaceView(
-    Plane.fromFunction((x, y) => {
-      val c1 = this.getPixel(x, y)
-      that.getPixel(x, y).fold(c1)(c2 => f(c1, c2))
-    }),
+  final def zipWith(that: Surface, f: (Color, Color) => Color): SurfaceView = SurfaceView(
+    new Plane {
+      def getPixel(x: Int, y: Int): Color = {
+        val c1 = outer.getPixel(x, y)
+        that.getPixel(x, y).fold(c1)(c2 => f(c1, c2))
+      }
+    },
     width = that.width,
     height = that.height
   )
 
-  /** Clips this plane to a chosen rectangle, returning a surface view.
-    *
-    * @param cx leftmost pixel on the plane
-    * @param cy topmost pixel on the plane
-    * @param cw clip width
-    * @param ch clip height
-    */
-  def clip(cx: Int, cy: Int, cw: Int, ch: Int): SurfaceView =
+  final def clip(cx: Int, cy: Int, cw: Int, ch: Int): SurfaceView =
     if (cx == 0 && cy == 0) toSurfaceView(cw, ch)
-    else contramap((x, y) => (cx + x, cy + y)).toSurfaceView(cw, ch)
+    else
+      new Plane {
+        def getPixel(x: Int, y: Int): Color = {
+          outer.getPixel(x + cx, y + cy)
+        }
+      }.toSurfaceView(cw, ch)
 
   /** Converts this plane to a surface view, assuming (0, 0) as the top-left corner
     *
     * @param width surface view width
     * @param height surface view height
     */
-  def toSurfaceView(width: Int, height: Int): SurfaceView =
+  final def toSurfaceView(width: Int, height: Int): SurfaceView =
     SurfaceView(this, width, height)
 
   /** Converts this plane to a RAM surface, assuming (0, 0) as the top-left corner
@@ -57,7 +63,7 @@ final class Plane private (unboxedGenerator: (Int, Int) => Int) {
     * @param width surface width
     * @param height surface height
     */
-  def toRamSurface(width: Int, height: Int): RamSurface =
+  final def toRamSurface(width: Int, height: Int): RamSurface =
     toSurfaceView(width, height).toRamSurface()
 }
 
@@ -73,26 +79,34 @@ object Plane {
     *
     * @param generator generator function
     */
-  def fromFunction(generator: (Int, Int) => Color): Plane = new Plane((x, y) => generator(x, y).argb)
+  def fromFunction(generator: (Int, Int) => Color): Plane = new Plane {
+    def getPixel(x: Int, y: Int): Color = {
+      generator(x, y)
+    }
+  }
 
   /** Creates a plane from a surface, filling the remaining pixels with a fallback color.
     * @param surface reference surface
     * @param fallback fallback color
     */
-  def fromSurfaceWithFallback(surface: Surface, fallback: Color): Plane =
-    new Plane((x, y) => surface.getPixel(x, y).getOrElse(fallback).argb)
+  def fromSurfaceWithFallback(surface: Surface, fallback: Color): Plane = new Plane {
+    def getPixel(x: Int, y: Int): Color = {
+      surface.getPixel(x, y).getOrElse(fallback)
+    }
+  }
 
   /** Creates a plane from a surface, by repeating that surface accross both axis.
     * @param surface reference surface
     */
   def fromSurfaceWithRepetition(surface: Surface): Plane =
-    new Plane((x, y) =>
-      surface
-        .getPixel(
-          floorMod(x, surface.width),
-          floorMod(y, surface.height)
-        )
-        .getOrElse(defaultColor)
-        .argb
-    )
+    new Plane {
+      def getPixel(x: Int, y: Int): Color = {
+        surface
+          .getPixel(
+            floorMod(x, surface.width),
+            floorMod(y, surface.height)
+          )
+          .getOrElse(defaultColor)
+      }
+    }
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -41,15 +41,8 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
   def clip(cx: Int, cy: Int, cw: Int, ch: Int): SurfaceView = {
     val newWidth  = math.min(cw, this.width - cx)
     val newHeight = math.min(ch, this.height - cy)
-    if (cx == 0 && cy == 0)
-      if (newWidth == width && newHeight == height) this
-      else copy(width = newWidth, height = newHeight)
-    else
-      SurfaceView(
-        plane.contramap((x, y) => (cx + x, cy + y)),
-        width = newWidth,
-        height = newHeight
-      )
+    if (cx == 0 && cy == 0 && newWidth == width && newHeight == height) this
+    else plane.clip(cx, cy, cw, ch)
   }
 
   def getPixels(): Vector[Array[Color]] =


### PR DESCRIPTION
Makes the `Plane` a trait with some specialized implementations to avoid some extra boxing from using lambdas (e.g. on clip).

This also allows one to implement optimized Plane implementations if needed.