### PR TITLE
Make examples cross-compilable

### DIFF
--- a/examples/release/01-color-square.sc
+++ b/examples/release/01-color-square.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.0"
+//> using lib "eu.joaocosta::minart::0.4.0"
 
 /*
  * Welcome to the minart tutorial!

--- a/examples/release/02-portable-color-square.sc
+++ b/examples/release/02-portable-color-square.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.0"
+//> using lib "eu.joaocosta::minart::0.4.0"
 
 /*
  * In this next example, we are going to do draw the same colored square, but now in a portable way.

--- a/examples/release/03-fire-animation.sc
+++ b/examples/release/03-fire-animation.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.0"
+//> using lib "eu.joaocosta::minart::0.4.0"
 
 /*
  * In the previous examples we just drew a static image on the screen.

--- a/examples/release/04-pointer.sc
+++ b/examples/release/04-pointer.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.0"
+//> using lib "eu.joaocosta::minart::0.4.0"
 
 /*
  * Now that we learned the basics of animation, we can start to look at more dynamic applications.

--- a/examples/release/05-snake-game.sc
+++ b/examples/release/05-snake-game.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.0"
+//> using lib "eu.joaocosta::minart::0.4.0"
 
 /*
  * Now that we learned the basics of animation and input handling, we are almost ready to make a game.

--- a/examples/release/06-surface-blit.sc
+++ b/examples/release/06-surface-blit.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.0"
+//> using lib "eu.joaocosta::minart::0.4.0"
 
 /*
  * Writing directly to a canvas pixel by pixel worked fine in the previous examples, but

--- a/examples/release/07-canvas-settings.sc
+++ b/examples/release/07-canvas-settings.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.0"
+//> using lib "eu.joaocosta::minart::0.4.0"
 
 /**
  * On some occasions, we might need to change our canvas settings.

--- a/examples/release/08-pure-color-square.scala
+++ b/examples/release/08-pure-color-square.scala
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.0"
+//> using lib "eu.joaocosta::minart::0.4.0"
 
 /*
  * Some people might prefer to code using a "programs as values" approach.

--- a/examples/release/09-image.sc
+++ b/examples/release/09-image.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.0"
+//> using lib "eu.joaocosta::minart::0.4.0"
 
 /*
  * It is sometimes convenient to load images from external resources.

--- a/examples/release/10-surface-view.sc
+++ b/examples/release/10-surface-view.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.0"
+//> using lib "eu.joaocosta::minart::0.4.0"
 
 /*
  * It can be quite cumbersome an ineficient to apply multiple transformations to a surface if we just use the getPixel

--- a/examples/snapshot/01-color-square.sc
+++ b/examples/snapshot/01-color-square.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.1-SNAPSHOT"
+//> using lib "eu.joaocosta::minart::0.4.1-SNAPSHOT"
 
 /*
  * Welcome to the minart tutorial!

--- a/examples/snapshot/02-portable-color-square.sc
+++ b/examples/snapshot/02-portable-color-square.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.1-SNAPSHOT"
+//> using lib "eu.joaocosta::minart::0.4.1-SNAPSHOT"
 
 /*
  * In this next example, we are going to do draw the same colored square, but now in a portable way.

--- a/examples/snapshot/03-fire-animation.sc
+++ b/examples/snapshot/03-fire-animation.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.1-SNAPSHOT"
+//> using lib "eu.joaocosta::minart::0.4.1-SNAPSHOT"
 
 /*
  * In the previous examples we just drew a static image on the screen.

--- a/examples/snapshot/04-pointer.sc
+++ b/examples/snapshot/04-pointer.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.1-SNAPSHOT"
+//> using lib "eu.joaocosta::minart::0.4.1-SNAPSHOT"
 
 /*
  * Now that we learned the basics of animation, we can start to look at more dynamic applications.

--- a/examples/snapshot/05-snake-game.sc
+++ b/examples/snapshot/05-snake-game.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.1-SNAPSHOT"
+//> using lib "eu.joaocosta::minart::0.4.1-SNAPSHOT"
 
 /*
  * Now that we learned the basics of animation and input handling, we are almost ready to make a game.

--- a/examples/snapshot/06-surface-blit.sc
+++ b/examples/snapshot/06-surface-blit.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.1-SNAPSHOT"
+//> using lib "eu.joaocosta::minart::0.4.1-SNAPSHOT"
 
 /*
  * Writing directly to a canvas pixel by pixel worked fine in the previous examples, but

--- a/examples/snapshot/07-canvas-settings.sc
+++ b/examples/snapshot/07-canvas-settings.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.1-SNAPSHOT"
+//> using lib "eu.joaocosta::minart::0.4.1-SNAPSHOT"
 
 /**
  * On some occasions, we might need to change our canvas settings.

--- a/examples/snapshot/08-pure-color-square.scala
+++ b/examples/snapshot/08-pure-color-square.scala
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.1-SNAPSHOT"
+//> using lib "eu.joaocosta::minart::0.4.1-SNAPSHOT"
 
 /*
  * Some people might prefer to code using a "programs as values" approach.

--- a/examples/snapshot/09-image.sc
+++ b/examples/snapshot/09-image.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.1-SNAPSHOT"
+//> using lib "eu.joaocosta::minart::0.4.1-SNAPSHOT"
 
 /*
  * It is sometimes convenient to load images from external resources.

--- a/examples/snapshot/10-surface-view.sc
+++ b/examples/snapshot/10-surface-view.sc
@@ -1,5 +1,5 @@
 //> using scala "3.1.2"
-//> using lib "eu.joaocosta::minart:0.4.1-SNAPSHOT"
+//> using lib "eu.joaocosta::minart::0.4.1-SNAPSHOT"
 
 /*
  * It can be quite cumbersome an ineficient to apply multiple transformations to a surface if we just use the getPixel


### PR DESCRIPTION
Allows examples to be cross-compiled to scala-native and scala-js.

Close #221 