### PR TITLE
Improve Resource interface

### DIFF
--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/NativeResource.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/NativeResource.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.backend
 
-import java.io.{FileInputStream, FileOutputStream, InputStream, OutputStream}
+import java.io.{File, FileInputStream, FileOutputStream, InputStream, OutputStream}
 
 import scala.concurrent.Future
 import scala.io.Source
@@ -15,28 +15,19 @@ import eu.joaocosta.minart.runtime.Resource
   *  Due to scala-native limitations, the async methods are actually synchronous.
   */
 final case class NativeResource(resourcePath: String) extends Resource {
-
-  // Required for scala 2.11
-  private implicit val sourceReleasable: Releasable[Source] = new Releasable[Source] {
-    def release(source: Source) = source.close()
-  }
+  override def exists(): Boolean =
+    this.getClass().getResource("/" + resourcePath) != null ||
+      new File(path).exists()
 
   def path = "./" + resourcePath
-  def withSource[A](f: Source => A): Try[A] = {
-    Using[Source, A](
-      Source.fromInputStream(unsafeInputStream())
-    )(f)
-  }
-  def withSourceAsync[A](f: Source => A): Future[A] =
-    Future.fromTry(withSource(f))
-  def withInputStream[A](f: InputStream => A): Try[A] = Using[InputStream, A](unsafeInputStream())(f)
-  def withInputStreamAsync[A](f: InputStream => A): Future[A] =
-    Future.fromTry(withInputStream(f))
 
   // TODO use Try(Source.fromResource(resourcePath)).getOrElse(Source.fromFile(path)) on scala 2.12+
   def unsafeInputStream(): InputStream =
     Try(new FileInputStream(path)).orElse(Try(Option(this.getClass().getResourceAsStream("/" + resourcePath)).get)).get
+  def unsafeOutputStream(): OutputStream = new FileOutputStream(path)
 
-  def withOutputStream(f: OutputStream => Unit): Unit =
-    Using[OutputStream, Unit](new FileOutputStream(path))(f)
+  def withSourceAsync[A](f: Source => A): Future[A] =
+    Future.fromTry(withSource(f))
+  def withInputStreamAsync[A](f: InputStream => A): Future[A] =
+    Future.fromTry(withInputStream(f))
 }

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/runtime/pure/ResourceIOOps.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/runtime/pure/ResourceIOOps.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.runtime.pure
 
-import java.io.InputStream
+import java.io.{InputStream, OutputStream}
 
 import scala.io.Source
 import scala.util.Try
@@ -17,6 +17,9 @@ trait ResourceIOOps {
   /** Path to the resource
     */
   val path: ResourceIO[String] = accessResource(_.path)
+
+  /** Checks if the resource exists */
+  val exists: ResourceIO[Boolean] = accessResource(_.exists())
 
   /** Loads the resource synchronously, processes the contents using a [[scala.io.Source]] and returns the result.
     *  The Source is closed in the end, so it should not escape this call.
@@ -43,4 +46,10 @@ trait ResourceIOOps {
     */
   def withInputStreamAsync[A](f: InputStream => A): ResourceIO[Poll[A]] =
     accessResource(res => Poll.fromFuture(res.withInputStreamAsync(f)))
+
+  /** Provides a [[java.io.OutputStream]] to write data to this resource location.
+    * The OutputStream is closed in the end, so it should not escape this call.
+    */
+  def withOutputStream(f: OutputStream => Unit): ResourceIO[Try[Unit]] =
+    accessResource(_.withOutputStream(f))
 }


### PR DESCRIPTION
Follow up to #237.

- Adds new `exists` and `unsafeOutputStream` methods to `Resource`
- Makes `withOutputStream` return `Try[Unit]` instead of `Unit`
- Adds missing methods to `ResourceIO`
- Moves some default implementations to `Resource`