### PR TITLE
Store historical input events

### DIFF
--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -92,7 +92,6 @@ class SdlCanvas() extends SurfaceBackedCanvas {
     surface = new SdlSurface(
       SDL_CreateRGBSurface(0.toUInt, newSettings.width, newSettings.height, 32, 0.toUInt, 0.toUInt, 0.toUInt, 0.toUInt)
     )
-    keyboardInput = KeyboardInput(Set(), Set(), Set())
     val fullExtendedSettings = extendedSettings.copy(
       windowWidth = windowSurface.w,
       windowHeight = windowSurface.h

--- a/core/shared/src/main/scala/eu/joaocosta/minart/input/PointerInput.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/input/PointerInput.scala
@@ -1,24 +1,30 @@
 package eu.joaocosta.minart.input
 
+import scala.collection.immutable.Queue
+
 /** The pointer input stores the state of the mouse (or similar device) at a certain point in time.
   * It also accumulates points that have been pressed and released.
   *
   * @param position the current pointer position
-  * @param events points where the pointer was pressed/released (the boolean indicates pressed when true, released when false)
-  * @param keysReleased points where the pointer was released
+  * @param events points where the pointer was pressed/released (the boolean indicates pressed when true, released when false).
+  *               Note that only the most recent PointerInput.maxEvents are guaranteed to be present.
   * @param pressedOn if defined, it means the mouse is currently down and was pressed at that position. Otherwise, the mouse is currently up
   */
 case class PointerInput(
     position: Option[PointerInput.Position],
-    events: List[(PointerInput.Position, Boolean)],
+    events: Queue[PointerInput.Event],
     pressedOn: Option[PointerInput.Position]
 ) {
 
-  /* Points where the pointer was pressed */
-  lazy val pointsPressed: List[PointerInput.Position] = events.filter(_._2).map(_._1)
+  /** Points where the pointer was pressed */
+  lazy val pointsPressed: List[PointerInput.Position] = events.collect { case PointerInput.Event.Pressed(pos) =>
+    pos
+  }.toList
 
-  /* Points where the pointer was released */
-  lazy val pointsReleased: List[PointerInput.Position] = events.filterNot(_._2).map(_._1)
+  /** Points where the pointer was released */
+  lazy val pointsReleased: List[PointerInput.Position] = events.collect { case PointerInput.Event.Released(pos) =>
+    pos
+  }.toList
 
   /** Check if the mouse button is currently pressed */
   def isPressed: Boolean = pressedOn.isDefined
@@ -27,11 +33,17 @@ case class PointerInput(
   def move(pos: Option[PointerInput.Position]): PointerInput =
     this.copy(position = pos)
 
+  private def pushEvent(event: PointerInput.Event) = {
+    val newQueue = events :+ event
+    if (newQueue.size >= PointerInput.maxEvents * 2) this.copy(events = newQueue.drop(PointerInput.maxEvents))
+    else this.copy(events = newQueue)
+  }
+
   /** Returns a new state where the pointer has been pressed. */
   def press: PointerInput =
     position
       .map { pos =>
-        this.copy(events = events :+ (pos, true), pressedOn = Some(pos))
+        pushEvent(PointerInput.Event.Pressed(pos)).copy(pressedOn = Some(pos))
       }
       .getOrElse(this)
 
@@ -39,19 +51,35 @@ case class PointerInput(
   def release: PointerInput =
     position
       .map { pos =>
-        this.copy(events = events :+ (pos, false), pressedOn = None)
+        pushEvent(PointerInput.Event.Released(pos)).copy(pressedOn = None)
       }
       .getOrElse(this)
 
   /** Clears the `pointsPressed` and `pointsReleased`. */
-  def clearEvents(): PointerInput = copy(events = Nil)
+  def clearEvents(): PointerInput = copy(events = Queue.empty)
 }
 
 object PointerInput {
 
   /** Pointer Input with everything unset
     */
-  val empty = PointerInput(None, Nil, None)
+  val empty = PointerInput(None, Queue.empty, None)
+
+  /** Maximum events guaranteed to be stored by PointerInput */
+  val maxEvents = 1024
+
+  /** Pointer Event */
+  sealed trait Event {
+    def pos: Position
+  }
+  object Event {
+
+    /** Event representing a pointer press */
+    final case class Pressed(pos: Position) extends Event
+
+    /** Event representing a pointer release */
+    final case class Released(pos: Position) extends Event
+  }
 
   /** Position on the screen
     */


### PR DESCRIPTION
Follow up to #307 

Turns out that it's quite helpful sometimes to have an ordered list of events that happened on a frame. So now this list is stored in the KeyboardInput/MouseInput.

This might still need some tweaks, but I feel like this is the correct way to go. The `keysPressed`/`keysReleased` behavior also changed slightly to what I think is a more sane behavior (previously if a key was pressed and released mid-frame, it was as if it was released, but not pressed...).