### PR TITLE
Store ordered history in the PointerInput

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
@@ -145,7 +145,7 @@ class HtmlCanvas(parentNode: => dom.Node = dom.document.body) extends SurfaceBac
       keyboardInput = keyboardInput.clearPressRelease()
     }
     if (buffers.contains(Canvas.Buffer.PointerBuffer)) {
-      pointerInput = pointerInput.clearPressRelease()
+      pointerInput = pointerInput.clearEvents()
     }
     if (buffers.contains(Canvas.Buffer.Backbuffer)) {
       surface.fill(settings.clearColor)

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -102,7 +102,7 @@ class AwtCanvas() extends SurfaceBackedCanvas {
       keyListener.clearPressRelease()
     }
     if (buffers.contains(Canvas.Buffer.PointerBuffer)) {
-      mouseListener.clearPressRelease()
+      mouseListener.clearEvents()
     }
     if (buffers.contains(Canvas.Buffer.Backbuffer)) {
       surface.fill(settings.clearColor)
@@ -233,8 +233,8 @@ object AwtCanvas {
     def mouseClicked(ev: MouseEvent): Unit  = ()
     def mouseEntered(ev: MouseEvent): Unit  = ()
     def mouseExited(ev: MouseEvent): Unit   = ()
-    def clearPressRelease(): Unit = synchronized {
-      state = state.clearPressRelease()
+    def clearEvents(): Unit = synchronized {
+      state = state.clearEvents()
     }
     def getPointerInput(): PointerInput = computeState().move(getMousePos())
   }

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -121,7 +121,7 @@ class SdlCanvas() extends SurfaceBackedCanvas {
       keyboardInput = keyboardInput.clearPressRelease()
     }
     if (buffers.contains(Canvas.Buffer.PointerBuffer)) {
-      pointerInput = pointerInput.clearPressRelease()
+      pointerInput = pointerInput.clearEvents()
     }
     if (handleEvents() && buffers.contains(Canvas.Buffer.Backbuffer)) {
       surface.fill(settings.clearColor)

--- a/core/shared/src/main/scala/eu/joaocosta/minart/input/PointerInput.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/input/PointerInput.scala
@@ -4,16 +4,24 @@ package eu.joaocosta.minart.input
   * It also accumulates points that have been pressed and released.
   *
   * @param position the current pointer position
-  * @param pointsPressed points where the pointer pressed
+  * @param events points where the pointer was pressed/released (the boolean indicates pressed when true, released when false)
   * @param keysReleased points where the pointer was released
-  * @param isPressed true if the pointer is currently pressed
+  * @param pressedOn if defined, it means the mouse is currently down and was pressed at that position. Otherwise, the mouse is currently up
   */
 case class PointerInput(
     position: Option[PointerInput.Position],
-    pointsPressed: List[PointerInput.Position],
-    pointsReleased: List[PointerInput.Position],
-    isPressed: Boolean
+    events: List[(PointerInput.Position, Boolean)],
+    pressedOn: Option[PointerInput.Position]
 ) {
+
+  /* Points where the pointer was pressed */
+  lazy val pointsPressed: List[PointerInput.Position] = events.filter(_._2).map(_._1)
+
+  /* Points where the pointer was released */
+  lazy val pointsReleased: List[PointerInput.Position] = events.filterNot(_._2).map(_._1)
+
+  /** Check if the mouse button is currently pressed */
+  def isPressed: Boolean = pressedOn.isDefined
 
   /** Updates the pointer position. */
   def move(pos: Option[PointerInput.Position]): PointerInput =
@@ -23,7 +31,7 @@ case class PointerInput(
   def press: PointerInput =
     position
       .map { pos =>
-        this.copy(pointsPressed = pointsPressed :+ pos, isPressed = true)
+        this.copy(events = events :+ (pos, true), pressedOn = Some(pos))
       }
       .getOrElse(this)
 
@@ -31,20 +39,19 @@ case class PointerInput(
   def release: PointerInput =
     position
       .map { pos =>
-        this.copy(pointsReleased = pointsReleased :+ pos, isPressed = false)
+        this.copy(events = events :+ (pos, false), pressedOn = None)
       }
       .getOrElse(this)
 
   /** Clears the `pointsPressed` and `pointsReleased`. */
-  def clearPressRelease(): PointerInput =
-    PointerInput(position, if (isPressed) pointsPressed.lastOption.toList else Nil, Nil, isPressed)
+  def clearEvents(): PointerInput = copy(events = Nil)
 }
 
 object PointerInput {
 
   /** Pointer Input with everything unset
     */
-  val empty = PointerInput(None, Nil, Nil, false)
+  val empty = PointerInput(None, Nil, None)
 
   /** Position on the screen
     */


### PR DESCRIPTION
Stores the ordered history of events in the `PointerInput`, so that it's easier to distinguish a "press -> release" from a "release -> press"

It also adds a `pressedOn: Option[Postion]` that keeps the last clicked position, which allows the events to be cleared with the `clearEvents` (previously `clearPressRelease`) method. This is particularly useful for UIs which need to know if the mouse was pressed in a specific frame (e.g. to activate a button)