### PR TITLE
Render optimizations and fixes

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
@@ -1,5 +1,7 @@
 package eu.joaocosta.minart.backend
 
+import scala.scalajs.js.typedarray._
+
 import org.scalajs.dom.ImageData
 
 import eu.joaocosta.minart.graphics.{Color, MutableSurface}
@@ -10,59 +12,28 @@ import eu.joaocosta.minart.graphics.{Color, MutableSurface}
   */
 final class ImageDataSurface(val data: ImageData) extends MutableSurface {
 
-  val width: Int      = data.width
-  val height: Int     = data.height
-  private val lines   = 0 until height
-  private val columns = 0 until width
+  val width: Int         = data.width
+  val height: Int        = data.height
+  private val dataBuffer = new Int32Array(data.data.asInstanceOf[Uint8ClampedArray].buffer)
 
   def unsafeGetPixel(x: Int, y: Int): Color = {
-    val baseAddr = 4 * (y * width + x)
-    Color(data.data(baseAddr + 0), data.data(baseAddr + 1), data.data(baseAddr + 2))
-  }
-
-  def getPixels(): Vector[Array[Color]] = {
-    val imgData = data.data
-    lines.map { y =>
-      val lineBase = y * width
-      columns.map { x =>
-        val baseAddr = 4 * (lineBase + x)
-        Color(imgData(baseAddr), imgData(baseAddr + 1), imgData(baseAddr + 2))
-      }.toArray
-    }.toVector
+    Color.fromBGR(dataBuffer(y * width + x))
   }
 
   def putPixel(x: Int, y: Int, color: Color): Unit =
     if (x >= 0 && y >= 0 && x < width && y < height) {
-      val lineBase = y * width
-      val baseAddr = 4 * (lineBase + x)
-      data.data(baseAddr + 0) = color.r
-      data.data(baseAddr + 1) = color.g
-      data.data(baseAddr + 2) = color.b
+      dataBuffer(y * width + x) = color.abgr
     }
 
   override def fill(color: Color): Unit = {
-    var base = 0
-    while (base < 4 * height * width) {
-      data.data(base + 0) = color.r
-      data.data(base + 1) = color.g
-      data.data(base + 2) = color.b
-      data.data(base + 3) = 255
-      base += 4
-    }
+    dataBuffer.fill(color.abgr)
   }
 
   def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
     var yy = 0
     while (yy < h) {
-      val lineBase = yy * width
-      var xx       = 0
-      while (xx < w) {
-        val baseAddr = 4 * (lineBase + xx)
-        data.data(baseAddr + 0) = color.r
-        data.data(baseAddr + 1) = color.g
-        data.data(baseAddr + 2) = color.b
-        xx += 1
-      }
+      val start = yy * width + x
+      dataBuffer.fill(color.abgr, start, start + w)
       yy += 1
     }
   }

--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
@@ -40,7 +40,7 @@ final class ImageDataSurface(val data: ImageData) extends MutableSurface {
       data.data(baseAddr + 2) = color.b
     }
 
-  def fill(color: Color): Unit = {
+  override def fill(color: Color): Unit = {
     var base = 0
     while (base < 4 * height * width) {
       data.data(base + 0) = color.r
@@ -48,6 +48,22 @@ final class ImageDataSurface(val data: ImageData) extends MutableSurface {
       data.data(base + 2) = color.b
       data.data(base + 3) = 255
       base += 4
+    }
+  }
+
+  def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
+    var yy = 0
+    while (yy < h) {
+      val lineBase = yy * width
+      var xx       = 0
+      while (xx < w) {
+        val baseAddr = 4 * (lineBase + xx)
+        data.data(baseAddr + 0) = color.r
+        data.data(baseAddr + 1) = color.g
+        data.data(baseAddr + 2) = color.b
+        xx += 1
+      }
+      yy += 1
     }
   }
 }

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
@@ -22,11 +22,24 @@ final class BufferedImageSurface(val bufferedImage: BufferedImage) extends Mutab
       imagePixels
         .setElem(y * width + x, color.argb)
 
