### PR TITLE
Fractional translate and simpler scale

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -84,7 +84,7 @@ trait Plane extends Function2[Int, Int, Color] { outer =>
     Plane.MatrixPlane(matrix, this)
 
   /** Translates a plane. */
-  def translate(dx: Int, dy: Int): Plane = contramapMatrix(Matrix(1, 0, -dx, 0, 1, -dy))
+  def translate(dx: Double, dy: Double): Plane = contramapMatrix(Matrix(1, 0, -dx, 0, 1, -dy))
 
   /** Flips a plane horizontally. */
   def flipH: Plane = contramapMatrix(Matrix(-1, 0, 0, 0, 1, 0))

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -95,6 +95,9 @@ trait Plane extends Function2[Int, Int, Color] { outer =>
   /** Scales a plane. */
   def scale(sx: Double, sy: Double): Plane = contramapMatrix(Matrix(1.0 / sx, 0, 0, 0, 1.0 / sy, 0))
 
+  /** Scales a plane. */
+  def scale(s: Double): Plane = scale(s, s)
+
   /** Rotates a plane. */
   def rotate(theta: Double): Plane = {
     val ct = math.cos(theta)

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -63,6 +63,9 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
   def scale(sx: Double, sy: Double): SurfaceView =
     copy(plane = plane.scale(sx, sy), width = (width * sx).toInt, height = (height * sx).toInt)
 
+  /** Scales a surface. */
+  def scale(s: Double): SurfaceView = scale(s, s)
+
   /** Transposes a surface. */
   def transpose: SurfaceView =
     plane.transpose.toSurfaceView(height, width)


### PR DESCRIPTION
After trying #312 for a while I noticed two pain points:

- It's pretty common to want to scale with the same factor on x and y
- `translate` is the only matrix operation that doesn't take `Double`s

There are a few rounding errors that can happen by forcing translate to take an `Int`, namely when there's a translation followed by an upscale. Having a `Double` here allows the user to have a bit more control of the kind of rounding that should happen in the translation.