### PR TITLE
Remove patch version from CI matrix

### DIFF
--- a/.github/workflows/compile_test.yml
+++ b/.github/workflows/compile_test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        scala: [2.11.12, 2.12.16, 2.13.8, 3.2.0]
+        scala: ["2.11", "2.12", "2.13", "3.2"]
         platform: [JVM, JS, Native]
 
     env:


### PR DESCRIPTION
This should be enough for me to not have to constantly change the branch protection rules when a new Scala patch is released.