### PR TITLE
Ignore key repeat events

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/input/KeyboardInput.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/input/KeyboardInput.scala
@@ -18,7 +18,9 @@ case class KeyboardInput(keysDown: Set[Key], keysPressed: Set[Key], keysReleased
   def isUp(key: Key): Boolean = !keysDown(key)
 
   /** Returns a new state where a key has been pressed. */
-  def press(key: Key): KeyboardInput = KeyboardInput(keysDown + key, keysPressed + key, keysReleased - key)
+  def press(key: Key): KeyboardInput =
+    if (keysDown(key)) this
+    else KeyboardInput(keysDown + key, keysPressed + key, keysReleased - key)
 
   /** Returns a new state where a key has been released. */
   def release(key: Key): KeyboardInput = KeyboardInput(keysDown - key, keysPressed - key, keysReleased + key)


### PR DESCRIPTION
Key repeat events are quite cumbersome to handle, make the `KeyboardInput#keysPressed` unintuitive and also don't help to guarantee that things work the same way on all platforms.

I feel like it's simpler to just ignore repeated key presses. If needed, it should be possible to emulate key repeat on the application side, by checking `KeyboardInput#isDown`.