### PR TITLE
Add LowLevelAudioPlayer and AudioPlayerManager

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsAudioPlayer.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsAudioPlayer.scala
@@ -7,22 +7,28 @@ import org.scalajs.dom._
 import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.runtime._
 
-object JsAudioPlayer extends AudioPlayer {
+class JsAudioPlayer() extends LowLevelAudioPlayer {
   private lazy val audioCtx      = new AudioContext();
-  private val sampleRate         = 44100
-  private val bufferSize         = 4096
   private val preemptiveCallback = LoopFrequency.hz15.millis
 
-  private val playQueue = new AudioPlayer.MultiChannelAudioQueue(sampleRate)
+  private var playQueue: AudioPlayer.MultiChannelAudioQueue = _
+  private var callbackRegistered                            = false
 
-  private var callbackRegistered = false
+  protected def unsafeInit(settings: AudioPlayer.Settings): Unit = {
+    playQueue = new AudioPlayer.MultiChannelAudioQueue(settings.sampleRate)
+  }
+
+  protected def unsafeDestroy(): Unit = {
+    stop()
+  }
+
   private val callback: (Double, Int) => () => Unit = (startTime: Double, consumed: Int) =>
     () => {
       if (playQueue.nonEmpty) {
-        val batchSize   = math.min(bufferSize, playQueue.size)
-        val duration    = (1000.0 * batchSize) / sampleRate
+        val batchSize   = math.min(settings.bufferSize, playQueue.size)
+        val duration    = (1000.0 * batchSize) / settings.sampleRate
         val audioSource = audioCtx.createBufferSource()
-        val buffer      = audioCtx.createBuffer(1, batchSize, sampleRate)
+        val buffer      = audioCtx.createBuffer(1, batchSize, settings.sampleRate)
         val channelData = buffer.getChannelData(0)
         (0 until batchSize).foreach { i =>
           channelData(i) = playQueue.dequeue().toFloat
@@ -33,8 +39,8 @@ object JsAudioPlayer extends AudioPlayer {
           audioSource.start()
           window.setTimeout(callback(audioCtx.currentTime, batchSize), duration - preemptiveCallback)
         } else {
-          audioSource.start(startTime + consumed.toDouble / sampleRate)
-          val nextTarget    = (startTime + (consumed + batchSize).toDouble / sampleRate)
+          audioSource.start(startTime + consumed.toDouble / settings.sampleRate)
+          val nextTarget    = (startTime + (consumed + batchSize).toDouble / settings.sampleRate)
           val sleepDuration = (nextTarget - audioCtx.currentTime) * 1000 - preemptiveCallback
           window.setTimeout(callback(startTime, consumed + batchSize), sleepDuration)
         }

--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/defaults/package.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/defaults/package.scala
@@ -9,8 +9,8 @@ package object defaults {
   implicit lazy val defaultLoopRunner: DefaultBackend[Any, JsLoopRunner.type] =
     DefaultBackend.fromConstant(JsLoopRunner)
 
-  implicit lazy val defaultAudioPlayer: DefaultBackend[Any, JsAudioPlayer.type] =
-    DefaultBackend.fromConstant(JsAudioPlayer)
+  implicit lazy val defaultAudioPlayer: DefaultBackend[Any, JsAudioPlayer] =
+    DefaultBackend.fromFunction((_) => new JsAudioPlayer())
 
   implicit lazy val defaultPlatform: DefaultBackend[Any, Platform.JS.type] =
     DefaultBackend.fromConstant(Platform.JS)

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/defaults/package.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/defaults/package.scala
@@ -9,8 +9,8 @@ package object defaults {
   implicit lazy val defaultLoopRunner: DefaultBackend[Any, JavaLoopRunner.type] =
     DefaultBackend.fromConstant(JavaLoopRunner)
 
-  implicit lazy val defaultAudioPlayer: DefaultBackend[Any, JavaAudioPlayer.type] =
-    DefaultBackend.fromConstant(JavaAudioPlayer)
+  implicit lazy val defaultAudioPlayer: DefaultBackend[Any, JavaAudioPlayer] =
+    DefaultBackend.fromFunction((_) => new JavaAudioPlayer())
 
   implicit lazy val defaultPlatform: DefaultBackend[Any, Platform.JVM.type] =
     DefaultBackend.fromConstant(Platform.JVM)

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlAudioPlayer.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlAudioPlayer.scala
@@ -13,13 +13,31 @@ import sdl2.SDL._
 import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.runtime._
 
-object SdlAudioPlayer extends AudioPlayer {
-  private val sampleRate                        = 44100
-  private val bufferSize                        = 4096
-  private val preemptiveCallback                = LoopFrequency.hz15.millis
-  private var device: Option[SDL_AudioDeviceID] = None
+class SdlAudioPlayer() extends LowLevelAudioPlayer {
+  private val preemptiveCallback        = LoopFrequency.hz15.millis
+  private var device: SDL_AudioDeviceID = _
 
-  private val playQueue = new AudioPlayer.MultiChannelAudioQueue(sampleRate)
+  private var playQueue: AudioPlayer.MultiChannelAudioQueue = _
+  private var callbackRegistered                            = false
+
+  protected def unsafeInit(settings: AudioPlayer.Settings): Unit = {
+    playQueue = new AudioPlayer.MultiChannelAudioQueue(settings.sampleRate)
+    SDL_InitSubSystem(SDL_INIT_AUDIO)
+    val want = stackalloc[SDL_AudioSpec]()
+    val have = stackalloc[SDL_AudioSpec]()
+    want.freq = settings.sampleRate
+    want.format = AUDIO_S8
+    want.channels = 1.toUByte
+    want.samples = settings.bufferSize.toUShort
+    want.callback = null // Ideally this should use a SDL callback
+    device = SDL_OpenAudioDevice(null, 0, want, have, 0)
+  }
+
+  protected def unsafeDestroy(): Unit = {
+    stop()
+    SDL_CloseAudioDevice(device)
+    SDL_QuitSubSystem(SDL_INIT_AUDIO)
+  }
 
   // TODO: Ideally this should use a callback like this or it's own callback
   // Try this once scala native supports multi threading (or manually schedule futures to enqueue data)
@@ -31,14 +49,13 @@ object SdlAudioPlayer extends AudioPlayer {
     }
   }*/
   private implicit val ec: ExecutionContext = ExecutionContext.global
-  private var callbackRegistered            = false
   private def callback(nextSchedule: Long): Future[Unit] = Future {
     if (playQueue.nonEmpty) {
-      if (System.currentTimeMillis() > nextSchedule && SDL_GetQueuedAudioSize(device.get).toInt < bufferSize) {
-        val len  = scala.math.min(bufferSize, playQueue.size)
+      if (System.currentTimeMillis() > nextSchedule && SDL_GetQueuedAudioSize(device).toInt < settings.bufferSize) {
+        val len  = scala.math.min(settings.bufferSize, playQueue.size)
         val buff = Array.fill(len)(playQueue.dequeueByte())
-        if (SDL_QueueAudio(device.get, buff.asInstanceOf[ByteArray].at(0), len.toUInt) == 0) {
-          val bufferedMillis = (1000 * len) / sampleRate
+        if (SDL_QueueAudio(device, buff.asInstanceOf[ByteArray].at(0), len.toUInt) == 0) {
+          val bufferedMillis = (1000 * len) / settings.sampleRate
           Some(System.currentTimeMillis() + bufferedMillis - preemptiveCallback)
         } else None
       } else Some(nextSchedule)
@@ -54,34 +71,22 @@ object SdlAudioPlayer extends AudioPlayer {
   def play(clip: AudioClip): Unit = play(clip, 0)
 
   def play(clip: AudioClip, channel: Int): Unit = {
-    if (device == None) {
-      SDL_InitSubSystem(SDL_INIT_AUDIO)
-      val want = stackalloc[SDL_AudioSpec]()
-      val have = stackalloc[SDL_AudioSpec]()
-      want.freq = sampleRate
-      want.format = AUDIO_S8
-      want.channels = 1.toUByte
-      want.samples = bufferSize.toUShort
-      want.callback = null // Ideally this should use a SDL callback
-      device = Some(SDL_OpenAudioDevice(null, 0, want, have, 0))
-    }
-    // SDL_LockAudioDevice(device.get)
+    // SDL_LockAudioDevice(device)
     playQueue.enqueue(clip, channel)
     if (!callbackRegistered) {
       callbackRegistered = true
       callback(0)
     }
-    // SDL_UnlockAudioDevice(device.get)
-    SDL_PauseAudioDevice(device.get, 0)
+    // SDL_UnlockAudioDevice(device)
+    SDL_PauseAudioDevice(device, 0)
   }
 
   def isPlaying(): Boolean =
-    playQueue.nonEmpty &&
-      device.forall(dev => SDL_GetQueuedAudioSize(dev).toInt == 0)
+    playQueue.nonEmpty && SDL_GetQueuedAudioSize(device).toInt == 0
 
   def stop(): Unit = {
     playQueue.clear()
-    device.foreach(dev => SDL_ClearQueuedAudio(dev))
+    SDL_ClearQueuedAudio(device)
   }
 
   def stop(channel: Int): Unit = {

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/defaults/package.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/defaults/package.scala
@@ -9,8 +9,8 @@ package object defaults {
   implicit lazy val defaultLoopRunner: DefaultBackend[Any, SdlLoopRunner.type] =
     DefaultBackend.fromConstant(SdlLoopRunner)
 
-  implicit lazy val defaultAudioPlayer: DefaultBackend[Any, SdlAudioPlayer.type] =
-    DefaultBackend.fromConstant(SdlAudioPlayer)
+  implicit lazy val defaultAudioPlayer: DefaultBackend[Any, SdlAudioPlayer] =
+    DefaultBackend.fromFunction((_) => new SdlAudioPlayer())
 
   implicit lazy val defaultPlatform: DefaultBackend[Any, Platform.Native.type] =
     DefaultBackend.fromConstant(Platform.Native)

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioPlayer.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioPlayer.scala
@@ -26,8 +26,15 @@ trait AudioPlayer {
 }
 
 object AudioPlayer {
-  def apply()(implicit backend: DefaultBackend[Any, AudioPlayer]): AudioPlayer =
-    backend.defaultValue()
+
+  /** Returns a new [[AudioPlayer]] for the default backend for the target platform.
+    *
+    * @return [[AudioPlayer]] using the default backend for the target platform
+    */
+  def create(settings: AudioPlayer.Settings)(implicit backend: DefaultBackend[Any, LowLevelAudioPlayer]): AudioPlayer =
+    AudioPlayerManager().init(settings)
+
+  case class Settings(sampleRate: Int = 44100, bufferSize: Int = 4096)
 
   sealed trait AudioQueue {
     def isEmpty: Boolean

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioPlayerManager.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioPlayerManager.scala
@@ -1,0 +1,35 @@
+package eu.joaocosta.minart.audio
+
+import eu.joaocosta.minart.backend.defaults._
+
+/** Abstraction that provides an `init` operation to create a new audio player.
+  *
+  * This is helpful to deal with the fact that creating a new audio player is a
+  * side-effectful operation.
+  */
+trait AudioPlayerManager {
+
+  /** Returns a low-level audio player object.
+    *
+    * @return low-level audio player object
+    */
+  def init(settings: AudioPlayer.Settings): LowLevelAudioPlayer
+}
+
+object AudioPlayerManager {
+
+  def apply(audioPlayerBuilder: () => LowLevelAudioPlayer): AudioPlayerManager = new AudioPlayerManager {
+    def init(settings: AudioPlayer.Settings): LowLevelAudioPlayer = {
+      val player = audioPlayerBuilder()
+      player.init(settings)
+      player
+    }
+  }
+
+  /** Returns [[AudioPlayerManager]] for the default backend for the target platform.
+    *
+    * @return [[AudioPlayerManager]] using the default backend for the target platform
+    */
+  def apply()(implicit backend: DefaultBackend[Any, LowLevelAudioPlayer]): AudioPlayerManager =
+    AudioPlayerManager(() => LowLevelAudioPlayer.create())
+}

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/LowLevelAudioPlayer.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/LowLevelAudioPlayer.scala
@@ -1,0 +1,52 @@
+package eu.joaocosta.minart.audio
+
+import eu.joaocosta.minart.backend.defaults._
+
+/** A low-level version of a audio player that provides its own manager.
+  */
+trait LowLevelAudioPlayer extends AudioPlayer with AutoCloseable {
+  private[this] var _settings: AudioPlayer.Settings = _
+  def settings: AudioPlayer.Settings =
+    if (_settings == null) AudioPlayer.Settings()
+    else _settings
+
+  protected def unsafeInit(settings: AudioPlayer.Settings): Unit
+  protected def unsafeDestroy(): Unit
+
+  /** Checks if the audio player is created or if it has been destroyed
+    */
+  def isCreated(): Boolean = !(_settings == null)
+
+  /** Creates the audio player.
+    *
+    * Playback operations can only be called after calling this.
+    */
+  def init(settings: AudioPlayer.Settings): Unit = {
+    if (isCreated()) {
+      close()
+    }
+    if (!isCreated()) {
+      unsafeInit(settings)
+    }
+  }
+
+  /** Destroys the audio player.
+    *
+    * Calling any operation on this player after calling close() without calling
+    * init() has an undefined behavior.
+    */
+  def close(): Unit = if (isCreated()) {
+    unsafeDestroy()
+    _settings = null
+  }
+}
+
+object LowLevelAudioPlayer {
+
+  /** Returns a new [[LowLevelAudioPlayer]] for the default backend for the target platform.
+    *
+    * @return [[LowLevelAudioPlayer]] using the default backend for the target platform
+    */
+  def create()(implicit backend: DefaultBackend[Any, LowLevelAudioPlayer]): LowLevelAudioPlayer =
+    backend.defaultValue()
+}

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/LowLevelCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/LowLevelCanvas.scala
@@ -2,7 +2,7 @@ package eu.joaocosta.minart.graphics
 
 import eu.joaocosta.minart.backend.defaults._
 
-/** A low-level version of a canvas that provides its own canvas manager.
+/** A low-level version of a canvas that provides its own manager.
   */
 trait LowLevelCanvas extends Canvas with AutoCloseable {
   protected[this] var extendedSettings: LowLevelCanvas.ExtendedSettings = _
@@ -20,8 +20,6 @@ trait LowLevelCanvas extends Canvas with AutoCloseable {
   /** Creates the canvas window.
     *
     * Rendering operations can only be called after calling this.
-    *
-    * @return canvas object linked to the created window
     */
   def init(settings: Canvas.Settings): Unit = {
     if (isCreated()) {
@@ -34,7 +32,7 @@ trait LowLevelCanvas extends Canvas with AutoCloseable {
 
   /** Destroys the canvas window.
     *
-    * Calling any operation on this canvas after calling close without calling
+    * Calling any operation on this canvas after calling close() without calling
     * init() has an undefined behavior.
     */
   def close(): Unit = if (isCreated()) {

--- a/examples/snapshot/11-audio.sc
+++ b/examples/snapshot/11-audio.sc
@@ -41,15 +41,17 @@ object Audio {
       .zipWith(bass, (high, low) => high * 0.7 + low * 0.3)
 }
 
+val audioPlayer = AudioPlayer.create(AudioPlayer.Settings())
+
 ImpureRenderLoop
   .statelessRenderLoop(
     canvas => {
       // When someone presses "Space", we send our sound wave to the queue
       if (canvas.getKeyboardInput().keysPressed.contains(KeyboardInput.Key.Space))
-        AudioPlayer().play(Audio.testSample)
+        audioPlayer.play(Audio.testSample)
       // When someone presses "Backspace", we stop the audio player
       if (canvas.getKeyboardInput().keysPressed.contains(KeyboardInput.Key.Backspace))
-        AudioPlayer().stop()
+        audioPlayer.stop()
       canvas.clear()
       canvas.fill(Color(0, 128, 0))
       canvas.redraw()

--- a/examples/snapshot/12-audio-clip.sc
+++ b/examples/snapshot/12-audio-clip.sc
@@ -19,14 +19,16 @@ import eu.joaocosta.minart.backend.defaults._
  */
 val clip = Sound.loadAiffClip(Resource("assets/sample.aiff")).get
 
+val audioPlayer = AudioPlayer.create(AudioPlayer.Settings())
+
 // Same logic as the audio example
 ImpureRenderLoop
   .statelessRenderLoop(
     canvas => {
       if (canvas.getKeyboardInput().keysPressed.contains(KeyboardInput.Key.Space))
-        AudioPlayer().play(clip)
+        audioPlayer.play(clip)
       if (canvas.getKeyboardInput().keysPressed.contains(KeyboardInput.Key.Backspace))
-        AudioPlayer().stop()
+        audioPlayer.stop()
       canvas.clear()
       canvas.fill(Color(0, 128, 0))
       canvas.redraw()


### PR DESCRIPTION
Adds `LowLevelAudioPlayer` and `AudioPlayerManager` abstractions, similar to the Canvas.

This allows some audio parameters, such as the sample rate and buffer size to be configurable.