### PR TITLE
Add write operations to Resource

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsResource.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsResource.scala
@@ -1,12 +1,13 @@
 package eu.joaocosta.minart.backend
 
-import java.io.{ByteArrayInputStream, InputStream}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
 
 import scala.concurrent.{Future, Promise}
 import scala.io.Source
 import scala.scalajs.js
-import scala.util.Try
+import scala.util.{Try, Using}
 
+import org.scalajs.dom
 import org.scalajs.dom.{ProgressEvent, XMLHttpRequest}
 
 import eu.joaocosta.minart.runtime.Resource
@@ -16,22 +17,35 @@ import eu.joaocosta.minart.runtime.Resource
 final case class JsResource(resourcePath: String) extends Resource {
   def path = "./" + resourcePath
 
+  private def loadFromLocalStorage(): Option[String] =
+    Option(dom.window.localStorage.getItem(resourcePath))
+
   def withSource[A](f: Source => A): Try[A] = Try {
-    val xhr = new XMLHttpRequest()
-    xhr.open("GET", path, false)
-    xhr.send()
-    f(Source.fromString(xhr.responseText))
+    val data = loadFromLocalStorage() match {
+      case Some(d) => d
+      case None =>
+        val xhr = new XMLHttpRequest()
+        xhr.open("GET", path, false)
+        xhr.send()
+        xhr.responseText
+    }
+    f(Source.fromString(data))
   }
 
   def withSourceAsync[A](f: Source => A): Future[A] = {
     val promise = Promise[A]()
-    val xhr     = new XMLHttpRequest()
-    xhr.open("GET", path)
-    xhr.onloadend = (event: ProgressEvent) => {
-      if (xhr.status != 200) promise.failure(new Exception(xhr.statusText))
-      else promise.complete(Try(f(Source.fromString(xhr.responseText))))
+    loadFromLocalStorage() match {
+      case Some(data) =>
+        promise.complete(Try(f(Source.fromString(data))))
+      case None =>
+        val xhr = new XMLHttpRequest()
+        xhr.open("GET", path)
+        xhr.onloadend = (event: ProgressEvent) => {
+          if (xhr.status != 200) promise.failure(new Exception(xhr.statusText))
+          else promise.complete(Try(f(Source.fromString(xhr.responseText))))
+        }
+        xhr.send()
     }
-    xhr.send()
     promise.future
   }
 
@@ -41,22 +55,39 @@ final case class JsResource(resourcePath: String) extends Resource {
 
   def withInputStreamAsync[A](f: InputStream => A): Future[A] = {
     val promise = Promise[A]()
-    val xhr     = new XMLHttpRequest()
-    xhr.open("GET", path)
-    xhr.overrideMimeType("text/plain; charset=x-user-defined")
-    xhr.onloadend = (event: ProgressEvent) => {
-      if (xhr.status != 200) promise.failure(new Exception(xhr.statusText))
-      else promise.complete(Try(f(new ByteArrayInputStream(xhr.responseText.toCharArray.map(_.toByte)))))
+    loadFromLocalStorage() match {
+      case Some(data) =>
+        val is = new ByteArrayInputStream(data.toCharArray.map(_.toByte))
+        promise.complete(Try(f(is)))
+      case None =>
+        val xhr = new XMLHttpRequest()
+        xhr.open("GET", path)
+        xhr.overrideMimeType("text/plain; charset=x-user-defined")
+        xhr.onloadend = (event: ProgressEvent) => {
+          if (xhr.status != 200) promise.failure(new Exception(xhr.statusText))
+          else promise.complete(Try(f(new ByteArrayInputStream(xhr.responseText.toCharArray.map(_.toByte)))))
+        }
+        xhr.send()
     }
-    xhr.send()
     promise.future
   }
 
   def unsafeInputStream(): InputStream = {
-    val xhr = new XMLHttpRequest()
-    xhr.open("GET", path, false)
-    xhr.overrideMimeType("text/plain; charset=x-user-defined")
-    xhr.send()
-    new ByteArrayInputStream(xhr.responseText.toCharArray.map(_.toByte))
+    val data = loadFromLocalStorage() match {
+      case Some(d) => d
+      case None =>
+        val xhr = new XMLHttpRequest()
+        xhr.open("GET", path, false)
+        xhr.overrideMimeType("text/plain; charset=x-user-defined")
+        xhr.send()
+        xhr.responseText
+    }
+    new ByteArrayInputStream(data.toCharArray.map(_.toByte))
   }
+
+  def withOutputStream(f: OutputStream => Unit): Unit =
+    Using[OutputStream, Unit](new ByteArrayOutputStream()) { os =>
+      f(os)
+      dom.window.localStorage.setItem(resourcePath, os.toString())
+    }
 }

--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsResource.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsResource.scala
@@ -86,8 +86,8 @@ final case class JsResource(resourcePath: String) extends Resource {
   }
 
   def withOutputStream(f: OutputStream => Unit): Unit =
-    Using[OutputStream, Unit](new ByteArrayOutputStream()) { os =>
+    Using[ByteArrayOutputStream, Unit](new ByteArrayOutputStream()) { os =>
       f(os)
-      dom.window.localStorage.setItem(resourcePath, os.toString())
+      dom.window.localStorage.setItem(resourcePath, os.toByteArray().iterator.map(_.toChar).mkString(""))
     }
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/Resource.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/Resource.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.runtime
 
-import java.io.InputStream
+import java.io.{InputStream, OutputStream}
 
 import scala.concurrent.Future
 import scala.io.Source
@@ -44,6 +44,11 @@ trait Resource {
     * This method should only be used if for some reason the input stream must stay open (e.g. for data streaming)
     */
   def unsafeInputStream(): InputStream
+
+  /** Provides a [[java.io.OutputStream]] to write data to this resource location.
+    * The OutputStream is closed in the end, so it should not escape this call.
+    */
+  def withOutputStream(f: OutputStream => Unit): Unit
 }
 
 object Resource {


### PR DESCRIPTION
Adds a new `withOutputStream` operation on `Resource` that saves data to a file on JVM/Native and to localStorage on JS.
While `OutputStream` is not a very convenient interface, it is good enough for now... I'm not sure what a higher level interface should look like (`writeString`? `writeBytes`?).

This helps implementing a hot reload stratagy like the one proposed in #45 

Also, this PR the order resources are loaded to always try a file/localStorage first. This way an application can, for example, have an `init.conf` in the resources with the default configuration and let the user save it's configuration also to `init.conf`. If the file is deleted, the application will load back the default config.