### PR TITLE
Fix FlatMap stack safety

### DIFF
--- a/pure/shared/src/main/scala/eu/joaocosta/minart/runtime/pure/RIO.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/runtime/pure/RIO.scala
@@ -1,35 +1,49 @@
 package eu.joaocosta.minart.runtime.pure
 
+import scala.annotation.tailrec
+
 /** Representation of an effectful operation, based on Haskell's RIO Monad.
   */
 sealed trait RIO[-R, +A] {
 
   /** Runs this operation. */
-  def run(resource: R): A
+  @tailrec
+  final def run(resource: R): A = this match {
+    case RIO.Suspend(thunk) =>
+      thunk(resource)
+    case RIO.FlatMap(io, andThen) =>
+      io match {
+        case RIO.Suspend(thunk) =>
+          andThen(thunk(resource)).run(resource)
+        case RIO.FlatMap(nextIo, nextAndThen) =>
+          nextIo.flatMap(next => nextAndThen(next).flatMap(andThen)).run(resource)
+      }
+  }
 
   /** Maps the result of this operation. */
   def map[B](f: A => B): RIO[R, B]
 
   /** Combines two operations by applying a function to the result of the first operation. */
-  def flatMap[RR <: R, B](f: A => RIO[RR, B]): RIO[RR, B] = RIO.FlatMap[RR, A, B](this, f)
+  final def flatMap[RR <: R, B](f: A => RIO[RR, B]): RIO[RR, B] = RIO.FlatMap[RR, A, B](this, f)
 
   /** Combines two operations by discarding the result of the first operation. */
-  def andThen[RR <: R, B](that: RIO[RR, B]): RIO[RR, B] = RIO.FlatMap[RR, A, B](this, _ => that)
+  final def andThen[RR <: R, B](that: RIO[RR, B]): RIO[RR, B] = this.flatMap(_ => that)
 
   /** Combines two operations by discarding the result of the second operation. */
-  def andFinally[RR <: R, B](that: RIO[RR, B]): RIO[RR, A] = RIO.FlatMap[RR, A, A](this, x => that.as(x))
+  final def andFinally[RR <: R, B](that: RIO[RR, B]): RIO[RR, A] = this.flatMap(x => that.as(x))
 
   /** Combines two operations by combining their results with the given function. */
-  def zipWith[RR <: R, B, C](that: RIO[RR, B])(f: (A, B) => C): RIO[RR, C] = this.flatMap(x => that.map(y => f(x, y)))
+  final def zipWith[RR <: R, B, C](that: RIO[RR, B])(f: (A, B) => C): RIO[RR, C] =
+    this.flatMap(x => that.map(y => f(x, y)))
 
   /** Combines two operations by combining their results into a tuple. */
-  def zip[RR <: R, B](that: RIO[RR, B]): RIO[RR, (A, B)] = this.zipWith(that)((x, y) => x -> y)
+  final def zip[RR <: R, B](that: RIO[RR, B]): RIO[RR, (A, B)] = this.zipWith(that)((x, y) => x -> y)
 
   /** Changes the result of this operation to another value. */
-  def as[B](x: B): RIO[R, B] = this.map(_ => x)
+  final def as[B](x: B): RIO[R, B] = this.map(_ => x)
 
   /** Transforms the resource required by this operation. */
-  def contramap[RR](f: RR => R): RIO[RR, A] = RIO.Suspend[RR, A](res => this.run(f(res)))
+  final def contramap[RR](f: RR => R): RIO[RR, A] = RIO.Suspend[RR, A](res => this.run(f(res)))
 
   /** Provides the required resource to this operation. */
   def provide(res: R): RIO[Any, A] = this.contramap(_ => res)
@@ -40,11 +54,9 @@ sealed trait RIO[-R, +A] {
 
 object RIO extends IOOps.IOBaseOps[Any] {
   private[pure] final case class Suspend[R, A](thunk: R => A) extends RIO[R, A] {
-    def run(resource: R): A          = thunk(resource)
     def map[B](f: A => B): RIO[R, B] = Suspend(thunk.andThen(f))
   }
   private[pure] final case class FlatMap[R, A, B](io: RIO[R, A], andThen: A => RIO[R, B]) extends RIO[R, B] {
-    def run(resource: R): B          = andThen(io.run(resource)).run(resource)
     def map[C](f: B => C): RIO[R, C] = FlatMap[R, B, C](this, x => Suspend(_ => f(x)))
   }
 


### PR DESCRIPTION
Turns out that RIO (and State) flatMap operation was not actually stack safe. This fixes the problem and adds some more tests.