### PR TITLE
Remove covariance from FrameEffect

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/AppLoop.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/AppLoop.scala
@@ -71,7 +71,7 @@ object AppLoop {
     * @param terminateWhen loop termination check
     */
 
-  def statefulLoop[State, Settings, Subsystem <: LowLevelSubsystem[Settings], F[-_, +_]](
+  def statefulLoop[State, Settings, Subsystem <: LowLevelSubsystem[Settings], F[-_, _]](
       renderFrame: State => F[Subsystem, State],
       terminateWhen: State => Boolean = (_: State) => false
   )(implicit effect: FrameEffect[F]): AppLoop.Definition[State, Settings, Subsystem] = {
@@ -107,7 +107,7 @@ object AppLoop {
     * @param renderFrame operation to render the frame
     * @param frameRate frame rate limit
     */
-  def statelessLoop[Settings, Subsystem <: LowLevelSubsystem[Settings], F[-_, +_]](
+  def statelessLoop[Settings, Subsystem <: LowLevelSubsystem[Settings], F[-_, _]](
       renderFrame: F[Subsystem, Unit]
   )(implicit effect: FrameEffect[F]): AppLoop.Definition[Unit, Settings, Subsystem] =
     statefulLoop[Unit, Settings, Subsystem, F]((_) => renderFrame)
@@ -118,7 +118,7 @@ object AppLoop {
     * @param renderFrame operation to render the frame and update the state
     * @param terminateWhen loop termination check
     */
-  def statefulRenderLoop[State, F[-_, +_]](
+  def statefulRenderLoop[State, F[-_, _]](
       renderFrame: State => F[Canvas, State],
       terminateWhen: State => Boolean = (_: State) => false
   )(implicit effect: FrameEffect[F]): AppLoop.Definition[State, Canvas.Settings, LowLevelCanvas] =
@@ -131,7 +131,7 @@ object AppLoop {
     *
     * @param renderFrame operation to render the frame
     */
-  def statelessRenderLoop[F[-_, +_]](
+  def statelessRenderLoop[F[-_, _]](
       renderFrame: F[Canvas, Unit]
   )(implicit effect: FrameEffect[F]): AppLoop.Definition[Unit, Canvas.Settings, LowLevelCanvas] =
     statelessLoop[Canvas.Settings, LowLevelCanvas, F](
@@ -144,7 +144,7 @@ object AppLoop {
     * @param renderFrame operation to render the frame and update the state
     * @param terminateWhen loop termination check
     */
-  def statefulAudioLoop[State, F[-_, +_]](
+  def statefulAudioLoop[State, F[-_, _]](
       renderFrame: State => F[AudioPlayer, State],
       terminateWhen: State => Boolean = (_: State) => false
   )(implicit effect: FrameEffect[F]): AppLoop.Definition[State, AudioPlayer.Settings, LowLevelAudioPlayer] =
@@ -157,7 +157,7 @@ object AppLoop {
     *
     * @param renderFrame operation to render the frame
     */
-  def statelessAudioLoop[F[-_, +_]](
+  def statelessAudioLoop[F[-_, _]](
       renderFrame: F[AudioPlayer, Unit]
   )(implicit
       effect: FrameEffect[F]
@@ -175,7 +175,7 @@ object AppLoop {
     * @param renderFrame operation to render the frame and update the state
     * @param terminateWhen loop termination check
     */
-  def statefulAppLoop[State, F[-_, +_]](
+  def statefulAppLoop[State, F[-_, _]](
       renderFrame: State => F[Canvas with AudioPlayer, State],
       terminateWhen: State => Boolean = (_: State) => false
   )(implicit
@@ -200,7 +200,7 @@ object AppLoop {
     *
     * @param renderFrame operation to render the frame
     */
-  def statelessAppLoop[F[-_, +_]](
+  def statelessAppLoop[F[-_, _]](
       renderFrame: F[Canvas with AudioPlayer, Unit]
   )(implicit
       effect: FrameEffect[F]

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/FrameEffect.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/FrameEffect.scala
@@ -2,11 +2,9 @@ package eu.joaocosta.minart.runtime
 
 /** Typeclass for effect types for computations that run on each frame.
   *
-  * `F1[Subsystem, NewState]` represents a computation that takes a subsystem and returns a new state.
-  * `F2[Subsystem, OldState, NewState]` represents a computation that takes a subsystem and an old state returns a
-  * new state.
+  * `F[Subsystem, NewState]` represents a computation that takes a subsystem and returns a new state.
   */
-trait FrameEffect[F[-_, +_]] {
+trait FrameEffect[F[-_, _]] {
   def contramap[A, AA, B](f: F[A, B], g: AA => A): F[AA, B]
   def unsafeRun[A, B](f: F[A, B], subsystem: A): B
 }


### PR DESCRIPTION
Removes the covariance requirement from FrameEffect.

This didn't make much sense anyway, as that parameter would be either ignored (on a stateless loop) or be be used as an input for the loop (on a stateless loop).

This also allows for some very primitive cats-effect interop with
```scala
// Not really needed, but it helps to be able to use all minart-pure helpers
implicit def asSyncIO[S, A](rio: RIO[S, A]): Kleisli[SyncIO, S, A] = Kleisli.ask[SyncIO, S].map(s => rio.run(s))

implicit val catsFrameEffect: FrameEffect[[S, A] =>> Kleisli[SyncIO, S, A]] = new FrameEffect {
  def contramap[A, AA, B](f: Kleisli[SyncIO, A, B], g: AA => A): Kleisli[SyncIO, AA, B] = f.local(g)
  def unsafeRun[A, B](f: Kleisli[SyncIO, A, B], subsystem: A): B = f.run(subsystem).unsafeRunSync()
}
```

Which, while not great (I'm still not sure how I can support async IO yet), it's already a nice step forward towards #18 .
