### PR TITLE
Fix BMP padding

### DIFF
--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageFormat.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageFormat.scala
@@ -14,4 +14,12 @@ object BmpImageFormat {
   val defaultFormat = new BmpImageFormat[Iterator](ByteReader.IteratorByteReader, ByteWriter.IteratorByteWriter)
 
   val supportedFormats = Set("BM")
+
+  // Every line in a BMP file is padded to 4 bytes
+  private[bmp] def linePadding(width: Int, bitsPerPixel: Int): Int = {
+    val bytesPerPixel = bitsPerPixel / 8
+    val bytesPerLine  = bytesPerPixel * width
+    val extraBytes    = bytesPerLine % 4
+    if (extraBytes == 0) 0 else (4 - extraBytes)
+  }
 }

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageLoaderSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageLoaderSpec.scala
@@ -66,7 +66,7 @@ object ImageLoaderSpec extends BasicTestSuite {
       assert(imageRect.get.height == 119)
     }
 
-    test("Load the same data from different formats") {
+    test("Load the same data from different formats (square image)") {
       val bmpRgb  = Image.loadBmpImage(Resource("scala.bmp")).get.getPixels().map(_.toVector)
       val bmpArgb = Image.loadBmpImage(Resource("scala-argb.bmp")).get.getPixels().map(_.toVector)
       val ppmP2   = Image.loadPpmImage(Resource("scala-txt.pgm")).get.getPixels().map(_.toVector)
@@ -81,6 +81,15 @@ object ImageLoaderSpec extends BasicTestSuite {
       assert(bmpRgb == ppmP6)
       assert(bmpRgb == ppmP3)
       assert(bmpRgb == qoi)
+    }
+
+    test("Load the same data from different formats (non-square image)") {
+      val bmp = Image.loadBmpImage(Resource("scala-rect.bmp")).get.getPixels().map(_.toVector)
+      val ppm = Image.loadPpmImage(Resource("scala-rect.ppm")).get.getPixels().map(_.toVector)
+      val qoi = Image.loadQoiImage(Resource("scala-rect.qoi")).get.getPixels().map(_.toVector)
+
+      assert(bmp == ppm)
+      assert(bmp == qoi)
     }
   }
 }

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageWriterSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageWriterSpec.scala
@@ -11,12 +11,12 @@ object ImageWriterSpec extends BasicTestSuite {
 
   def roundtripTest(baseResource: Resource, imageFormat: ImageReader with ImageWriter) = {
     val (oldPixels, newPixels) = (for {
-      original <- imageFormat.loadImage(baseResource).get.right
+      original <- imageFormat.loadImage(baseResource).get.right.toOption
       originalPixels = original.getPixels().map(_.toVector)
-      stored <- imageFormat.toByteArray(original).right
-      loaded <- imageFormat.fromByteArray(stored).right
+      stored <- imageFormat.toByteArray(original).right.toOption
+      loaded <- imageFormat.fromByteArray(stored).right.toOption
       loadedPixels = loaded.getPixels().map(_.toVector)
-    } yield (originalPixels, loadedPixels)).toOption.get
+    } yield (originalPixels, loadedPixels)).get
 
     assert(oldPixels == newPixels)
   }

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageWriterSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageWriterSpec.scala
@@ -11,12 +11,12 @@ object ImageWriterSpec extends BasicTestSuite {
 
   def roundtripTest(baseResource: Resource, imageFormat: ImageReader with ImageWriter) = {
     val (oldPixels, newPixels) = (for {
-      original <- imageFormat.loadImage(baseResource).get.right.toOption
+      original <- imageFormat.loadImage(baseResource).get.right
       originalPixels = original.getPixels().map(_.toVector)
-      stored <- imageFormat.toByteArray(original).right.toOption
-      loaded <- imageFormat.fromByteArray(stored).right.toOption
+      stored <- imageFormat.toByteArray(original).right
+      loaded <- imageFormat.fromByteArray(stored).right
       loadedPixels = loaded.getPixels().map(_.toVector)
-    } yield (originalPixels, loadedPixels)).get
+    } yield (originalPixels, loadedPixels)).toOption.get
 
     assert(oldPixels == newPixels)
   }
@@ -25,14 +25,17 @@ object ImageWriterSpec extends BasicTestSuite {
   if (Platform() != Platform.JS) {
     test("Write a PPM image") {
       roundtripTest(Resource("scala.ppm"), ppm.PpmImageFormat.defaultFormat)
+      roundtripTest(Resource("scala-rect.ppm"), ppm.PpmImageFormat.defaultFormat)
     }
 
     test("Write a BMP image") {
       roundtripTest(Resource("scala.bmp"), bmp.BmpImageFormat.defaultFormat)
+      roundtripTest(Resource("scala-rect.bmp"), bmp.BmpImageFormat.defaultFormat)
     }
 
     test("Write a QOI image") {
       roundtripTest(Resource("scala.qoi"), qoi.QoiImageFormat.defaultFormat)
+      roundtripTest(Resource("scala-rect.qoi"), qoi.QoiImageFormat.defaultFormat)
     }
   }
 }


### PR DESCRIPTION
Turns out that lines in BMPs are padded to 4 bytes, so some 24 bit BMPs were incorrectly loaded/stored.

This PR fixes that and adds some more tests to catch this problem (I should have actually included this tests in #199, but somehow I missed it)