### PR TITLE
Add missing size methods to SpriteSheet

### DIFF
--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/SpriteSheet.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/SpriteSheet.scala
@@ -8,7 +8,7 @@ import eu.joaocosta.minart.graphics._
   *  @param spriteWidth width of each sprite
   *  @param spriteHeight height of each sprite
   */
-class SpriteSheet(surface: Surface, spriteWidth: Int, spriteHeight: Int) {
+class SpriteSheet(surface: Surface, val spriteWidth: Int, val spriteHeight: Int) {
 
   /** How many sprites are stored on each line */
   val spritesPerLine = surface.width / spriteWidth

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/SpriteSheet.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/SpriteSheet.scala
@@ -13,6 +13,12 @@ class SpriteSheet(surface: Surface, spriteWidth: Int, spriteHeight: Int) {
   /** How many sprites are stored on each line */
   val spritesPerLine = surface.width / spriteWidth
 
+  /** How many sprites are stored on each column */
+  val spritesPerColumn = surface.height / spriteHeight
+
+  /** How many sprites are stored */
+  val size = spritesPerColumn * spritesPerLine
+
   /** Gets a sprite at a given position in the sheet.
     *
     *  @param line line of the sprite

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/SpriteSheetSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/SpriteSheetSpec.scala
@@ -12,6 +12,14 @@ object SpriteSheetSpec extends BasicTestSuite {
     )
   ).view.scale(2, 4).toRamSurface()
 
+  test("Compute the number of sprites") {
+    val spriteSheet = new SpriteSheet(surface, 2, 4)
+
+    assert(spriteSheet.spritesPerLine == 3)
+    assert(spriteSheet.spritesPerColumn == 2)
+    assert(spriteSheet.size == 6)
+  }
+
   test("Fetch sprite by position") {
     val spriteSheet = new SpriteSheet(surface, 2, 4)
 


### PR DESCRIPTION
Turns out the `SpriteSheet` class only had the number of elements per line, which made it cumbersome to iterate over all elements.

Maybe `SpriteSheet` should extend `IndexedSeq[Surface]` or `IndexedSeq[IndexedSeq[Surface]]`... but I'll think more about that later.