### PR TITLE
Add coflatMap operations

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
@@ -21,6 +21,13 @@ final case class AudioWave(wave: Double => Double) extends (Double => Double) {
     */
   def zipWith(that: AudioWave, f: (Double, Double) => Double): AudioWave = AudioWave(t => f(this.wave(t), that.wave(t)))
 
+  /** Coflatmaps this wave with a AudioWave => Double function.
+    * Effectively, each sample of the new wave is computed from a translated wave, which can be used to
+    * implement convolutions.
+    */
+  def coflatMap(f: AudioWave => Double): AudioWave =
+    AudioWave(t => f(AudioWave((dt: Double) => wave(t + dt))))
+
   /** Returns a new AudioWave without the first `time` seconds
     */
   def drop(time: Double): AudioWave =

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -51,6 +51,16 @@ trait Plane extends Function2[Int, Int, Color] { outer =>
     height = that.height
   )
 
+  /** Coflatmaps this plane with a Plane => Color function.
+    * Effectively, each pixel of the new plane is computed from a translated plane, which can be used to
+    * implement convolutions.
+    */
+  final def coflatMap(f: Plane => Color): Plane =
+    new Plane {
+      def getPixel(x: Int, y: Int): Color =
+        f((dx: Int, dy: Int) => outer.getPixel(x + dx, y + dy))
+    }
+
   final def clip(cx: Int, cy: Int, cw: Int, ch: Int): SurfaceView =
     if (cx == 0 && cy == 0) toSurfaceView(cw, ch)
     else

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
@@ -106,6 +106,23 @@ object PlaneSpec extends BasicTestSuite {
     assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
   }
 
+  test("Coflatmapping it updates the colors based on the kernel") {
+    val newSurface =
+      Plane
+        .fromSurfaceWithRepetition(surface)
+        .coflatMap(img => img(1, 2))
+        .toRamSurface(surface.width, surface.height)
+    val newPixels = newSurface.getPixels()
+    val expectedPixels =
+      Plane
+        .fromSurfaceWithRepetition(surface)
+        .translate(-1, -2)
+        .toRamSurface(surface.width, surface.height)
+        .getPixels()
+
+    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+  }
+
   test("Clipping clips the view") {
     val newSurface =
       Plane.fromSurfaceWithRepetition(surface).clip(5, 5, 2, 2).toRamSurface()

--- a/examples/snapshot/10-surface-view.sc
+++ b/examples/snapshot/10-surface-view.sc
@@ -52,6 +52,12 @@ AppLoop
         .scale(zoom, zoom)                                                // scale
         .rotate(t)                                                        // rotate
         .contramap((x, y) => (x + (5 * math.sin(t + y / 10.0)).toInt, y)) // Wobbly effect
+        .coflatMap { img =>                                               // Average blur
+          val window = (-1 to 1).flatMap(x => (-1 to 1).map(y => img(x, y)))
+          window.foldLeft(Color(0, 0, 0)) { case (Color(r, g, b), Color(rr, gg, bb)) =>
+            Color(r + rr / window.size, g + gg / window.size, g + gg / window.size)
+          }
+        }
         .flatMap(color =>
           (x, y) => // Add a crazy checkerboard effect
             if (x % 32 < 16 != y % 32 < 16) color.invert


### PR DESCRIPTION
Adds a `coflatMap` operation to `Plane` and `AudioWave`, based on:
- https://blog.adrian-salajan.com/blog/2021/05/11/image-editing-with-comonads
- http://justinhj.github.io/2019/06/20/comonads-for-life.html

This allows one to apply convolutions (even if the performance is not ideal).

Some notes:
- I decided to not implement anything like a `FocusedGrid`. Instead I pass a translated `Plane`  to the function.
- The same happens for the `AudioWave`.
- On the same note, while I could implement `extract`, it felt a bit odd (it's more intuitive to just do `Plane.getPixel(0, 0)`)
- Finally, I didn't add any helper methods to `SurfaceView` or `AudioClip`, so that a user has to be explicit on what happens in the borders and the resulting size.