### PR TITLE
Cleanup minart image

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RenderLoop.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RenderLoop.scala
@@ -83,7 +83,7 @@ object RenderLoop {
     def statefulRenderLoop[S](
         renderFrame: F2[Canvas, S, S],
         frameRate: LoopFrequency,
-        terminateWhen: S => Boolean = (s: S) => false
+        terminateWhen: S => Boolean = (_: S) => false
     ): RenderLoop[S]
 
     /** Creates a render loop that keeps no state.

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/BmpImageLoader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/BmpImageLoader.scala
@@ -1,9 +1,15 @@
 package eu.joaocosta.minart.graphics.image
 
+import java.io.InputStream
+
+import eu.joaocosta.minart.graphics.RamSurface
 import eu.joaocosta.minart.graphics.image.helpers._
 
 @deprecated("Use eu.joaocosta.minart.graphics.image.bmp.BmpImageFormat instead")
-final class BmpImageLoader[F[_]](val byteReader: ByteReader[F]) extends bmp.BmpImageLoader[F]
+final class BmpImageLoader[F[_]](val byteReader: ByteReader[F]) extends ImageLoader { self =>
+  private val reader = new bmp.BmpImageReader[F] { val byteReader = self.byteReader }
+  def loadImage(is: InputStream): Either[String, RamSurface] = reader.loadImage(is)
+}
 
 object BmpImageLoader {
   @deprecated("Use eu.joaocosta.minart.graphics.image.bmp.BmpImageFormat.defaultFormat instead")

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/Image.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/Image.scala
@@ -8,12 +8,12 @@ import eu.joaocosta.minart.runtime.Resource
 /** Object containing user-friendly functions to images. */
 object Image {
 
-  /** Loads an image using a custom ImageLoader.
+  /** Loads an image using a custom ImageReader.
     *
-    * @param loader ImageLoader to use
+    * @param loader ImageReader to use
     * @param resource Resource pointing to the image
     */
-  def loadImage(loader: ImageLoader, resource: Resource): Try[RamSurface] = {
+  def loadImage(loader: ImageReader, resource: Resource): Try[RamSurface] = {
     loader.loadImage(resource).flatMap {
       case Left(error)   => Failure(new Exception(error))
       case Right(result) => Success(result)

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ImageLoader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ImageLoader.scala
@@ -1,38 +1,6 @@
 package eu.joaocosta.minart.graphics.image
 
-import java.io.{ByteArrayInputStream, InputStream}
-
-import scala.util.Try
-
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.runtime.Resource
-
 /** Image loader with a low-level implementation on how to load an image.
   */
-trait ImageLoader {
-
-  /** Loads an image from an InputStream.
-    *
-    * @param is InputStream with the image data
-    * @return Either a RamSurface with the image data or an error string
-    */
-  def loadImage(is: InputStream): Either[String, RamSurface]
-
-  /** Loads an image from a Resource.
-    *
-    * @param resource Resource with the image data
-    * @return Either a RamSurface with the image data or an error string, inside a Try capturing the IO exceptions
-    */
-  def loadImage(resource: Resource): Try[Either[String, RamSurface]] =
-    resource.withInputStream(is => loadImage(is))
-
-  /** Loads an image from a byte array.
-    *
-    * @param data Byte array
-    * @return Either a RamSurface with the image data or an error string
-    */
-  def fromByteArray(data: Array[Byte]): Either[String, RamSurface] = {
-    val is = new ByteArrayInputStream(data)
-    loadImage(is)
-  }
-}
+@deprecated("Use ImageReader instead")
+trait ImageLoader extends ImageReader

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ImageReader.scala
@@ -1,0 +1,38 @@
+package eu.joaocosta.minart.graphics.image
+
+import java.io.{ByteArrayInputStream, InputStream}
+
+import scala.util.Try
+
+import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.runtime.Resource
+
+/** Image reader with a low-level implementation on how to load an image.
+  */
+trait ImageReader {
+
+  /** Loads an image from an InputStream.
+    *
+    * @param is InputStream with the image data
+    * @return Either a RamSurface with the image data or an error string
+    */
+  def loadImage(is: InputStream): Either[String, RamSurface]
+
+  /** Loads an image from a Resource.
+    *
+    * @param resource Resource with the image data
+    * @return Either a RamSurface with the image data or an error string, inside a Try capturing the IO exceptions
+    */
+  def loadImage(resource: Resource): Try[Either[String, RamSurface]] =
+    resource.withInputStream(is => loadImage(is))
+
+  /** Loads an image from a byte array.
+    *
+    * @param data Byte array
+    * @return Either a RamSurface with the image data or an error string
+    */
+  def fromByteArray(data: Array[Byte]): Either[String, RamSurface] = {
+    val is = new ByteArrayInputStream(data)
+    loadImage(is)
+  }
+}

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/PpmImageLoader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/PpmImageLoader.scala
@@ -1,9 +1,15 @@
 package eu.joaocosta.minart.graphics.image
 
+import java.io.InputStream
+
+import eu.joaocosta.minart.graphics.RamSurface
 import eu.joaocosta.minart.graphics.image.helpers._
 
 @deprecated("Use eu.joaocosta.minart.graphics.image.ppm.PpmImageFormat instead")
-final class PpmImageLoader[F[_]](val byteReader: ByteReader[F]) extends ppm.PpmImageLoader[F]
+final class PpmImageLoader[F[_]](val byteReader: ByteReader[F]) extends ImageLoader { self =>
+  private val reader = new ppm.PpmImageReader[F] { val byteReader = self.byteReader }
+  def loadImage(is: InputStream): Either[String, RamSurface] = reader.loadImage(is)
+}
 
 object PpmImageLoader {
   @deprecated("Use eu.joaocosta.minart.graphics.image.ppm.PpmImageFormat.defaultFormat instead")

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/QoiImageLoader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/QoiImageLoader.scala
@@ -1,9 +1,15 @@
 package eu.joaocosta.minart.graphics.image
 
+import java.io.InputStream
+
+import eu.joaocosta.minart.graphics.RamSurface
 import eu.joaocosta.minart.graphics.image.helpers._
 
 @deprecated("Use eu.joaocosta.minart.graphics.image.qoi.QoiImageFormat instead")
-final class QoiImageLoader[F[_]](val byteReader: ByteReader[F]) extends qoi.QoiImageLoader[F]
+final class QoiImageLoader[F[_]](val byteReader: ByteReader[F]) extends ImageLoader { self =>
+  private val reader = new qoi.QoiImageReader[F] { val byteReader = self.byteReader }
+  def loadImage(is: InputStream): Either[String, RamSurface] = reader.loadImage(is)
+}
 
 object QoiImageLoader {
   @deprecated("Use eu.joaocosta.minart.graphics.image.qoi.QoiImageFormat.defaultFormat instead")

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/SpriteSheet.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/SpriteSheet.scala
@@ -3,14 +3,30 @@ package eu.joaocosta.minart.graphics.image
 import eu.joaocosta.minart.graphics._
 
 /** A sprite sheet containing multiple sprites in a single image.
+  *
+  *  @param surface Surface with the sprite sheet
+  *  @param spriteWidth width of each sprite
+  *  @param spriteHeight height of each sprite
   */
 class SpriteSheet(surface: Surface, spriteWidth: Int, spriteHeight: Int) {
 
+  /** How many sprites are stored on each line */
   val spritesPerLine = surface.width / spriteWidth
 
+  /** Gets a sprite at a given position in the sheet.
+    *
+    *  @param column column of the sprite
+    *  @param line line of the sprite
+    *  @return surface view with the sprite
+    */
   def getSprite(column: Int, line: Int): SurfaceView =
     surface.view.clip(line * spriteWidth, column * spriteHeight, spriteWidth, spriteHeight)
 
+  /** Gets a sprite at the nth position in the sheet.
+    *
+    *  @param n position of the sprite (moves down a column when the end of a line is reached)
+    *  @return surface view with the sprite
+    */
   def getSprite(n: Int): SurfaceView =
     getSprite(n / spritesPerLine, n % spritesPerLine)
 }

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageFormat.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageFormat.scala
@@ -10,7 +10,7 @@ import eu.joaocosta.minart.graphics.image.helpers._
   * Supports uncompressed 24/32bit Windows BMPs.
   */
 final class BmpImageFormat[F[_]](val byteReader: ByteReader[F], val byteWriter: ByteWriter[F])
-    extends BmpImageLoader[F]
+    extends BmpImageReader[F]
     with BmpImageWriter[F]
 
 object BmpImageFormat {

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageFormat.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageFormat.scala
@@ -1,13 +1,10 @@
 package eu.joaocosta.minart.graphics.image.bmp
 
-import java.io.InputStream
-
-import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.image.helpers._
 
-/** Image loader and writer for BMP files.
+/** Image reader and writer for BMP files.
   *
-  * Supports uncompressed 24/32bit Windows BMPs.
+  * Supports reading uncompressed 24/32bit Windows BMPs and writing uncompressed 24 bit Windows BMPs.
   */
 final class BmpImageFormat[F[_]](val byteReader: ByteReader[F], val byteWriter: ByteWriter[F])
     extends BmpImageReader[F]

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageReader.scala
@@ -8,11 +8,11 @@ import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.image._
 import eu.joaocosta.minart.graphics.image.helpers._
 
-/** Image loader for BMP files.
+/** Image reader for BMP files.
   *
   * Supports uncompressed 24/32bit Windows BMPs.
   */
-trait BmpImageLoader[F[_]] extends ImageLoader {
+trait BmpImageReader[F[_]] extends ImageReader {
   val byteReader: ByteReader[F]
   import byteReader._
 

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageReader.scala
@@ -46,7 +46,7 @@ trait BmpImageReader[F[_]] extends ImageReader {
     }
   }
 
-  def loadHeader(bytes: F[Int]): ParseResult[Header] = {
+  private def loadHeader(bytes: F[Int]): ParseResult[Header] = {
     (for {
       magic <- readString(2).validate(
         BmpImageFormat.supportedFormats,

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageWriter.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageWriter.scala
@@ -35,7 +35,7 @@ trait BmpImageWriter[F[_]] extends ImageWriter {
     }
   }
 
-  def storeHeader(surface: Surface): ByteStreamState[String] = {
+  private def storeHeader(surface: Surface): ByteStreamState[String] = {
     (for {
       _ <- writeString("BM")
       _ <- writeLENumber(14 + 40 + 3 * surface.width * surface.height, 4) // BMP size

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/Header.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/Header.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.graphics.image.bmp
 
-final case class Header(
+private[bmp] final case class Header(
     magic: String,
     size: Int,
     offset: Int,

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/Header.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/Header.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.graphics.image.ppm
 
-final case class Header(
+private[ppm] final case class Header(
     magic: String,
     width: Int,
     height: Int,

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageFormat.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageFormat.scala
@@ -5,12 +5,12 @@ import java.io.InputStream
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.image.helpers._
 
-/** Image loader and writer for PGM/PPM files.
+/** Image format and writer for PGM/PPM files.
   *
   * Supports P2, P3, P5 and P6 PGM/PPM files with a 8 bit color range.
   */
 final class PpmImageFormat[F[_]](val byteReader: ByteReader[F], val byteWriter: ByteWriter[F])
-    extends PpmImageLoader[F]
+    extends PpmImageReader[F]
     with PpmImageWriter[F]
 
 object PpmImageFormat {

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageFormat.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageFormat.scala
@@ -1,13 +1,11 @@
 package eu.joaocosta.minart.graphics.image.ppm
 
-import java.io.InputStream
-
-import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.image.helpers._
 
 /** Image format and writer for PGM/PPM files.
   *
-  * Supports P2, P3, P5 and P6 PGM/PPM files with a 8 bit color range.
+  * Supports reading P2, P3, P5 and P6 PGM/PPM files with a 8 bit color range
+  * and stores data as P6 PPM files with a 8 bit color range.
   */
 final class PpmImageFormat[F[_]](val byteReader: ByteReader[F], val byteWriter: ByteWriter[F])
     extends PpmImageReader[F]

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
@@ -8,15 +8,15 @@ import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.image._
 import eu.joaocosta.minart.graphics.image.helpers._
 
-/** Image loader for PGM/PPM files.
+/** Image reader for PGM/PPM files.
   *
   * Supports P2, P3, P5 and P6 PGM/PPM files with a 8 bit color range.
   */
-trait PpmImageLoader[F[_]] extends ImageLoader {
+trait PpmImageReader[F[_]] extends ImageReader {
   val byteReader: ByteReader[F]
 
   import PpmImageFormat._
-  import PpmImageLoader._
+  import PpmImageReader._
   private val byteStringOps = new ByteStringOps(byteReader)
   import byteReader._
   import byteStringOps._
@@ -70,7 +70,7 @@ trait PpmImageLoader[F[_]] extends ImageLoader {
   }
 
   def loadHeader(bytes: F[Int]): ParseResult[Header] = {
-    val byteStringOps = new PpmImageLoader.ByteStringOps(byteReader)
+    val byteStringOps = new PpmImageReader.ByteStringOps(byteReader)
     import byteStringOps._
     (
       for {
@@ -109,7 +109,7 @@ trait PpmImageLoader[F[_]] extends ImageLoader {
   }
 }
 
-object PpmImageLoader {
+object PpmImageReader {
   private final class ByteStringOps[F[_]](val byteReader: ByteReader[F]) {
     import byteReader._
     private val newLine = '\n'.toInt

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
@@ -15,7 +15,6 @@ import eu.joaocosta.minart.graphics.image.helpers._
 trait PpmImageReader[F[_]] extends ImageReader {
   val byteReader: ByteReader[F]
 
-  import PpmImageFormat._
   import PpmImageReader._
   private val byteStringOps = new ByteStringOps(byteReader)
   import byteReader._
@@ -69,7 +68,7 @@ trait PpmImageReader[F[_]] extends ImageReader {
     }
   }
 
-  def loadHeader(bytes: F[Int]): ParseResult[Header] = {
+  private def loadHeader(bytes: F[Int]): ParseResult[Header] = {
     val byteStringOps = new PpmImageReader.ByteStringOps(byteReader)
     import byteStringOps._
     (

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/Header.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/Header.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.graphics.image.qoi
 
-final case class Header(
+private[qoi] final case class Header(
     magic: String,
     width: Long,
     height: Long,

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/Op.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/Op.scala
@@ -1,8 +1,7 @@
 package eu.joaocosta.minart.graphics.image.qoi
 
-// Private structures
-sealed trait Op
-object Op {
+private[qoi] sealed trait Op
+private[qoi] object Op {
   final case class OpRgb(red: Int, green: Int, blue: Int)              extends Op
   final case class OpRgba(red: Int, green: Int, blue: Int, alpha: Int) extends Op
   final case class OpIndex(index: Int)                                 extends Op

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiColor.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiColor.scala
@@ -2,12 +2,12 @@ package eu.joaocosta.minart.graphics.image.qoi
 
 import eu.joaocosta.minart.graphics.Color
 
-final case class QoiColor(r: Int, g: Int, b: Int, a: Int) {
+private[qoi] final case class QoiColor(r: Int, g: Int, b: Int, a: Int) {
   def toMinartColor = Color(r, g, b)
   def hash          = (r * 3 + g * 5 + b * 7 + a * 11) % 64
 }
 
-object QoiColor {
+private[qoi] object QoiColor {
   def fromMinartColor(color: Color): QoiColor =
     QoiColor(color.r, color.g, color.b, 255)
 }

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageFormat.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageFormat.scala
@@ -1,8 +1,5 @@
 package eu.joaocosta.minart.graphics.image.qoi
 
-import java.io.InputStream
-
-import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.image.helpers._
 
 /** Image format for QOI files.

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageFormat.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageFormat.scala
@@ -5,10 +5,10 @@ import java.io.InputStream
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.image.helpers._
 
-/** Image loader for QOI files.
+/** Image format for QOI files.
   */
 final class QoiImageFormat[F[_]](val byteReader: ByteReader[F], val byteWriter: ByteWriter[F])
-    extends QoiImageLoader[F]
+    extends QoiImageReader[F]
     with QoiImageWriter[F]
 
 object QoiImageFormat {

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageReader.scala
@@ -8,13 +8,13 @@ import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.image._
 import eu.joaocosta.minart.graphics.image.helpers._
 
-/** Image loader for QOI files.
+/** Image reader for QOI files.
   */
-trait QoiImageLoader[F[_]] extends ImageLoader {
+trait QoiImageReader[F[_]] extends ImageReader {
   val byteReader: ByteReader[F]
 
   import QoiImageFormat._
-  import QoiImageLoader._
+  import QoiImageReader._
   import byteReader._
 
   // Binary helpers
@@ -149,7 +149,7 @@ trait QoiImageLoader[F[_]] extends ImageLoader {
   }
 }
 
-object QoiImageLoader {
+object QoiImageReader {
 
   private final case class QoiState(
       imageAcc: List[QoiColor] = Nil,

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageReader.scala
@@ -120,7 +120,7 @@ trait QoiImageReader[F[_]] extends ImageReader {
       }
   }
 
-  def loadHeader(bytes: F[Int]): ParseResult[Header] = {
+  private def loadHeader(bytes: F[Int]): ParseResult[Header] = {
     (
       for {
         magic    <- readString(4).validate(supportedFormats, m => s"Unsupported format: $m")

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageWriter.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageWriter.scala
@@ -8,13 +8,13 @@ import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.image._
 import eu.joaocosta.minart.graphics.image.helpers._
 
-/** Image writer for Qoi files.
+/** Image writer for QOI files.
   */
 trait QoiImageWriter[F[_]] extends ImageWriter {
   val byteWriter: ByteWriter[F]
   import byteWriter._
 
-  final def storeHeader(surface: Surface): ByteStreamState[String] = {
+  private def storeHeader(surface: Surface): ByteStreamState[String] = {
     (for {
       _ <- writeString("qoif")
       _ <- writeBENumber(surface.width, 4)
@@ -60,7 +60,7 @@ trait QoiImageWriter[F[_]] extends ImageWriter {
   }
 
   @tailrec
-  final def storeOps(ops: List[Op], acc: ByteStreamState[String] = emptyStream): ByteStreamState[String] = ops match {
+  private def storeOps(ops: List[Op], acc: ByteStreamState[String] = emptyStream): ByteStreamState[String] = ops match {
     case Nil => acc
     case op :: xs =>
       val nextStream = (for {

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageWriterSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageWriterSpec.scala
@@ -9,7 +9,7 @@ import eu.joaocosta.minart.runtime._
 
 object ImageWriterSpec extends BasicTestSuite {
 
-  def roundtripTest(baseResource: Resource, imageFormat: ImageLoader with ImageWriter) = {
+  def roundtripTest(baseResource: Resource, imageFormat: ImageReader with ImageWriter) = {
     val (oldPixels, newPixels) = (for {
       original <- imageFormat.loadImage(baseResource).get.right.toOption
       originalPixels = original.getPixels().map(_.toVector)


### PR DESCRIPTION
Cleans up minart image a bit.

Mostly:
- Renamed `ImageLoader` to `ImageReader` (to make to closer to `ImageWriter`)
- Marked image format internals as private
- Improved scaladoc
- Removed unused imports