### PR TITLE
Multiple bugfixes

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
@@ -32,7 +32,7 @@ final class ImageDataSurface(val data: ImageData) extends MutableSurface {
   def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
     var yy = 0
     while (yy < h) {
-      val start = yy * width + x
+      val start = (yy + y) * width + x
       dataBuffer.fill(color.abgr, start, start + w)
       yy += 1
     }

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
@@ -30,7 +30,7 @@ final class BufferedImageSurface(val bufferedImage: BufferedImage) extends Mutab
   def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
     var yy = 0
     while (yy < h) {
-      val lineBase = yy * width
+      val lineBase = (yy + y) * width
       var xx       = 0
       while (xx < w) {
         dataBuffer.setElem(lineBase + xx + x, color.argb)

--- a/core/shared/src/test/scala/eu/joaocosta/minart/audio/AudioQueueSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/audio/AudioQueueSpec.scala
@@ -11,6 +11,16 @@ object AudioQueueSpec extends BasicTestSuite {
     assert(queue.dequeue() == 0)
   }
 
+  test("An single channel audio queue has size Int.MaxValue") {
+    val queue = new AudioQueue.SingleChannelAudioQueue(1)
+    queue.enqueue(AudioWave.silence.take(Double.PositiveInfinity))
+    assert(queue.size == Int.MaxValue)
+    assert(queue.isEmpty == false)
+    queue.dequeue()
+    assert(queue.size == Int.MaxValue)
+    assert(queue.isEmpty == false)
+  }
+
   test("A single channel audio queue correctly samples audio") {
     val clip = AudioClip(x => x / 2.0, 2.0)
 

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/audio/pure/AudioPlayerIOOps.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/audio/pure/AudioPlayerIOOps.scala
@@ -12,13 +12,32 @@ trait AudioPlayerIOOps {
   def accessAudioPlayer[A](f: AudioPlayer => A): AudioPlayerIO[A] =
     RIO.access[AudioPlayer, A](f)
 
-  /** Enqueues an audio clip to be played later.
+  /** Enqueues an audio clip to be played later in channel 0.
+    *
+    *  @param clip audio clip to play
     */
-  def play(wave: AudioClip): AudioPlayerIO[Unit] = accessAudioPlayer(_.play(wave))
+  def play(clip: AudioClip): AudioPlayerIO[Unit] = accessAudioPlayer(_.play(clip))
 
   /** Enqueues an audio clip to be played later in a certain channel.
+    *
+    *  @param clip audio clip to play
+    *  @param channel channel where to play the audio clip
     */
-  def play(wave: AudioClip, channel: Int): AudioPlayerIO[Unit] = accessAudioPlayer(_.play(wave, channel))
+  def play(clip: AudioClip, channel: Int): AudioPlayerIO[Unit] = accessAudioPlayer(_.play(clip, channel))
+
+  /** Enqueues an audio wave to be played later in channel 0.
+    * The Audio Wave will play infinitely until stop() is called.
+    *
+    *  @param wave audio wave to play
+    */
+  def play(wave: AudioWave): AudioPlayerIO[Unit] = accessAudioPlayer(_.play(wave))
+
+  /** Enqueues an audio wave to be played later in a certain channel.
+    *  The Audio Wave will play infinitely until stop() is called.
+    *  @param wave audio wave to play
+    *  @param channel channel where to play the audio wave
+    */
+  def play(wave: AudioWave, channel: Int): AudioPlayerIO[Unit] = accessAudioPlayer(_.play(wave, channel))
 
   /** Checks if this player still has data to be played.
     */


### PR DESCRIPTION
Fixes multiple bugs detected while porting hyper loop runner

- Methods to play `AudioWave`s were missing from `AudioPlayerIO`
- `Canvas#fillRegion` was broken on both JVM and JS
- The `AudioQueue` size would overflow with inifinite clips