### PR TITLE
Fix AWT window focus

### DIFF
--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -84,7 +84,9 @@ class AwtCanvas() extends SurfaceBackedCanvas {
       keyListener = new AwtCanvas.KeyListener()
       mouseListener = new AwtCanvas.MouseListener(javaCanvas, extendedSettings)
       javaCanvas.addKeyListener(keyListener)
+      javaCanvas.frame.addKeyListener(keyListener)
       javaCanvas.addMouseListener(mouseListener)
+      javaCanvas.frame.addMouseListener(mouseListener)
       clear(Set(Canvas.Buffer.Backbuffer))
     }
   }
@@ -132,8 +134,10 @@ object AwtCanvas {
       new Dimension(scaledWidth, scaledHeight)
 
     val frame = new JFrame("Minart")
-    frame.add(this)
+    frame.setUndecorated(fullScreen)
     frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE)
+
+    frame.add(this)
     frame.pack()
     GraphicsEnvironment
       .getLocalGraphicsEnvironment()
@@ -145,7 +149,6 @@ object AwtCanvas {
     val buffStrategy = getBufferStrategy
 
     override def paint(g: Graphics) = outerCanvas.javaRedraw(g)
-
     frame.setVisible(true)
     frame.setResizable(false)
     frame.addWindowListener(new WindowAdapter() {


### PR DESCRIPTION
Fix the focus of AWT windows.

Turns out that the focus would change when the window settings changed (e.g. by going into fullscreen), which would disable the keyboard input until the component was focused again (e.g. by clicking on it).

This PR also removes the decorations in fullscreen, which were showing up on Windows.