### PR TITLE
Add unsafeGetPixel operation

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
@@ -15,11 +15,10 @@ final class ImageDataSurface(val data: ImageData) extends MutableSurface {
   private val lines   = 0 until height
   private val columns = 0 until width
 
-  def getPixel(x: Int, y: Int): Option[Color] =
-    if (x >= 0 && y >= 0 && x < width && y < height) {
-      val baseAddr = 4 * (y * width + x)
-      Some(Color(data.data(baseAddr + 0), data.data(baseAddr + 1), data.data(baseAddr + 2)))
-    } else None
+  def unsafeGetPixel(x: Int, y: Int): Color = {
+    val baseAddr = 4 * (y * width + x)
+    Color(data.data(baseAddr + 0), data.data(baseAddr + 1), data.data(baseAddr + 2))
+  }
 
   def getPixels(): Vector[Array[Color]] = {
     val imgData = data.data

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
@@ -11,16 +11,8 @@ final class BufferedImageSurface(val bufferedImage: BufferedImage) extends Mutab
   val height              = bufferedImage.getHeight()
   private val imagePixels = bufferedImage.getRaster.getDataBuffer.asInstanceOf[DataBufferInt]
 
-  def getPixel(x: Int, y: Int): Option[Color] =
-    if (x >= 0 && y >= 0 && x < width && y < height)
-      Some(
-        Color.fromRGB(
-          imagePixels.getElem(
-            y * width + x
-          )
-        )
-      )
-    else None
+  def unsafeGetPixel(x: Int, y: Int): Color =
+    Color.fromRGB(imagePixels.getElem(y * width + x))
 
   def getPixels(): Vector[Array[Color]] =
     imagePixels.getData().iterator.map(Color.fromRGB).grouped(width).map(_.toArray).toVector

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
@@ -20,19 +20,16 @@ final class SdlSurface(val data: Ptr[SDL_Surface]) extends MutableSurface with A
   private val columns  = 0 until width
   private val renderer = SDL_CreateSoftwareRenderer(data)
 
-  def getPixel(x: Int, y: Int): Option[Color] =
-    if (data.pixels != null && x >= 0 && y >= 0 && x < width && y < height) {
-      // Assuming a BGRA surface
-      val baseAddr =
-        4 * (y * width + x)
-      Some(
-        Color(
-          (data.pixels(baseAddr + 2) & 0xff),
-          (data.pixels(baseAddr + 1) & 0xff),
-          (data.pixels(baseAddr + 0) & 0xff)
-        )
-      )
-    } else None
+  def unsafeGetPixel(x: Int, y: Int): Color = {
+    // Assuming a BGRA surface
+    val baseAddr =
+      4 * (y * width + x)
+    Color(
+      (data.pixels(baseAddr + 2) & 0xff),
+      (data.pixels(baseAddr + 1) & 0xff),
+      (data.pixels(baseAddr + 0) & 0xff)
+    )
+  }
 
   def getPixels(): Vector[Array[Color]] = {
     lines.map { y =>

--- a/backend/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/backend/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -71,4 +71,18 @@ trait MutableSurfaceTests extends BasicTestSuite {
     surface.blit(source)(0, 0, 0, 0, -1, -1)
     surface.blit(source)(0, 0, 0, 0, 2 * source.width, 2 * source.height)
   }
+
+  test("Correctly combine two surfaces") {
+    surface.fill(Color(255, 0, 0))
+    val source = surface.toRamSurface()
+    surface.fill(Color(0, 0, 0))
+
+    assert(surface.getPixel(0, 0) == Some(Color(0, 0, 0)))
+    assert(surface.getPixel(1, 1) == Some(Color(0, 0, 0)))
+
+    surface.blit(source)(1, 1)
+
+    assert(surface.getPixel(0, 0) == Some(Color(0, 0, 0)))
+    assert(surface.getPixel(1, 1) == Some(Color(255, 0, 0)))
+  }
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/MutableSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/MutableSurface.scala
@@ -30,17 +30,16 @@ trait MutableSurface extends Surface {
       maxX: Int,
       maxY: Int
   ): Unit = {
-    val thatPixels = that.getPixels()
-    var dy         = 0
+    var dy = 0
     mask match {
       case None =>
         while (dy < maxY) {
-          val line  = thatPixels(dy + cy)
+          val srcY  = dy + cy
           val destY = dy + y
           var dx    = 0
           while (dx < maxX) {
             val destX = dx + x
-            val color = line(dx + cx)
+            val color = that.unsafeGetPixel(dx + cx, srcY)
             putPixel(destX, destY, color)
             dx += 1
           }
@@ -48,12 +47,12 @@ trait MutableSurface extends Surface {
         }
       case Some(maskColor) =>
         while (dy < maxY) {
-          val line  = thatPixels(dy + cy)
+          val srcY  = dy + cy
           val destY = dy + y
           var dx    = 0
           while (dx < maxX) {
             val destX = dx + x
-            val color = line(dx + cx)
+            val color = that.unsafeGetPixel(dx + cx, srcY)
             if (color != maskColor) putPixel(destX, destY, color)
             dx += 1
           }
@@ -74,11 +73,7 @@ trait MutableSurface extends Surface {
       val maxY = math.min(ch, math.min(that.height - cy, this.height - y))
 
       if (maxX > 0 && maxY > 0) {
-        if (that.isInstanceOf[SurfaceView]) {
-          unsafeBlit(that.view.clip(cx, cy, maxX, maxY), mask, x, y, 0, 0, maxX, maxY)
-        } else {
-          unsafeBlit(that, mask, x, y, cx, cy, maxX, maxY)
-        }
+        unsafeBlit(that, mask, x, y, cx, cy, maxX, maxY)
       }
     }
   }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
@@ -11,11 +11,10 @@ final class RamSurface(val data: Vector[Array[Color]]) extends MutableSurface {
   def this(colors: Seq[Seq[Color]]) =
     this(colors.map(_.toArray).toVector)
 
-  def getPixel(x: Int, y: Int): Option[Color] =
-    if (x >= 0 && y >= 0 && x < width && y < height) Some(data(y)(x))
-    else None
+  def unsafeGetPixel(x: Int, y: Int): Color =
+    data(y)(x)
 
-  def getPixels(): Vector[Array[Color]] = data
+  def getPixels(): Vector[Array[Color]] = data.map(_.clone())
 
   def putPixel(x: Int, y: Int, color: Color): Unit =
     if (x >= 0 && y >= 0 && x < width && y < height)

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
@@ -16,6 +16,17 @@ trait Surface {
     */
   def view: SurfaceView = SurfaceView(this)
 
+  /** Gets the color from the this surface in an unsafe way.
+    *
+    * This operation is unsafe: reading a out of bounds pixel has undefined behavior.
+    * You should only use this if the performance of `getPixel` and `getPixels` are not acceptable.
+    *
+    * @param x pixel x position
+    * @param y pixel y position
+    * @return pixel color
+    */
+  def unsafeGetPixel(x: Int, y: Int): Color
+
   /** Gets the color from the this surface.
     * This operation can be perfomance intensive, so it might be worthwile
     * to either use `getPixels` to fetch multiple pixels at the same time or
@@ -25,7 +36,9 @@ trait Surface {
     * @param y pixel y position
     * @return pixel color
     */
-  def getPixel(x: Int, y: Int): Option[Color]
+  def getPixel(x: Int, y: Int): Option[Color] =
+    if (x >= 0 && y >= 0 && x < width && y < height) Some(unsafeGetPixel(x, y))
+    else None
 
   /** Returns the pixels from this surface.
     * This operation can be perfomance intensive, so it might be worthwile

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceBackedCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceBackedCanvas.scala
@@ -9,8 +9,8 @@ trait SurfaceBackedCanvas extends LowLevelCanvas {
   def putPixel(x: Int, y: Int, color: Color): Unit =
     surface.putPixel(x, y, color)
 
-  def getPixel(x: Int, y: Int): Option[Color] =
-    surface.getPixel(x, y)
+  def unsafeGetPixel(x: Int, y: Int): Color =
+    surface.unsafeGetPixel(x, y)
 
   def getPixels(): Vector[Array[Color]] =
     surface.getPixels()

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -7,9 +7,8 @@ package eu.joaocosta.minart.graphics
   */
 final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surface {
 
-  def getPixel(x: Int, y: Int): Option[Color] =
-    if (x >= 0 && y >= 0 && x < width && y < height) Some(plane.getPixel(x, y))
-    else None
+  def unsafeGetPixel(x: Int, y: Int): Color =
+    plane.getPixel(x, y)
 
   /** Maps the colors from this surface view. */
   def map(f: Color => Color): SurfaceView = copy(plane.map(f))
@@ -62,7 +61,7 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
     plane.transpose.toSurfaceView(height, width)
 
   def getPixels(): Vector[Array[Color]] =
-    Vector.tabulate(height)(y => Array.tabulate(width)(x => getPixel(x, y).getOrElse(SurfaceView.defaultColor)))
+    Vector.tabulate(height)(y => Array.tabulate(width)(x => unsafeGetPixel(x, y)))
 
   override def view: SurfaceView = this
 }

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -71,4 +71,19 @@ trait MutableSurfaceTests extends BasicTestSuite {
     surface.blit(source)(0, 0, 0, 0, -1, -1)
     surface.blit(source)(0, 0, 0, 0, 2 * source.width, 2 * source.height)
   }
+
+  test("Correctly combine two surfaces") {
+    surface.fill(Color(255, 0, 0))
+    val source = surface.toRamSurface()
+    surface.fill(Color(0, 0, 0))
+
+    assert(surface.getPixel(0, 0) == Some(Color(0, 0, 0)))
+    assert(surface.getPixel(1, 1) == Some(Color(0, 0, 0)))
+
+    surface.blit(source)(1, 1)
+
+    assert(surface.getPixel(0, 0) == Some(Color(0, 0, 0)))
+    assert(source.getPixel(0, 0) == Some(Color(255, 0, 0)))
+    assert(surface.getPixel(1, 1) == Some(Color(255, 0, 0)))
+  }
 }


### PR DESCRIPTION
Adds an `unsafeGetPixel` operation that fetches a pixel without bounds checks (with undefined behavior for out of bounds pixels)

While I was initially hesitant to add this, I changed my mind:
- I noticed that I'm emulating this behavior on a lot of code by first calling `val pixels = surface.getPixels()` and then `pixels(y)(x)`
  - This is not only unsafe, but it's also less performant than just having `unsafeGetPixels`
- There was a bug in the `RamSurface#getPixels()` and `RamSuface#toRamSurface()` (it was not cloning the array, so mutating the inner array or a copied surface would mutate the original surface). Fixing that made the previous method slower.
- The blit operation was fast only because `getPixels()` happened to be fast on `RamSurface`. This forced me to add an hack to keep `SurfaceViews` performant.
  - Even with this hack, rendering a large surface view on a large canvas (e.g. 1024 x 1024) was incredibly slow.
 
This PR not only adds that operation, but also fixes the `RamSurface` bug and the performance problems when blitting `SurfaceView`s

For now, I did not add this method to `minart-pure`. This is by design: If you can't pay the price of wrapping the result in an `Option`, then you probably also can't pay the price of wrapping the computation in a `RIO` and should just use something like `SurfaceIO.accessSurface {surface => // insert optimized unsafe mutable code here }` 