-  def fill(color: Color): Unit = {
+  override def fill(color: Color): Unit = {
     var i = 0
     while (i < height * width) {
       imagePixels.setElem(i, color.argb)
       i += 1
+    }
+  }
+
+  def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
+    var yy = 0
+    while (yy < h) {
+      val lineBase = yy * width
+      var xx       = 0
+      while (xx < w) {
+        imagePixels.setElem(lineBase + xx + x, color.argb)
+        xx += 1
+      }
+      yy += 1
     }
   }
 

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
@@ -7,25 +7,22 @@ import eu.joaocosta.minart.graphics.{Color, MutableSurface, Surface}
 /** Mutable image surface backed by an AWT Buffered Image.
   */
 final class BufferedImageSurface(val bufferedImage: BufferedImage) extends MutableSurface {
-  val width               = bufferedImage.getWidth()
-  val height              = bufferedImage.getHeight()
-  private val imagePixels = bufferedImage.getRaster.getDataBuffer.asInstanceOf[DataBufferInt]
+  val width              = bufferedImage.getWidth()
+  val height             = bufferedImage.getHeight()
+  private val dataBuffer = bufferedImage.getRaster.getDataBuffer.asInstanceOf[DataBufferInt]
 
   def unsafeGetPixel(x: Int, y: Int): Color =
-    Color.fromRGB(imagePixels.getElem(y * width + x))
-
-  def getPixels(): Vector[Array[Color]] =
-    imagePixels.getData().iterator.map(Color.fromRGB).grouped(width).map(_.toArray).toVector
+    Color.fromRGB(dataBuffer.getElem(y * width + x))
 
   def putPixel(x: Int, y: Int, color: Color): Unit =
     if (x >= 0 && y >= 0 && x < width && y < height)
-      imagePixels
+      dataBuffer
         .setElem(y * width + x, color.argb)
 
   override def fill(color: Color): Unit = {
     var i = 0
     while (i < height * width) {
-      imagePixels.setElem(i, color.argb)
+      dataBuffer.setElem(i, color.argb)
       i += 1
     }
   }
@@ -36,7 +33,7 @@ final class BufferedImageSurface(val bufferedImage: BufferedImage) extends Mutab
       val lineBase = yy * width
       var xx       = 0
       while (xx < w) {
-        imagePixels.setElem(lineBase + xx + x, color.argb)
+        dataBuffer.setElem(lineBase + xx + x, color.argb)
         xx += 1
       }
       yy += 1

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
@@ -56,9 +56,15 @@ final class SdlSurface(val data: Ptr[SDL_Surface]) extends MutableSurface with A
       data.pixels(baseAddr + 3) = 255.toByte
     }
 
