### PR TITLE
Add more color operations

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Color.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Color.scala
@@ -8,20 +8,75 @@ final class Color private (val argb: Int) extends AnyVal {
 
   @inline def rgb: Int = (argb & 0x00ffffff)
 
-  def invert: Color     = Color(255 - r, 255 - g, 255 - b)
+  /** Combines this with another color by summing each RGB value.
+    * Values are clamped on overflow.
+    */
+  def +(that: Color): Color =
+    Color(
+      math.min(this.r + that.r, 255).toInt,
+      math.min(this.g + that.g, 255).toInt,
+      math.min(this.b + that.b, 255).toInt
+    )
+
+  /** Combines this with another color by subtracting each RGB value.
+    * Values are clamped on underflow.
+    */
+  def -(that: Color): Color =
+    Color(
+      math.max(this.r - that.r, 0).toInt,
+      math.max(this.g - that.g, 0).toInt,
+      math.max(this.b - that.b, 0).toInt
+    )
+
+  /** Combines this with another color by multiplying each RGB value (on the [0.0, 1.0] range).
+    * Values are clamped on overflow.
+    */
+  def *(that: Color): Color =
+    Color(
+      (this.r * that.r) / 255,
+      (this.g * that.g) / 255,
+      (this.b * that.b) / 255
+    )
+
+  /** Inverts this color by inverting every RGB channel
+    */
+  def invert: Color = Color(255 - r, 255 - g, 255 - b)
+
   override def toString = s"Color($r,$g,$b)"
 }
 
 object Color {
+
+  /** Creates a new color from RGB values (on the [0-255] range).
+    *  Overflow/Underflow will wrap around.
+    */
   def apply(r: Int, g: Int, b: Int): Color =
     new Color((255 << 24) | ((r & 255) << 16) | ((g & 255) << 8) | (b & 255))
 
+  /** Creates a new color from RGB values (assuming unsinged bytes on the [0-255] range)
+    */
   def apply(r: Byte, g: Byte, b: Byte): Color =
     new Color((255 << 24) | ((r & 255) << 16) | ((g & 255) << 8) | (b & 255))
 
+  /** Creates a new color from a grayscale value (on the [0-255] range)
+    *  Overflow/Underflow will wrap around.
+    */
+  def grayscale(gray: Int): Color =
+    new Color((255 << 24) | ((gray & 255) << 16) | ((gray & 255) << 8) | (gray & 255))
+
+  /** Creates a new color from a grayscale value (assuming unsigned bytes on the [0-255] range)
+    */
+  def grayscale(gray: Byte): Color =
+    new Color((255 << 24) | ((gray & 255) << 16) | ((gray & 255) << 8) | (gray & 255))
+
+  /** Creates a new color from a 24bit backed RGB integer.
+    * Ignores the first byte.
+    */
   @inline def fromRGB(rgb: Int): Color =
     new Color(0xff000000 | rgb)
 
+  /** Extracts the RGB channels of a color.
+    */
   def unapply(color: Color): Some[(Int, Int, Int)] =
     Some(color.r, color.g, color.b)
 }

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/ColorSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/ColorSpec.scala
@@ -1,0 +1,58 @@
+package eu.joaocosta.minart.graphics
+
+import scala.util.Random
+
+import verify._
+
+object ColorSpec extends BasicTestSuite {
+
+  test("Can be created from RGB values") {
+    val colorInt  = Color(110, 120, 130)
+    val colorByte = Color(110.toByte, 120.toByte, 130.toByte)
+    assert(colorInt == colorByte)
+    assert(colorInt.r == 110 && colorInt.g == 120 && colorInt.b == 130)
+  }
+
+  test("Can be created from grayscale values") {
+    val colorInt  = Color.grayscale(130)
+    val colorByte = Color.grayscale(130)
+    assert(colorInt == colorByte)
+    assert(colorInt.r == 130 && colorInt.g == 130 && colorInt.b == 130)
+  }
+
+  test("Can be created from raw RGB values") {
+    val color    = Color(110, 120, 130)
+    val newColor = Color.fromRGB(color.argb)
+    assert(color == newColor)
+  }
+
+  test("Can be summed/subtracted without overflowing/underflowing") {
+    val colorA = Color(10, 20, 30)
+    val colorB = Color(30, 40, 50)
+    val colorC = Color(250, 40, 240)
+
+    assert(colorA + colorB == Color(40, 60, 80))
+    assert(colorB + colorC == Color(255, 80, 255))
+    assert(colorA + colorC == Color(255, 60, 255))
+
+    assert(colorA - colorB == Color(0, 0, 0))
+    assert(colorB - colorA == Color(20, 20, 20))
+    assert(colorB - colorC == Color(0, 0, 0))
+    assert(colorC - colorB == Color(220, 0, 190))
+    assert(colorA - colorC == Color(0, 0, 0))
+    assert(colorC - colorA == Color(240, 20, 210))
+  }
+
+  test("Can be multiplied without overflowing/undeflowing") {
+    val color = Color(0, 128, 255)
+
+    assert(color * color == Color(0, 64, 255))
+  }
+
+  test("Can be inverted") {
+    val color = Color(0, 128, 255).invert
+
+    assert(color == Color(255, 127, 0))
+  }
+
+}

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
@@ -25,7 +25,7 @@ trait PpmImageReader[ByteSeq] extends ImageReader {
     (
       for {
         value <- parseNextInt("Invalid value")
-      } yield Color(value, value, value)
+      } yield Color.grayscale(value)
     )
 
   // P3
@@ -41,7 +41,7 @@ trait PpmImageReader[ByteSeq] extends ImageReader {
   // P5
   private val loadBinaryGrayscalePixel: ParseState[String, Color] =
     readByte.collect(
-      { case Some(byte) => Color(byte, byte, byte) },
+      { case Some(byte) => Color.grayscale(byte) },
       _ => "Not enough data to read Grayscale pixel"
     )
 


### PR DESCRIPTION
Adds sum, subtraction and multiplication operations to `Color`. Also adds some tests.

This can be quite useful with `SurfaceView#zipWith` (and `Plane#zipWith`). 
I considered adding some more operations, but I think in those cases it's probably better to implement it manually (I am already reluctant of adding multiplication, but I guess it can be useful for some basic alpha blending)