### PR TITLE
Move surface view helpers from minart-image

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -50,6 +50,12 @@ trait Plane { outer =>
         }
       }.toSurfaceView(cw, ch)
 
+  /** Inverts a plane color. */
+  def invertColor: Plane = map(_.invert)
+
+  /** Transposes a surface. */
+  def transpose: Plane = contramap((x, y) => (y, x))
+
   /** Converts this plane to a surface view, assuming (0, 0) as the top-left corner
     *
     * @param width surface view width

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -45,6 +45,22 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
     else plane.clip(cx, cy, cw, ch)
   }
 
+  /** Inverts a surface color. */
+  def invertColor: SurfaceView = map(_.invert)
+
+  /** Flips a surface horizontally. */
+  def flipH: SurfaceView =
+    contramap((x, y) => (width - x - 1, y))
+      .toSurfaceView(width, height)
+
+  /** Flips an surface vertically. */
+  def flipV: SurfaceView = contramap((x, y) => (x, height - y - 1))
+    .toSurfaceView(width, height)
+
+  /** Transposes a surface. */
+  def transpose: SurfaceView =
+    plane.transpose.toSurfaceView(height, width)
+
   def getPixels(): Vector[Array[Color]] =
     Vector.tabulate(height)(y => Array.tabulate(width)(x => getPixel(x, y).getOrElse(SurfaceView.defaultColor)))
 

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/Image.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/Image.scala
@@ -6,35 +6,8 @@ import scala.util.{Failure, Success, Try}
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.runtime.Resource
 
-/** Object containing user-friendly functions to load and manipulate images.
-  */
+/** Object containing user-friendly functions to images. */
 object Image {
-
-  /** Inverts an image color.
-    */
-  def invert(surface: Surface): SurfaceView =
-    surface.view.map(_.invert)
-
-  /** Flips an image horizontally.
-    */
-  def flipH(surface: Surface): SurfaceView =
-    surface.view
-      .contramap((x, y) => (surface.width - x - 1, y))
-      .clip(0, 0, surface.width, surface.height)
-
-  /** Flips an image vertically.
-    */
-  def flipV(surface: Surface): SurfaceView =
-    surface.view
-      .contramap((x, y) => (x, surface.height - y - 1))
-      .clip(0, 0, surface.width, surface.height)
-
-  /** Transposes an image.
-    */
-  def transpose(surface: Surface): SurfaceView =
-    surface.view
-      .contramap((x, y) => (y, x))
-      .clip(0, 0, surface.height, surface.width)
 
   /** Loads an image using a custom ImageLoader.
     *


### PR DESCRIPTION
Moves the SurfaceView helpers such as `flipV`/`flipH` away from minart-image. Those didn't really fit in that module.