### PR TITLE
Add flatMap to Plane and SurfaceView

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -4,12 +4,18 @@ package eu.joaocosta.minart.graphics
  *
  * Can be clipped to create a surface.
  */
-trait Plane { outer =>
+trait Plane extends Function2[Int, Int, Color] { outer =>
+  def apply(x: Int, y: Int): Color = getPixel(x, y)
   def getPixel(x: Int, y: Int): Color
 
   /** Maps the colors from this plane. */
   final def map(f: Color => Color): Plane = new Plane {
     def getPixel(x: Int, y: Int): Color = f(outer.getPixel(x, y))
+  }
+
+  /* Flatmaps this plane */
+  final def flatMap(f: Color => (Int, Int) => Color): Plane = new Plane {
+    def getPixel(x: Int, y: Int): Color = f(outer.getPixel(x, y)).apply(x, y)
   }
 
   /** Contramaps the positions from this plane. */
@@ -79,6 +85,14 @@ object Plane {
     val rem = x % y
     if (rem >= 0) rem
     else rem + y
+  }
+
+  /** Creates a plane from a constant color
+    *
+    * @param constant constant color
+    */
+  def fromConstant(color: Color): Plane = new Plane {
+    def getPixel(x: Int, y: Int): Color = color
   }
 
   /** Creates a plane from a generator function

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -13,6 +13,10 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
   /** Maps the colors from this surface view. */
   def map(f: Color => Color): SurfaceView = copy(plane.map(f))
 
+  /** Flatmaps the inner plane of this surface view */
+  def flatMap(f: Color => (Int, Int) => Color): SurfaceView =
+    copy(plane.flatMap(x => f(x)))
+
   /** Contramaps the positions from this surface view. */
   def contramap(f: (Int, Int) => (Int, Int)): Plane =
     plane.contramap(f)

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
@@ -47,6 +47,21 @@ object PlaneSpec extends BasicTestSuite {
     assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
   }
 
+  test("Flatmapping it updates the colors based on the position") {
+    val newSurface =
+      Plane
+        .fromSurfaceWithRepetition(surface)
+        .flatMap(color => (x, y) => if (y >= 8) color.invert else color)
+        .toRamSurface(surface.width, surface.height)
+    val newPixels = newSurface.getPixels()
+    val expectedPixels =
+      originalPixels.take(8) ++ originalPixels.drop(8).map(_.map(_.invert))
+
+    assert(newSurface.width == surface.width)
+    assert(newSurface.height == surface.height)
+    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+  }
+
   test("Contramapping updates the positions") {
     val newSurface =
       Plane

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/SurfaceViewSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/SurfaceViewSpec.scala
@@ -33,6 +33,19 @@ object SurfaceViewSpec extends BasicTestSuite {
     assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
   }
 
+  test("The flatMap view updates the colors based on the position") {
+    val newSurface = surface.view
+      .flatMap(color => (x, y) => if (y >= 8) color.invert else color)
+      .toRamSurface()
+    val newPixels = newSurface.getPixels()
+    val expectedPixels =
+      originalPixels.take(8) ++ originalPixels.drop(8).map(_.map(_.invert))
+
+    assert(newSurface.width == surface.width)
+    assert(newSurface.height == surface.height)
+    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+  }
+
   test("The contramap view updates the positions") {
     val newSurface = surface.view.contramap((x, y) => (y, x)).clip(0, 0, surface.height, surface.width).toRamSurface()
     val newPixels  = newSurface.getPixels()

--- a/examples/snapshot/10-surface-view.sc
+++ b/examples/snapshot/10-surface-view.sc
@@ -50,12 +50,16 @@ ImpureRenderLoop
       val image = Plane.fromSurfaceWithRepetition(updatedBitmap) // Create an inifinitePlane from our surface
         .contramap((x, y) => ((x * zoom).toInt, (y * zoom).toInt)) // Apply zooming logic
         .contramap((x, y) => ((x * frameCos - y * frameSin).toInt, (x * frameSin + y * frameCos).toInt)) // Rotatiion
+        .flatMap(color => (x, y) => // Add a crazy checkerboard effect
+            if (x % 32 < 16 != y % 32 < 16) color.invert
+            else color
+          )
         .clip(0, 0, 128, 128) // Clip into a SurfaceView
 
       // Draw the image. Note that image is a SurfaceView, we don't need to convert it into a RamSurface.
       canvas.blit(image)(0, 0)
       canvas.redraw()
-      t + 0.05
+      t + 0.01
     },
     LoopFrequency.hz60
   ).run(canvasSettings, 0)


### PR DESCRIPTION
While not a monad, its still possible to implement `flatMap` on a `Plane`, which is quite useful for some image efects (as shown in the updated example).

I'm not entirely sure if it's correct to implement this on the `SurfaceView` (it looks a bit awkward on for comprehensions), but it seems like an helpful method as well, so I just implemented it as well.
Maybe it would be more lawful if I made `SurfaceView` extend `PartialFunction[(Int, Int), Color]` and then defined `def flatMap(f: Color => PartialFunction[(Int, Int), Color]): SurfaceView`, but this brings other problems (I don't like `PartialFunction`s and this could in theory change the width and height of the `SurfaceView`, and I would have no easy way to check for that)