### PR TITLE
Use SDL_WaitEvent in singleFrame

### DIFF
--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlLoopRunner.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlLoopRunner.scala
@@ -47,9 +47,7 @@ object SdlLoopRunner extends LoopRunner {
       var quit  = false
       val event = stackalloc[SDL_Event]()
       while (!quit) {
-        while (SDL_PollEvent(event) != 0) {
-          if (event.type_ == SDL_QUIT) { quit = true }
-        }
+        if (SDL_WaitEvent(event) == 1 && event.type_ == SDL_QUIT) { quit = true }
       }
       cleanup()
     }


### PR DESCRIPTION
SDL_WaitEvent should be more performant than a busy loop polling events.

Actually, I wonder if it would make sense to have a special "FrameRate" that would only run the next iteration when there is an event, but that's another problem for another day.