### PR TITLE
Support Plane affine transformations

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Matrix.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Matrix.scala
@@ -1,0 +1,24 @@
+package eu.joaocosta.minart.graphics
+
+/** Affine Transformatiom matrix of the form
+  *  [a b c]
+  *  [d e f]
+  *  [0 0 1]
+  */
+final case class Matrix(a: Double, b: Double, c: Double, d: Double, e: Double, f: Double) {
+  def multiply(that: Matrix) =
+    Matrix(
+      this.a * that.a + this.b * that.d,
+      this.a * that.b + this.b * that.e,
+      this.a * that.c + this.b * that.f + this.c,
+      this.d * that.a + this.e * that.d,
+      this.d * that.b + this.e * that.e,
+      this.d * that.c + this.e * that.f + this.f
+    )
+  def apply(x: Double, y: Double): (Double, Double) =
+    (a * x + b * y + c * 1, d * x + e * y + f * 1)
+  def apply(x: Int, y: Int): (Int, Int) = {
+    val res = apply(x.toDouble, y.toDouble)
+    (res._1.toInt, res._2.toInt)
+  }
+}

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -53,12 +53,15 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
 
   /** Flips a surface horizontally. */
   def flipH: SurfaceView =
-    contramap((x, y) => (width - x - 1, y))
-      .toSurfaceView(width, height)
+    copy(plane = plane.flipH.translate(width, 0))
 
-  /** Flips an surface vertically. */
-  def flipV: SurfaceView = contramap((x, y) => (x, height - y - 1))
-    .toSurfaceView(width, height)
+  /** Flips a surface vertically. */
+  def flipV: SurfaceView =
+    copy(plane = plane.flipV.translate(0, height))
+
+  /** Scales a surface. */
+  def scale(sx: Double, sy: Double): SurfaceView =
+    copy(plane = plane.scale(sx, sy), width = (width * sx).toInt, height = (height * sx).toInt)
 
   /** Transposes a surface. */
   def transpose: SurfaceView =

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MatrixSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MatrixSpec.scala
@@ -1,0 +1,26 @@
+package eu.joaocosta.minart.graphics
+
+import scala.util.Random
+
+import verify._
+
+object MatrixSpec extends BasicTestSuite {
+
+  test("Can be applied") {
+    // [1 2 3] [3] = [10] (1*3 + 2*2 + 3*1)
+    // [4 5 6] [2]   [28] (4*3 + 5*2 + 6*1)
+    // [0 0 1] [1]   [ 1]
+    val testMatrix = Matrix(1, 2, 3, 4, 5, 6)
+    assert(testMatrix.apply(3, 2) == (10, 28))
+  }
+
+  test("Can be multiplied") {
+    // [1 2 3] [6 5 4] = [12  9  9]
+    // [4 5 6] [3 2 1]   [39 30 27]
+    // [0 0 1] [0 0 1]   [ 0  0  1]
+    val testMatrix = Matrix(1, 2, 3, 4, 5, 6).multiply(
+      Matrix(6, 5, 4, 3, 2, 1)
+    )
+    assert(testMatrix == Matrix(12, 9, 9, 39, 30, 27))
+  }
+}

--- a/examples/snapshot/10-surface-view.sc
+++ b/examples/snapshot/10-surface-view.sc
@@ -45,12 +45,13 @@ AppLoop
     (canvas: Canvas) => {
       val frameSin = math.sin(t)
       val frameCos = math.cos(t)
-      val zoom     = frameSin + 2.0
+      val zoom     = 1.0 / (frameSin + 2.0)
 
       val image = Plane
-        .fromSurfaceWithRepetition(updatedBitmap)                  // Create an inifinitePlane from our surface
-        .contramap((x, y) => ((x * zoom).toInt, (y * zoom).toInt)) // Apply zooming logic
-        .contramap((x, y) => ((x * frameCos - y * frameSin).toInt, (x * frameSin + y * frameCos).toInt)) // Rotatiion
+        .fromSurfaceWithRepetition(updatedBitmap) // Create an inifinitePlane from our surface
+        .scale(zoom, zoom) // scale
+        .rotate(t) // rotate
+        .contramap((x, y) => (x + (5 * math.sin(t + y/10.0)).toInt, y)) // Wobbly effect
         .flatMap(color =>
           (x, y) => // Add a crazy checkerboard effect
             if (x % 32 < 16 != y % 32 < 16) color.invert


### PR DESCRIPTION
Support Plane affine transformations.

After some benchmarks, this is much faster for composite transformations (which I guess would be expected).

While in theory one could precompute the matrix and apply it in contramap, having this as a first class concept in Minart allows Planes and SurfaceViews to provide some helpful methods (such as `scale` and `rotate`) that automatically compose in a performant way.

Also, applying matrix transformations using contramap can be a bit counterintuitive - most literature assumes that the transformation happens as a map, so in Minart you have to invert all matrices. Having those helper methods makes the whole process much more user friendly.

Still, the old contramap is still there, for more complex use cases.