-  def fill(color: Color): Unit = {
+  override def fill(color: Color): Unit = {
     SDL_SetRenderDrawColor(renderer, color.r.toUByte, color.g.toUByte, color.b.toUByte, 0.toUByte)
     SDL_RenderClear(renderer)
+  }
+
+  def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
+    SDL_SetRenderDrawColor(renderer, color.r.toUByte, color.g.toUByte, color.b.toUByte, 0.toUByte)
+    val rect = stackalloc[SDL_Rect]().init(x, y, w, h)
+    SDL_RenderFillRect(renderer, rect)
   }
 
   override def blit(

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
@@ -14,29 +14,18 @@ import eu.joaocosta.minart.graphics.{Color, MutableSurface, Surface}
   */
 final class SdlSurface(val data: Ptr[SDL_Surface]) extends MutableSurface with AutoCloseable {
 
-  val width: Int        = data.w
-  val height: Int       = data.h
-  private val lines     = 0 until height
-  private val columns   = 0 until width
-  private val renderer  = SDL_CreateSoftwareRenderer(data)
-  private val pixelsArr = data.pixels.asInstanceOf[Ptr[Int]]
+  val width: Int         = data.w
+  val height: Int        = data.h
+  private val renderer   = SDL_CreateSoftwareRenderer(data)
+  private val dataBuffer = data.pixels.asInstanceOf[Ptr[Int]]
 
   def unsafeGetPixel(x: Int, y: Int): Color = {
-    Color.fromRGB(pixelsArr(y * width + x))
-  }
-
-  def getPixels(): Vector[Array[Color]] = {
-    lines.map { y =>
-      val lineBase = y * width
-      columns.map { x =>
-        Color.fromRGB(pixelsArr(lineBase + x))
-      }.toArray
-    }.toVector
+    Color.fromRGB(dataBuffer(y * width + x))
   }
 
   def putPixel(x: Int, y: Int, color: Color): Unit =
     if (data.pixels != null && x >= 0 && y >= 0 && x < width && y < height) {
-      pixelsArr(y * width + x) = color.argb
+      dataBuffer(y * width + x) = color.argb
     }
 
   override def fill(color: Color): Unit = {

--- a/backend/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/backend/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -39,6 +39,11 @@ trait MutableSurfaceTests extends BasicTestSuite {
     assert(surface.getPixels().flatten.forall(_ == Color(1, 2, 3)))
     surface.fill(Color(3, 2, 1))
     assert(surface.getPixels().flatten.forall(_ == Color(3, 2, 1)))
+
+    surface.fillRegion(0, 0, 1, 2, Color(1, 1, 1))
+    assert(surface.getPixel(0, 0) == Some(Color(1, 1, 1)))
+    assert(surface.getPixel(0, 1) == Some(Color(1, 1, 1)))
+    assert(surface.getPixel(1, 0) == Some(Color(3, 2, 1)))
   }
 
   test("Combine two surfaces without blowing up") {

--- a/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/AllSubsystems.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/AllSubsystems.scala
@@ -34,8 +34,8 @@ private[minart] class AllSubsystems(canvas: LowLevelCanvas, audioPlayer: LowLeve
     canvas.blit(that, mask)(x, y, cx, cy, cw, ch)
 
   // Surface
-  def getPixels(): Vector[Array[Color]]     = canvas.getPixels()
-  def unsafeGetPixel(x: Int, y: Int): Color = canvas.unsafeGetPixel(x, y)
+  override def getPixels(): Vector[Array[Color]] = canvas.getPixels()
+  def unsafeGetPixel(x: Int, y: Int): Color      = canvas.unsafeGetPixel(x, y)
 
   // AudioPlayer
   def isPlaying(): Boolean                      = audioPlayer.isPlaying()

--- a/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/AllSubsystems.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/AllSubsystems.scala
@@ -24,8 +24,14 @@ private[minart] class AllSubsystems(canvas: LowLevelCanvas, audioPlayer: LowLeve
   def redraw(): Unit                           = canvas.redraw()
 
   // MutableSurface
-  def fill(color: Color): Unit                     = canvas.fill(color)
-  def putPixel(x: Int, y: Int, color: Color): Unit = canvas.putPixel(x, y, color)
+  override def fill(color: Color): Unit                              = canvas.fill(color)
+  def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = canvas.fillRegion(x, y, w, h, color)
+  def putPixel(x: Int, y: Int, color: Color): Unit                   = canvas.putPixel(x, y, color)
+  override def blit(
+      that: Surface,
+      mask: Option[Color] = None
+  )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit =
+    canvas.blit(that, mask)(x, y, cx, cy, cw, ch)
 
   // Surface
   def getPixels(): Vector[Array[Color]]     = canvas.getPixels()

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Blitter.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Blitter.scala
@@ -115,7 +115,7 @@ private[graphics] object Blitter {
 
       if (maxX > 0 && maxY > 0) {
         source match {
-          case ramSurf: RamSurface => unsafeBlitMatrix(dest, ramSurf.data, mask, x, y, cx, cy, maxX, maxY)
+          case ramSurf: RamSurface => unsafeBlitMatrix(dest, ramSurf.dataBuffer, mask, x, y, cx, cy, maxX, maxY)
           case _                   => unsafeBlitSurface(dest, source, mask, x, y, cx, cy, maxX, maxY)
         }
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Color.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Color.scala
@@ -8,6 +8,12 @@ final class Color private (val argb: Int) {
 
   @inline def rgb: Int = (argb & 0x00ffffff)
 
+  @inline def abgr: Int =
+    (argb & 0xff000000) |   // A
+      (b << 16) |           // B
+      (argb & 0x0000ff00) | // G
+      r                     // R
+
   /** Combines this with another color by summing each RGB value.
     * Values are clamped on overflow.
     */
@@ -73,10 +79,21 @@ object Color {
     new Color((255 << 24) | ((gray & 255) << 16) | ((gray & 255) << 8) | (gray & 255))
 
   /** Creates a new color from a 24bit backed RGB integer.
-    * Ignores the first byte.
+    * Ignores the first byte of a 32bit number.
     */
   @inline def fromRGB(rgb: Int): Color =
     new Color(0xff000000 | rgb)
+
+  /** Creates a new color from a 24bit backed BGR integer.
+    * Ignores the first byte of a 32bit number.
+    */
+  @inline def fromBGR(bgr: Int): Color =
+    new Color(
+      0xff000000 |
+        ((bgr & 0x00ff0000) >> 16) |
+        (bgr & 0x0000ff00) |
+        ((bgr & 0x000000ff)) << 16
+    )
 
   /** Extracts the RGB channels of a color.
     */

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/MutableSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/MutableSurface.scala
@@ -14,11 +14,21 @@ trait MutableSurface extends Surface {
     */
   def putPixel(x: Int, y: Int, color: Color): Unit
 
-  /** Fill the surface with a certain color
+  /** Fill part of the surface with a certain color
+    *
+    * @param color `Color` to fill the surface with
+    * @param x leftmost pixel on the destination surface
+    * @param y topmost pixel on the destination surface
+    * @param w region width
+    * @param h region height
+    */
+  def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit
+
+  /** Fill the whole surface with a certain color
     *
     * @param color `Color` to fill the surface with
     */
-  def fill(color: Color): Unit
+  def fill(color: Color): Unit = fillRegion(0, 0, width, height, color)
 
   /** Draws a surface on top of this surface.
     *

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
@@ -4,9 +4,9 @@ package eu.joaocosta.minart.graphics
   *
   * @param data the raw data that backs this surface
   */
-final class RamSurface(val data: Vector[Array[Color]]) extends MutableSurface {
-  val width  = data.headOption.map(_.size).getOrElse(0)
-  val height = data.size
+final class RamSurface(val dataBuffer: Vector[Array[Color]]) extends MutableSurface {
+  val width  = dataBuffer.headOption.map(_.size).getOrElse(0)
+  val height = dataBuffer.size
 
   def this(colors: Seq[Seq[Color]]) =
     this(colors.map(_.toArray).toVector)
@@ -15,19 +15,19 @@ final class RamSurface(val data: Vector[Array[Color]]) extends MutableSurface {
     this(Vector.fill(height)(Array.fill(width)(color)))
 
   def unsafeGetPixel(x: Int, y: Int): Color =
-    data(y)(x)
+    dataBuffer(y)(x)
 
-  def getPixels(): Vector[Array[Color]] = data.map(_.clone())
+  override def getPixels(): Vector[Array[Color]] = dataBuffer.map(_.clone())
 
   def putPixel(x: Int, y: Int, color: Color): Unit =
     if (x >= 0 && y >= 0 && x < width && y < height)
-      data(y)(x) = color
+      dataBuffer(y)(x) = color
 
   def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
     var yy = 0
     while (yy < h) {
       var xx   = 0
-      val line = data(yy)
+      val line = dataBuffer(yy)
       while (xx < w) {
         line(xx) = color
         xx += 1

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
@@ -23,15 +23,15 @@ final class RamSurface(val data: Vector[Array[Color]]) extends MutableSurface {
     if (x >= 0 && y >= 0 && x < width && y < height)
       data(y)(x) = color
 
-  def fill(color: Color): Unit = {
-    var y = 0
-    while (y < height) {
-      var x = 0
-      while (x < width) {
+  def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
+    var yy = 0
+    while (yy < h) {
+      var xx = 0
+      while (xx < w) {
         data(y)(x) = color
-        x += 1
+        xx += 1
       }
-      y += 1
+      yy += 1
     }
   }
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
@@ -26,9 +26,10 @@ final class RamSurface(val data: Vector[Array[Color]]) extends MutableSurface {
   def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
     var yy = 0
     while (yy < h) {
-      var xx = 0
+      var xx   = 0
+      val line = data(yy)
       while (xx < w) {
-        data(y)(x) = color
+        line(xx) = color
         xx += 1
       }
       yy += 1

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
@@ -46,7 +46,11 @@ trait Surface {
     *
     * @return color matrix
     */
-  def getPixels(): Vector[Array[Color]]
+  def getPixels(): Vector[Array[Color]] = {
+    Vector.tabulate(height) { y =>
+      Array.tabulate(width)(x => unsafeGetPixel(x, y))
+    }
+  }
 
   /** Copies this surface into a new surface stored in RAM */
   final def toRamSurface(): RamSurface = new RamSurface(getPixels())

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceBackedCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceBackedCanvas.scala
@@ -15,7 +15,10 @@ trait SurfaceBackedCanvas extends LowLevelCanvas {
   def getPixels(): Vector[Array[Color]] =
     surface.getPixels()
 
-  def fill(color: Color): Unit =
+  def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit =
+    surface.fillRegion(x, y, w, h, color)
+
+  override def fill(color: Color): Unit =
     surface.fill(color)
 
   override def blit(

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceBackedCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceBackedCanvas.scala
@@ -12,7 +12,7 @@ trait SurfaceBackedCanvas extends LowLevelCanvas {
   def unsafeGetPixel(x: Int, y: Int): Color =
     surface.unsafeGetPixel(x, y)
 
-  def getPixels(): Vector[Array[Color]] =
+  override def getPixels(): Vector[Array[Color]] =
     surface.getPixels()
 
   def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit =

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -64,9 +64,6 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
   def transpose: SurfaceView =
     plane.transpose.toSurfaceView(height, width)
 
-  def getPixels(): Vector[Array[Color]] =
-    Vector.tabulate(height)(y => Array.tabulate(width)(x => unsafeGetPixel(x, y)))
-
   override def view: SurfaceView = this
 }
 

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -40,7 +40,7 @@ trait MutableSurfaceTests extends BasicTestSuite {
     surface.fill(Color(3, 2, 1))
     assert(surface.getPixels().flatten.forall(_ == Color(3, 2, 1)))
 
-    surface.fill(Color(1, 1, 1), 0, 0, 1, 2)
+    surface.fillRegion(0, 0, 1, 2, Color(1, 1, 1))
     assert(surface.getPixel(0, 0) == Some(Color(1, 1, 1)))
     assert(surface.getPixel(0, 1) == Some(Color(1, 1, 1)))
     assert(surface.getPixel(1, 0) == Some(Color(3, 2, 1)))

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -39,6 +39,11 @@ trait MutableSurfaceTests extends BasicTestSuite {
     assert(surface.getPixels().flatten.forall(_ == Color(1, 2, 3)))
     surface.fill(Color(3, 2, 1))
     assert(surface.getPixels().flatten.forall(_ == Color(3, 2, 1)))
+
+    surface.fill(Color(1, 1, 1), 0, 0, 1, 2)
+    assert(surface.getPixel(0, 0) == Some(Color(1, 1, 1)))
+    assert(surface.getPixel(0, 1) == Some(Color(1, 1, 1)))
+    assert(surface.getPixel(1, 0) == Some(Color(3, 2, 1)))
   }
 
   test("Combine two surfaces without blowing up") {

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/SpriteSheet.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/SpriteSheet.scala
@@ -15,12 +15,12 @@ class SpriteSheet(surface: Surface, spriteWidth: Int, spriteHeight: Int) {
 
   /** Gets a sprite at a given position in the sheet.
     *
-    *  @param column column of the sprite
     *  @param line line of the sprite
+    *  @param column column of the sprite
     *  @return surface view with the sprite
     */
-  def getSprite(column: Int, line: Int): SurfaceView =
-    surface.view.clip(line * spriteWidth, column * spriteHeight, spriteWidth, spriteHeight)
+  def getSprite(line: Int, column: Int): SurfaceView =
+    surface.view.clip(column * spriteWidth, line * spriteHeight, spriteWidth, spriteHeight)
 
   /** Gets a sprite at the nth position in the sheet.
     *

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/MSurfaceIOOps.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/graphics/pure/MSurfaceIOOps.scala
@@ -18,6 +18,18 @@ trait MSurfaceIOOps extends SurfaceIOOps {
     */
   def putPixel(x: Int, y: Int, color: Color): MSurfaceIO[Unit] = accessMSurface(_.putPixel(x, y, color))
 
+  /** Fill part of the surface with a certain color
+    *
+    * @param color `Color` to fill the surface with
+    * @param x leftmost pixel on the destination surface
+    * @param y topmost pixel on the destination surface
+    * @param w region width
+    * @param h region height
+    */
+  def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): MSurfaceIO[Unit] = accessMSurface(
+    _.fillRegion(x, y, w, h, color)
+  )
+
   /** Fill the surface with a certain color
     *
     * @param color `Color` to fill the surface with


### PR DESCRIPTION
Adds multiple render optimizations. Those were particularly noticeable in the native backend.

Also adds a new `fillRegion` operation to fill a square region in a surface. Not only is this a very useful method, but it also can be heavilly optimized on each backend.

Finally, this PR fixes a small issue with the `Spritesheet` implementation, as the parameter names were wrong.