### PR TITLE
Add parentNode to HtmlCanvas

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
@@ -11,8 +11,7 @@ import eu.joaocosta.minart.input._
 
 /** A low level Canvas implementation that shows the image in an HTML Canvas element.
   */
-class HtmlCanvas() extends SurfaceBackedCanvas {
-
+class HtmlCanvas(parentNode: dom.Node = dom.document.body) extends SurfaceBackedCanvas {
   // Rendering resources
 
   private[this] var containerDiv: dom.HTMLDivElement  = _
@@ -49,7 +48,7 @@ class HtmlCanvas() extends SurfaceBackedCanvas {
     containerDiv = dom.document.createElement("div").asInstanceOf[dom.HTMLDivElement]
     canvas = dom.document.createElement("canvas").asInstanceOf[JsCanvas]
     containerDiv.appendChild(canvas)
-    childNode = dom.document.body.appendChild(containerDiv)
+    childNode = parentNode.appendChild(containerDiv)
     ctx = canvas.getContext("2d").asInstanceOf[dom.CanvasRenderingContext2D]
     changeSettings(newSettings)
     dom.document.addEventListener[Event](
@@ -135,7 +134,7 @@ class HtmlCanvas() extends SurfaceBackedCanvas {
   // Cleanup
 
   def unsafeDestroy(): Unit = if (childNode != null) {
-    dom.document.body.removeChild(childNode)
+    parentNode.removeChild(childNode)
     childNode = null
   }
 


### PR DESCRIPTION
Makes the parent node of the `HtmlCanvas` confiurable.
This is quite useful when the canvas should be inserted inside some element (like a `div`) instead of the `body`.

For JS applications, this can be configured by overriding the default backend:
```scala
implicit val myCanvas: DefaultBackend[Any, HtmlCanvas] =
  DefaultBackend.fromFunction((_) => new HtmlCanvas(dom.document.getElementById("content"))
```