### PR TITLE
Use toIntOption on the PpmImageReader

### DIFF
--- a/.github/workflows/compile_test.yml
+++ b/.github/workflows/compile_test.yml
@@ -121,4 +121,4 @@ jobs:
     - name: Compute coverage
       run: sbt -J-Xmx3G -Dsbt.color=always rootJVM/clean coverage rootJVM/test rootJVM/coverageAggregate
     - name: Upload report
-      run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r jvm/target/scala-3.2.0/coverage-report/cobertura.xml
+      run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r jvm/target/scala-3.2.1/coverage-report/cobertura.xml

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
@@ -3,6 +3,7 @@ package eu.joaocosta.minart.graphics.image.ppm
 import java.io.InputStream
 
 import scala.annotation.tailrec
+import scala.collection.compat._
 
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.image._
@@ -155,13 +156,7 @@ object PpmImageReader {
 
     def parseNextInt(errorMessage: String): ParseState[String, Int] =
       readNextString.flatMap { str =>
-        val intEither =
-          try {
-            Right(str.toInt)
-          } catch {
-            case _: Throwable =>
-              Left(s"$errorMessage: $str")
-          }
+        val intEither = str.toIntOption.map(int => Right(int)).getOrElse(Left(s"Failed to parse int: $str"))
         State.fromEither(intEither)
       }
   }


### PR DESCRIPTION
Changes the `PpmImageReader` to use `toIntOption`, now that it's supported by the collections compat library.