### PR TITLE
Periodically reenqueue audio on SdlAudioPlayer

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsAudioPlayer.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsAudioPlayer.scala
@@ -41,9 +41,7 @@ object JsAudioPlayer extends AudioPlayer {
   def play(clip: AudioClip): Unit = {
     val alreadyPlaying = isPlaying()
     playQueue.enqueue(clip)
-    if (!alreadyPlaying) {
-      callback(0.0, 0)()
-    }
+    if (!alreadyPlaying) callback(0.0, 0)()
   }
 
   def isPlaying(): Boolean = playQueue.nonEmpty


### PR DESCRIPTION
Follow up to #279 
Now it's possible to have the SdlAudioPlayer streaming audio from the queue, which should be way more memory efficient.