### PR TITLE
Make window title configurable

### DIFF
--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -74,6 +74,7 @@ class AwtCanvas() extends SurfaceBackedCanvas {
         extendedSettings.scaledWidth,
         extendedSettings.scaledHeight,
         newSettings.fullScreen,
+        newSettings.title,
         this
       )
       extendedSettings = extendedSettings.copy(
@@ -126,13 +127,14 @@ object AwtCanvas {
       scaledWidth: Int,
       scaledHeight: Int,
       fullScreen: Boolean,
+      title: String,
       outerCanvas: AwtCanvas
   ) extends JavaCanvas {
 
     override def getPreferredSize(): Dimension =
       new Dimension(scaledWidth, scaledHeight)
 
-    val frame = new JFrame("Minart")
+    val frame = new JFrame(title)
     frame.setUndecorated(fullScreen)
     frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE)
 

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -78,15 +78,17 @@ class SdlCanvas() extends SurfaceBackedCanvas {
     ubyteClearR = newSettings.clearColor.r.toUByte
     ubyteClearG = newSettings.clearColor.g.toUByte
     ubyteClearB = newSettings.clearColor.b.toUByte
-    window = SDL_CreateWindow(
-      c"Minart",
-      SDL_WINDOWPOS_CENTERED,
-      SDL_WINDOWPOS_CENTERED,
-      extendedSettings.scaledWidth,
-      extendedSettings.scaledHeight,
-      if (extendedSettings.settings.fullScreen) SDL_WINDOW_FULLSCREEN_DESKTOP
-      else SDL_WINDOW_SHOWN
-    )
+    Zone { implicit z =>
+      window = SDL_CreateWindow(
+        toCString(newSettings.title),
+        SDL_WINDOWPOS_CENTERED,
+        SDL_WINDOWPOS_CENTERED,
+        extendedSettings.scaledWidth,
+        extendedSettings.scaledHeight,
+        if (extendedSettings.settings.fullScreen) SDL_WINDOW_FULLSCREEN_DESKTOP
+        else SDL_WINDOW_SHOWN
+      )
+    }
     windowSurface = SDL_GetWindowSurface(window)
     surface = new SdlSurface(
       SDL_CreateRGBSurface(0.toUInt, newSettings.width, newSettings.height, 32, 0.toUInt, 0.toUInt, 0.toUInt, 0.toUInt)

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Canvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Canvas.scala
@@ -77,13 +77,15 @@ object Canvas {
     * @param scale The canvas integer scaling factor
     * @param fullscreen Whether the canvas should be rendered in a full screen window
     * @param clearColor The color to be used when the canvas is cleared
+    * @param title The title to use if this Canvas needs to create a window
     */
   case class Settings(
       width: Int,
       height: Int,
       scale: Int = 1,
       fullScreen: Boolean = false,
-      clearColor: Color = Color(255, 255, 255)
+      clearColor: Color = Color(255, 255, 255),
+      title: String = "Minart"
   )
 
 }


### PR DESCRIPTION
Makes the window title configurable in the Canvas settings.

This will not do anything in the HTML Canvas I guess I could change the page title, but I'm not entirely sure if that's desirable... it's probably better to just set the title in the HTML document wrapping the Canvas.