### PR TITLE
Better error messages when a Resource fails to load

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsResource.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsResource.scala
@@ -27,6 +27,7 @@ final case class JsResource(resourcePath: String) extends Resource {
         xhr.open("GET", path, false)
         xhr.overrideMimeType("text/plain; charset=x-user-defined")
         xhr.send()
+        if (xhr.status != 200) throw new Exception(s"Couldn't open resource: $resourcePath (${xhr.statusText})")
         xhr.responseText
     }
     new ByteArrayInputStream(data.toCharArray.map(_.toByte))
@@ -54,6 +55,7 @@ final case class JsResource(resourcePath: String) extends Resource {
         val xhr = new XMLHttpRequest()
         xhr.open("GET", path, false)
         xhr.send()
+        if (xhr.status != 200) throw new Exception(s"Couldn't open resource: $resourcePath (${xhr.statusText})")
         xhr.responseText
     }
     f(Source.fromString(data))
@@ -68,7 +70,8 @@ final case class JsResource(resourcePath: String) extends Resource {
         val xhr = new XMLHttpRequest()
         xhr.open("GET", path)
         xhr.onloadend = (event: ProgressEvent) => {
-          if (xhr.status != 200) promise.failure(new Exception(xhr.statusText))
+          if (xhr.status != 200)
+            promise.failure(new Exception(s"Couldn't open resource: $resourcePath (${xhr.statusText})"))
           else promise.complete(Try(f(Source.fromString(xhr.responseText))))
         }
         xhr.send()
@@ -87,7 +90,8 @@ final case class JsResource(resourcePath: String) extends Resource {
         xhr.open("GET", path)
         xhr.overrideMimeType("text/plain; charset=x-user-defined")
         xhr.onloadend = (event: ProgressEvent) => {
-          if (xhr.status != 200) promise.failure(new Exception(xhr.statusText))
+          if (xhr.status != 200)
+            promise.failure(new Exception(s"Couldn't open resource: $resourcePath (${xhr.statusText})"))
           else promise.complete(Try(f(new ByteArrayInputStream(xhr.responseText.toCharArray.map(_.toByte)))))
         }
         xhr.send()

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaResource.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaResource.scala
@@ -4,7 +4,7 @@ import java.io.{BufferedInputStream, File, FileInputStream, FileOutputStream, In
 
 import scala.concurrent._
 import scala.io.Source
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 import eu.joaocosta.minart.runtime.Resource
 
@@ -22,7 +22,10 @@ final case class JavaResource(resourcePath: String) extends Resource {
 
   def unsafeInputStream(): InputStream =
     Try(new BufferedInputStream(new FileInputStream(path)))
-      .orElse(Try(Option(this.getClass().getResourceAsStream("/" + resourcePath)).get))
+      .orElse(
+        Option(this.getClass().getResourceAsStream("/" + resourcePath))
+          .fold(Failure(new Exception(s"Couldn't open resource: $resourcePath")))(Success.apply)
+      )
       .get
   def unsafeOutputStream(): OutputStream = new FileOutputStream(path)
 

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaResource.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaResource.scala
@@ -24,7 +24,7 @@ final case class JavaResource(resourcePath: String) extends Resource {
     Try(new BufferedInputStream(new FileInputStream(path)))
       .orElse(
         Option(this.getClass().getResourceAsStream("/" + resourcePath))
-          .fold(Failure(new Exception(s"Couldn't open resource: $resourcePath")))(Success.apply)
+          .fold[Try[InputStream]](Failure(new Exception(s"Couldn't open resource: $resourcePath")))(Success.apply)
       )
       .get
   def unsafeOutputStream(): OutputStream = new FileOutputStream(path)

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/NativeResource.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/NativeResource.scala
@@ -24,7 +24,7 @@ final case class NativeResource(resourcePath: String) extends Resource {
     Try(new BufferedInputStream(new FileInputStream(path)))
       .orElse(
         Option(this.getClass().getResourceAsStream("/" + resourcePath))
-          .fold(Failure(new Exception(s"Couldn't open resource: $resourcePath")))(Success.apply)
+          .fold[Try[InputStream]](Failure(new Exception(s"Couldn't open resource: $resourcePath")))(Success.apply)
       )
       .get
   def unsafeOutputStream(): OutputStream = new FileOutputStream(path)

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/NativeResource.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/NativeResource.scala
@@ -4,7 +4,7 @@ import java.io.{BufferedInputStream, File, FileInputStream, FileOutputStream, In
 
 import scala.concurrent.Future
 import scala.io.Source
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 import eu.joaocosta.minart.runtime.Resource
 
@@ -22,7 +22,10 @@ final case class NativeResource(resourcePath: String) extends Resource {
 
   def unsafeInputStream(): InputStream =
     Try(new BufferedInputStream(new FileInputStream(path)))
-      .orElse(Try(Option(this.getClass().getResourceAsStream("/" + resourcePath)).get))
+      .orElse(
+        Option(this.getClass().getResourceAsStream("/" + resourcePath))
+          .fold(Failure(new Exception(s"Couldn't open resource: $resourcePath")))(Success.apply)
+      )
       .get
   def unsafeOutputStream(): OutputStream = new FileOutputStream(path)
 


### PR DESCRIPTION
Throw a nice exception when a resource fails to load instead of a cryptic `None.get`