### PR TITLE
Remove AnyVals

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Color.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Color.scala
@@ -1,7 +1,7 @@
 package eu.joaocosta.minart.graphics
 
 /** RGB Color */
-final class Color private (val argb: Int) extends AnyVal {
+final class Color private (val argb: Int) {
   @inline def r: Int = (argb & 0x00ff0000) >> 16
   @inline def g: Int = (argb & 0x0000ff00) >> 8
   @inline def b: Int = (argb & 0x000000ff)
@@ -42,7 +42,10 @@ final class Color private (val argb: Int) extends AnyVal {
     */
   def invert: Color = Color(255 - r, 255 - g, 255 - b)
 
-  override def toString = s"Color($r,$g,$b)"
+  override def toString: String = s"Color($r,$g,$b)"
+  override def hashCode(): Int  = argb.hashCode()
+  override def equals(that: Any): Boolean =
+    (that.isInstanceOf[Color] && this.argb == that.asInstanceOf[Color].argb)
 }
 
 object Color {

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiColor.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiColor.scala
@@ -2,7 +2,7 @@ package eu.joaocosta.minart.graphics.image.qoi
 
 import eu.joaocosta.minart.graphics.Color
 
-private[qoi] final class QoiColor private (val argb: Int) extends AnyVal {
+private[qoi] final class QoiColor private (val argb: Int) {
   @inline def a: Int = ((argb & 0xff000000) >> 24) & 0x0ff
   @inline def r: Int = (argb & 0x00ff0000) >> 16
   @inline def g: Int = (argb & 0x0000ff00) >> 8
@@ -10,6 +10,11 @@ private[qoi] final class QoiColor private (val argb: Int) extends AnyVal {
 
   def hash        = (r * 3 + g * 5 + b * 7 + a * 11) % 64
   def minartColor = Color.fromRGB(argb)
+
+  override def toString: String = s"QoiColor($r,$g,$b)"
+  override def hashCode(): Int  = hash
+  override def equals(that: Any) =
+    (that.isInstanceOf[QoiColor] && this.argb == that.asInstanceOf[QoiColor].argb)
 }
 
 private[qoi] object QoiColor {

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/runtime/pure/Poll.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/runtime/pure/Poll.scala
@@ -9,7 +9,7 @@ import scala.util.{Failure, Success, Try}
   *  might be applied sequentially every time `poll` is called.
   *  While this might be inneficient, this is by design, to simplify multiplatform development.
   */
-case class Poll[+A](poll: RIO[Any, Option[Try[A]]]) extends AnyVal {
+case class Poll[+A](poll: RIO[Any, Option[Try[A]]]) {
 
   /** Transforms the result of this operation. */
   def transform[B](f: Try[A] => Try[B]): Poll[B] =


### PR DESCRIPTION
Removes the `extends AnyVal` annotations from some objects.

I believe this currently has some problems with scala-native (https://github.com/scala-native/scala-native/issues/2712) leading to the segfaults that have been happening latelly on the CI.

I did some basic benchmarks and didn't see any real performance difference (I assume because there's boxing happening anyway when storing colors in Arrays).