### PR TITLE
Make Minart more beginner friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Minart
 
-![Sonatype Nexus (Releases)](https://img.shields.io/nexus/r/eu.joaocosta/minart-core_2.13?server=https%3A%2F%2Foss.sonatype.org)
- [![scaladoc (core)](https://javadoc.io/badge2/eu.joaocosta/minart-core_2.13/scaladoc%20%28core%29.svg)](https://javadoc.io/doc/eu.joaocosta/minart-core_2.13)
- [![scaladoc (pure)](https://javadoc.io/badge2/eu.joaocosta/minart-pure_2.13/scaladoc%20%28pure%29.svg)](https://javadoc.io/doc/eu.joaocosta/minart-pure_2.13)
+![Sonatype Nexus (Releases)](https://img.shields.io/nexus/r/eu.joaocosta/minart_3?server=https%3A%2F%2Foss.sonatype.org)
+ [![scaladoc (core)](https://javadoc.io/badge2/eu.joaocosta/minart-core_3/scaladoc%20%28core%29.svg)](https://javadoc.io/doc/eu.joaocosta/minart-core_3)
+ [![scaladoc (pure)](https://javadoc.io/badge2/eu.joaocosta/minart-pure_3/scaladoc%20%28pure%29.svg)](https://javadoc.io/doc/eu.joaocosta/minart-pure_3)
+ [![scaladoc (image)](https://javadoc.io/badge2/eu.joaocosta/minart-image_3/scaladoc%20%28image%29.svg)](https://javadoc.io/doc/eu.joaocosta/minartimage_3)
 
 Minart is a very minimalistic Scala library to put pixels in a canvas.
 
-It's mostly useful for small toy projects or prototypes that deal with
-generative art or software rendering.
+It's mostly useful for small toy projects or prototypes that deal with generative art or software rendering.
 
 Minart is still in a 0.x version. Quoting the semver specification:
 > Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable.
@@ -20,80 +20,14 @@ Minart is still in a 0.x version. Quoting the semver specification:
 * Integer scaling
 * Keyboard and pointer input
 * Surface blitting (with a mask)
+* Surface views and infinite planes
 
 ## Getting Started
 
-### The Canvas
-
-The `Canvas`, which provides the operations required to draw on the window and read inputs:
-
-#### Rendering Operations
-
-* `getPixel(x: Int, y: Int): Option[Color]`
-* `getPixels(): Vector[Array[Color]]`
-* `putPixel(x: Int, y: Int, color: Color): Unit`
-* `fill(color: Color): Unit`
-* And more...
-
-#### Input operations
-
-* `getKeyboardInput(): KeyboardInput`
-* `getPointerInput(): PointerInput`
-
-#### Render Loop operations
-
-* `clear(resources: Set[Canvas.Resource]): Unit`
-* `redraw(): Unit`
-
-### Settings
-
-* `width: Int`
-* `height: Int`
-* `settings: Canvas.Settings`
-* `changeSettings(newSettings: Canvas.Settings): Unit`
-
-### Creating a Canvas
-
-The simplest way to create a `Canvas` is to simply create a default canvas with
-`Canvas.create(settings: Canvas.Settings)`
-(e.g. `Canvas.create(Canvas.Settings(width = 640, height = 480))`).
-
-This will immediately create a window that can manipulated with the canvas operations.
-
-In practice, it's sometimes cumbersome to have the constructor perform side-effects like
-creating the window, so it is recommended to use the default `CanvasManager` instead, with
-`CanvasManager()`.
-
-The `CanvasManager` has a single `init(settings: Canvas.Settings)` method, that creates
-and returns a `LowLevelCanvas` (a `Canvas` with an extra `close` operation).
-
-### The RenderLoop
-
-While Minart provides `Canvas` implementations for the JVM, JS and Native, writing
-cross compatible render loops is not trivial
-(JavaScript render loops work with callbacks, native render loops with SDL need to
-read the SDL events to see if the window was closed...).
-
-To tackle this problem, the `RenderLoop` abstraction provides helpful operations
-to handle the render loops.
-
-It also takes care of creating and destroying the window.
-
-Note that `clear`/`redraw` still need to be called manually (since in some cases, it might be useful to not call those methods, especially `clear`).
-
-The render loop definition might seem a bit complicated (since it attempts to be agnostic of the effect type. There's an `ImpureRenderLoop` implementation that simply uses side-effectful functions.
-
-* `singleFrame(renderFrame: Canvas => Unit)(canvasSettings: Canvas.Settings): Unit`
-* `infiniteRenderLoop(renderFrame: Canvas => Unit, frameRate: FrameRate)(canvasSettings: Canvas.Settings): Unit`
-* `infiniteRenderLoop[S](renderFrame: (Canvas, S) => S, frameRate: FrameRate)(canvas.Settings, initialState: S): Unit`
-* `finiteRenderLoop[S](renderFrame: (Canvas, S) => S, terminateWhen: S => Boolean, frameRate: FrameRate)(canvas.Settings, initialState: S): Unit`
-
-## Sample Usage
-
-To include Minart, simply add `minart-core` to your project:
+To include Minart, simply add `minart` to your project:
 
 ```scala
-libraryDependencies += "eu.joaocosta" %% "minart-core" % "0.3.3"
+libraryDependencies += "eu.joaocosta" %% "minart" % "0.4.0-RC1"
 ```
 
 Or just create a new project using the provided giter8 template, with:
@@ -102,41 +36,24 @@ Or just create a new project using the provided giter8 template, with:
 g8 https://github.com/JD557/minart
 ```
 
-The `examples` folder contains some sample code.
+You can follow the tutorials in the `examples` directory.
+The examples in `examples/release` target the latest released version, while the examples in `examples/snapshot` target
+the code in the repository.
 
-Here's a simple example that renders a color gradient to a screen:
 
-```scala
-import eu.joaocosta.minart.backend.defaults._
-import eu.joaocosta.minart.graphics._
+## Advanced Usage
 
-object ColorSquare {
-  val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = 4)
+### Minimal builds
 
-  def main(args: Array[String]): Unit = {
-    ImpureRenderLoop
-      .singleFrame(c => {
-        for {
-          x <- (0 until c.width)
-          y <- (0 until c.height)
-        } {
-          val color =
-            Color((255 * x.toDouble / c.width).toInt, (255 * y.toDouble / c.height).toInt, 255)
-          c.putPixel(x, y, color)
-        }
-        c.redraw()
-      })(canvasSettings)
-  }
-}
-```
+The Minart project is divided in multiple small packages:
 
-## Multiplatform support
+- `minart-core`: This package is always required.
+- `minart-backend`: Contains the default implementations for each backend (AWT, HTML and SDL).
+  While usually required, you can skip it if you plan to implement your own backend.
+- `minart-pure`: Contains the RIO implementation for pure applications.
+  You can skip it if you plan to just write impure code or bring your own IO implementation.
+- `minart-image`: Contains logic to load images from PPM, BMP or QOI files.
+  You can skip it if you don't plan to load any images.
 
-To compile for different platforms, one needs to either use import `eu.joaocosta.minart.backend.defaults._`
-package and use the `apply` method or use the correct `Canvas` and `RenderLoop`.
-
-The following canvas and render loops are available:
-* All: `PpmCanvas`
-* JVM: `AwtCanvas` and `JavaRenderLoop`
-* JS: `HtmlCanvas` and `JsRenderLoop`
-* Native: `SdlCanvas` and `SdlRenderLoop`
+If for some reason you want to make your binary as small as possible, you can include individual packages instead of
+the full `minart` bundle.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,12 @@
+# Minart Examples
+
+Here you'll find multiple examples that also work as a tutorial to get started with Minart.
+
+Each example is prefixed by a number, which indicate the recommended order for each lesson.
+
+To run an example, you can use [scala-cli](https://scala-cli.virtuslab.org/).
+For instance, to run the first example, just run `scala-cli 1-color-square.sc`.
+
+The examples in `examples/release` target the latest released version, while the examples in `examples/snapshot` target
+the code in the repository. If you are starting out, it is recommended that you look at the examples in the `release`
+directory.

--- a/examples/release/1-color-square.sc
+++ b/examples/release/1-color-square.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-RC1"
 
 /*

--- a/examples/release/2-portable-color-square.sc
+++ b/examples/release/2-portable-color-square.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-RC1"
 
 /*

--- a/examples/release/3-fire.sc
+++ b/examples/release/3-fire.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-RC1"
 
 /*

--- a/examples/release/4-pointer.sc
+++ b/examples/release/4-pointer.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-RC1"
 
 /*

--- a/examples/release/5-snake.sc
+++ b/examples/release/5-snake.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-RC1"
 
 /*

--- a/examples/release/6-blitting.sc
+++ b/examples/release/6-blitting.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-RC1"
 
 /*

--- a/examples/release/7-settings.sc
+++ b/examples/release/7-settings.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-RC1"
 
 /**

--- a/examples/release/8-pure-color-square.scala
+++ b/examples/release/8-pure-color-square.scala
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-RC1"
 
 /*

--- a/examples/release/9-image.sc
+++ b/examples/release/9-image.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-RC1"
 
 /*

--- a/examples/snapshot/1-color-square.sc
+++ b/examples/snapshot/1-color-square.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-SNAPSHOT"
 
 /*

--- a/examples/snapshot/2-portable-color-square.sc
+++ b/examples/snapshot/2-portable-color-square.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-SNAPSHOT"
 
 /*

--- a/examples/snapshot/3-fire.sc
+++ b/examples/snapshot/3-fire.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-SNAPSHOT"
 
 /*

--- a/examples/snapshot/4-pointer.sc
+++ b/examples/snapshot/4-pointer.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-SNAPSHOT"
 
 /*

--- a/examples/snapshot/5-snake.sc
+++ b/examples/snapshot/5-snake.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-SNAPSHOT"
 
 /*

--- a/examples/snapshot/6-blitting.sc
+++ b/examples/snapshot/6-blitting.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-SNAPSHOT"
 
 /*

--- a/examples/snapshot/7-settings.sc
+++ b/examples/snapshot/7-settings.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-SNAPSHOT"
 
 /**

--- a/examples/snapshot/8-pure-color-square.scala
+++ b/examples/snapshot/8-pure-color-square.scala
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-SNAPSHOT"
 
 /*

--- a/examples/snapshot/9-image.sc
+++ b/examples/snapshot/9-image.sc
@@ -1,4 +1,4 @@
-//> using scala "3.1.1"
+//> using scala "3.1.2"
 //> using lib "eu.joaocosta::minart:0.4.0-SNAPSHOT"
 
 /*

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/package.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/package.scala
@@ -3,12 +3,34 @@ package eu.joaocosta.minart.graphics
 import eu.joaocosta.minart.runtime.pure.{IOOps, RIO}
 
 package object pure {
+
+  /** Representation of a operation on that requires a Surface, with the common Monad operations.
+    *  This is the same as `RIO[Surface, A]`.
+    */
   type SurfaceIO[+A] = RIO[Surface, A]
+
+  /** Object containing the operations that act on a Surface.
+    */
   object SurfaceIO extends SurfaceIOOps with IOOps[Surface]
+
+  /** Representation of a operation on that requires a Mutable Surface, with the common Monad operations.
+    *  This is the same as `RIO[MutableSurface, A]`.
+    */
   type MSurfaceIO[+A] = RIO[MutableSurface, A]
+
+  /** Object containing the operations that act on a Mutable Surface.
+    */
   object MSurfaceIO extends MSurfaceIOOps with IOOps[MutableSurface]
+
+  /** Representation of a operation that requires a Canvas, with the common Monad operations.
+    *  This is the same as `RIO[Canvas, A]`.
+    */
   type CanvasIO[+A] = RIO[Canvas, A]
+
+  /** Object containing the operations that act on a Canvas.
+    */
   object CanvasIO extends CanvasIOOps with IOOps[Canvas]
 
+  /** Alias for `State => RIO[Canvas, A]` */
   type StateCanvasIO[-Canvas, -State, +A] = Function1[State, RIO[Canvas, A]]
 }

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/runtime/pure/package.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/runtime/pure/package.scala
@@ -3,6 +3,13 @@ package eu.joaocosta.minart.runtime
 import eu.joaocosta.minart.runtime.pure.{IOOps, RIO}
 
 package object pure {
+
+  /** Representation of a operation on that requires a Resource, with the common Monad operations.
+    *  This is the same as `RIO[Resource, A]`.
+    */
   type ResourceIO[+A] = RIO[Resource, A]
+
+  /** Object containing the operations that act on a Resource.
+    */
   object ResourceIO extends ResourceIOOps with IOOps[Resource]
 }

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -13,11 +13,7 @@ lazy val root =
       Seq(
         scalaVersion := "$scala_version$",
         libraryDependencies ++= List(
-          $if(pure.truthy) $
-            "eu.joaocosta" %%% "minart-core" % "0.3.3",
-          "eu.joaocosta"   %%% "minart-pure" % "0.3.3"
-            $else$
-            "eu.joaocosta" %%% "minart-core" % "0.3.3" $endif$
+          "eu.joaocosta" %%% "minart" % "0.4.0-RC1",
         )
       )
     )

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -2,5 +2,5 @@ name = Minart Project
 organization = com.github.myself
 package = $organization$.project
 version = 1.0
-scala_version = 2.13.6
+scala_version = 3.1.2
 pure = no

--- a/src/main/g8/shared/src/main/scala/$if(!pure.truthy)$$package$$endif$/Main.scala
+++ b/src/main/g8/shared/src/main/scala/$if(!pure.truthy)$$package$$endif$/Main.scala
@@ -8,16 +8,17 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     ImpureRenderLoop
-      .singleFrame(c => {
+      .singleFrame(canvas => {
         for {
-          x <- (0 until c.settings.width)
-          y <- (0 until c.settings.height)
+          x <- (0 until canvas.width)
+          y <- (0 until canvas.height)
         } {
           val color =
-            Color((255 * x.toDouble / c.settings.width).toInt, (255 * y.toDouble / c.settings.height).toInt, 255)
-          c.putPixel(x, y, color)
+            Color((255 * x.toDouble / canvas.width).toInt, (255 * y.toDouble / canvas.height).toInt, 255)
+          canvas.putPixel(x, y, color)
         }
-        c.redraw()
-      })(canvasSettings)
+        canvas.redraw()
+      })
+      .run(canvasSettings)
   }
 }

--- a/src/main/g8/shared/src/main/scala/$if(pure.truthy)$$package$$endif$/Main.scala
+++ b/src/main/g8/shared/src/main/scala/$if(pure.truthy)$$package$$endif$/Main.scala
@@ -1,5 +1,6 @@
 package $package$
 
+import eu.joaocosta.minart.backend.defaults._
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.pure._
 import eu.joaocosta.minart.runtime._


### PR DESCRIPTION
Simplifies the giter8 template and the README to make the project more beginner friendly.

New users are now pointed straight to the examples/tutorials and are recommended to just include the `minart` bundle.