### PR TITLE
Add microsite

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
  [![scaladoc (pure)](https://javadoc.io/badge2/eu.joaocosta/minart-pure_3/scaladoc%20%28pure%29.svg)](https://javadoc.io/doc/eu.joaocosta/minart-pure_3)
  [![scaladoc (image)](https://javadoc.io/badge2/eu.joaocosta/minart-image_3/scaladoc%20%28image%29.svg)](https://javadoc.io/doc/eu.joaocosta/minart-image_3)
 
-Minart is a very minimalistic Scala library to put pixels in a canvas.
+Minart is a minimalistic Scala library to put pixels in a canvas.
 
 It's mostly useful for small toy projects or prototypes that deal with generative art or software rendering.
 

--- a/build.sbt
+++ b/build.sbt
@@ -29,9 +29,32 @@ ThisBuild / semanticdbVersion                              := scalafixSemanticdb
 ThisBuild / scalafixOnCompile                              := true
 ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.6.0"
 
+val siteSettings = Seq(
+    Compile / doc / scalacOptions ++= (
+      if (scalaBinaryVersion.value.startsWith("3"))
+        Seq("-siteroot", "docs")
+      else Seq()
+    )
+  )
+
+def docSettings(projectName: String) = Seq(
+    Compile / doc / scalacOptions ++= (
+      if (scalaBinaryVersion.value.startsWith("3"))
+        Seq(
+          "-project",
+          projectName,
+          "-project-version",
+          version.value,
+          "-social-links:" +
+            "github::https://github.com/JD557/Minart"
+        )
+      else Seq()
+    )
+  )
+
 val sharedSettings = Seq(
   libraryDependencies ++=
-    Seq("org.scala-lang.modules" %%% "scala-collection-compat" % "2.8.1")
+    Seq("org.scala-lang.modules" %%% "scala-collection-compat" % "2.8.1"),
 )
 
 val testSettings = Seq(
@@ -82,6 +105,8 @@ lazy val core =
     .settings(sharedSettings)
     .settings(testSettings)
     .settings(publishSettings)
+    .settings(docSettings("Minart"))
+    .settings(siteSettings)
     .jsSettings(jsSettings)
     .nativeSettings(nativeSettings)
 
@@ -92,6 +117,7 @@ lazy val backend =
     .settings(sharedSettings)
     .settings(testSettings)
     .settings(publishSettings)
+    .settings(docSettings("Minart Backend"))
     .jsSettings(jsSettings)
     .nativeSettings(nativeSettings)
 
@@ -102,6 +128,7 @@ lazy val pure =
     .settings(sharedSettings)
     .settings(testSettings)
     .settings(publishSettings)
+    .settings(docSettings("Minart Pure"))
     .jsSettings(jsSettings)
     .nativeSettings(nativeSettings)
 
@@ -113,6 +140,7 @@ lazy val image =
     .settings(sharedSettings)
     .settings(testSettings)
     .settings(publishSettings)
+    .settings(docSettings("Minart Image"))
     .jsSettings(jsSettings)
     .nativeSettings(nativeSettings)
 

--- a/docs/_docs/advanced-usage.md
+++ b/docs/_docs/advanced-usage.md
@@ -1,0 +1,20 @@
+---
+title: Advanced Usage
+---
+
+# Advanced Usage
+
+If for some reason you want to make your binary as small as possible, you can include individual packages instead of
+the full `minart` bundle.
+
+## Minimal builds
+
+The Minart project is divided in multiple small packages:
+
+- `minart-core`: This package is always required.
+- `minart-backend`: Contains the default implementations for each backend (AWT, HTML and SDL).
+  While usually required, you can skip it if you plan to implement your own backend.
+- `minart-pure`: Contains the RIO implementation for pure applications.
+  You can skip it if you plan to just write impure code or bring your own IO implementation.
+- `minart-image`: Contains logic to load and store images in PPM, BMP or QOI format.
+  You can skip it if you don't plan to read or write any images.

--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -1,0 +1,26 @@
+---
+title: Getting Started
+---
+
+# Getting Started
+
+To include Minart, simply add the `minart` library to your project:
+
+```scala
+libraryDependencies += "eu.joaocosta" %% "minart" % "{{ projectVersion }}"
+```
+
+Or just create a new project using the provided [giter8](http://www.foundweekends.org/giter8/) template, with:
+
+```
+g8 https://github.com/JD557/minart
+```
+
+## Tutorial
+
+The easiest way to start using the library is to follow the tutorials in the [`examples`](https://github.com/JD557/minart/tree/master/examples) directory.
+
+The examples in [`examples/release`](https://github.com/JD557/minart/tree/master/examples/release) target the latest released version,
+while the examples in [`examples/snapshot`](https://github.com/JD557/minart/tree/master/examples/snapshot) target the code in the repository.
+
+All the examples are `.sc` files that can be executed via [scala-cli](https://scala-cli.virtuslab.org/).

--- a/docs/_docs/index.html
+++ b/docs/_docs/index.html
@@ -1,0 +1,33 @@
+---
+title: Minart
+---
+
+<h1>Minart</h1>
+
+<p>
+  Minart is a minimal Scala library for multimedia applications, such as generative art or simple video games.
+</p>
+
+<p>
+  It's based on a few simple principles:
+
+  <ol>
+    <li>Simple things should be simple, complex things can be complex
+      <ul>
+        <li>It should be easier to put a pixel on the screen than to draw an image</li>
+      </ul>
+    </li>
+    <li>Platform agnostic abstractions vs platform specific optimizations
+      <ul>
+        <li>The code should cross-compile between JVM/JS/Native with the minimum number of changes</li>
+      </ul>
+    </li>
+  </ol>
+</p>
+
+<p>
+  <strong>Note:</strong> Minart is still in a 0.x version. Quoting the semver specification:
+  <blockquote>
+    Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable.
+  </blockquote>
+</p>

--- a/docs/_docs/overview.md
+++ b/docs/_docs/overview.md
@@ -1,0 +1,41 @@
+---
+title: Feature Overview
+---
+
+# Feature Overview
+
+## Cross-compilation
+
+Minart can target **JVM**, **JS** and **Native** backends.
+
+The library includes abstractions to make sure that the same code can run on
+all backends with no changes, while also making backend-specific changes easy
+to implement.
+
+## Small footprint
+
+External dependencies are kept to a minimum, to keep the resulting binaries small.
+
+For extreme cases, it's also possible to only import a subset of features.
+
+## Out of the box graphic features
+
+Minart comes out of the box with some basic graphic features, such as:
+  - Double buffered canvas
+  - Integer scaling
+  - Surface blitting (with a mask)
+
+It also includes **Surface views** and **Planes** which makes it possible to manipulate
+(possibly unbounded) images with familiar operations such as `map` and `flatMap`.
+
+## Input handling
+
+Minart comes with some helpers to handle Keyboard and pointer input.
+
+Not only is mouse input supported, but touch screen input also comes for free.
+
+### Resource loading
+
+A `Resource` abstraction provides a backend-agnostic way to load and store resources.
+
+Codecs for some image formats (PPM, BMP and QOI) is also included.

--- a/docs/_docs/structure.md
+++ b/docs/_docs/structure.md
@@ -1,0 +1,39 @@
+---
+title: Project structure
+---
+
+# Project structure
+
+## `eu.joaocosta.minart.runtime`
+
+This package contains the core abstractions that allow the code to run on all platforms without changes.
+
+The `Loop`/`LoopRunner` abstractions allows to write loops that run with a certain `LoopFrequency`.
+
+`Platform` provites runtime checks to know the current platform.
+
+`Resource`s represent data that can be written or read.
+- On JVM and Native it will load local files and embedded resources, while storing local files
+- On JS it will load data from the local storage or relative URIs, while storing the data on the local storage
+
+## `eu.joaocosta.minart.graphics`
+
+This package contains all the code required to draw on a screen.
+
+A `Surface` represents an image. It may be a `MutableSurface`, which allows drawing.
+
+A `Canvas` is a special type of `MutableSurface`, which represents a window.
+
+The `RenderLoop` abstraction works on top of the `Loop`/`LoopRunner` to continually write to a `Canvas`.
+
+`SurfaceView`s and `Planes` are abstractions to quickly and efficiently manipulate `Surface`s.
+
+## `eu.joaocosta.minart.input`
+
+Contains the `KeyboardInput` and `PointerInput`, which hold the current input status.
+
+## `eu.joaocosta.minart.backend`
+
+Contains the platform-specific internals.
+
+Most applications will only need to `import eu.joaocosta.minart.backend.defaults._`.

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -1,0 +1,10 @@
+index: index.html
+subsection:
+  - title: Feature Overview
+    page: overview.md
+  - title: Getting Started
+    page: getting-started.md
+  - title: Project Structure
+    page: structure.md
+  - title: Advanced Usage
+    page: advanced-usage.md


### PR DESCRIPTION
Adds a simple microsite to the `minart-core` scaladoc.

I'll decide what to do with it afterthe new version is published. I might just add some links to the `javadoc.io` on the README.