### PR TITLE
Make APIs more consistent between Planes/SurfaceViews and AudioWaves/AudioClips

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
@@ -42,9 +42,9 @@ final case class AudioClip(
   def flatMap(f: Double => AudioWave): AudioClip =
     AudioClip(wave.flatMap(f), duration)
 
-  /** Contramaps the values of the wave of this clip. The duration stays unchanged */
-  def contramap(f: Double => Double): AudioClip =
-    AudioClip(wave.contramap(f), duration)
+  /** Contramaps the values of the wave of this clip */
+  def contramap(f: Double => Double): AudioWave =
+    wave.contramap(f)
 
   /** Combines this clip with another by combining their values using the given function.
     */
@@ -70,15 +70,16 @@ final case class AudioClip(
 
   /** Returns a reversed version of this wave */
   def reverse: AudioClip =
-    contramap(t => duration - t)
+    contramap(t => duration - t).take(duration)
 
   /** Speeds up/down this clip according to a multiplier */
   def changeSpeed(multiplier: Double): AudioClip =
-    wave.contramap(t => multiplier * t).take(duration / multiplier)
+    contramap(t => multiplier * t).take(duration / multiplier)
 
   /** Returns an audio wave that repeats this clip forever */
   def repeating: AudioWave =
-    wave.contramap(t => AudioClip.floorMod(t, duration))
+    if (duration <= 0) AudioWave.silence
+    else contramap(t => AudioClip.floorMod(t, duration))
 
   /** Returns an audio wave that repeats this clip a certain number of times */
   def repeating(times: Int): AudioClip =

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
@@ -8,9 +8,9 @@ package eu.joaocosta.minart.audio
 final case class AudioClip(
     wave: AudioWave,
     duration: Double
-) extends (Double => Double) {
+) {
 
-  def apply(t: Double): Double =
+  def getAmplitude(t: Double): Double =
     if (t < 0 || t > duration) 0.0
     else (wave(t))
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
@@ -39,7 +39,7 @@ final case class AudioClip(
     AudioClip(wave.map(f), duration)
 
   /** Flatmaps the wave of this clip. The duration stays unchanged */
-  def flatMap(f: Double => Double => Double): AudioClip =
+  def flatMap(f: Double => AudioWave): AudioClip =
     AudioClip(wave.flatMap(f), duration)
 
   /** Contramaps the values of the wave of this clip. The duration stays unchanged */
@@ -61,7 +61,7 @@ final case class AudioClip(
   /** Appends an AudioClip to this one */
   def append(that: AudioClip): AudioClip =
     AudioClip(
-      AudioWave(t =>
+      AudioWave.fromFunction(t =>
         if (t <= this.duration) this.wave(t)
         else that.wave(t - this.duration)
       ),
@@ -101,13 +101,6 @@ final case class AudioClip(
 }
 
 object AudioClip {
-
-  /** Creates an audio clip from a wave and a duration
-    * @param wave function from time in seconds and amplitude in [-1, 1]
-    * @param duration clip duration
-    */
-  def apply(wave: Double => Double, duration: Double): AudioClip =
-    AudioWave(wave).take(duration)
 
   /** Empty audio clip */
   val empty = silence(0.0)

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
@@ -4,54 +4,67 @@ package eu.joaocosta.minart.audio
   *
   * @param wave continuous function representing the wave
   */
-final case class AudioWave(wave: Double => Double) extends (Double => Double) {
+trait AudioWave extends (Double => Double) { outer =>
 
-  def apply(t: Double): Double = wave(t)
+  /** Returns the amplitude at time t. */
+  def apply(t: Double): Double = getAmplitude(t)
+
+  /** Returns the amplitude at time t. */
+  def getAmplitude(t: Double): Double
 
   /** Maps the values of this wave. */
-  def map(f: Double => Double): AudioWave = AudioWave(t => f(wave(t)))
+  final def map(f: Double => Double): AudioWave = new AudioWave {
+    def getAmplitude(t: Double): Double = f(outer.getAmplitude(t))
+  }
 
   /** Flatmaps this wave with another wave. */
-  def flatMap(f: Double => Double => Double): AudioWave = AudioWave(t => f(wave(t))(t))
+  final def flatMap(f: Double => AudioWave): AudioWave = new AudioWave {
+    def getAmplitude(t: Double): Double = f(outer.getAmplitude(t)).getAmplitude(t)
+  }
 
   /** Contramaps the values of this wave. */
-  def contramap(f: Double => Double): AudioWave = AudioWave(t => wave(f(t)))
+  final def contramap(f: Double => Double): AudioWave = new AudioWave {
+    def getAmplitude(t: Double): Double = outer.getAmplitude(f(t))
+  }
 
   /** Combines this wave with another by combining their values using the given function.
     */
-  def zipWith(that: AudioWave, f: (Double, Double) => Double): AudioWave = AudioWave(t => f(this.wave(t), that.wave(t)))
+  final def zipWith(that: AudioWave, f: (Double, Double) => Double): AudioWave = new AudioWave {
+    def getAmplitude(t: Double): Double = f(outer.getAmplitude(t), that.getAmplitude(t))
+  }
 
   /** Coflatmaps this wave with a AudioWave => Double function.
     * Effectively, each sample of the new wave is computed from a translated wave, which can be used to
     * implement convolutions.
     */
-  def coflatMap(f: AudioWave => Double): AudioWave =
-    AudioWave(t => f(AudioWave((dt: Double) => wave(t + dt))))
+  final def coflatMap(f: AudioWave => Double): AudioWave = new AudioWave {
+    def getAmplitude(t: Double): Double = f((dt: Double) => outer.getAmplitude(t + dt))
+  }
 
   /** Returns a new AudioWave without the first `time` seconds
     */
-  def drop(time: Double): AudioWave =
+  final def drop(time: Double): AudioWave =
     this.contramap(_ + time)
 
   /** Returns an AudioClip from this wave with just the first `time` seconds */
-  def take(time: Double): AudioClip =
+  final def take(time: Double): AudioClip =
     AudioClip(this, time)
 
   /** Returns an AudioClip from this wave from `start` to `end` */
-  def clip(start: Double, end: Double): AudioClip =
+  final def clip(start: Double, end: Double): AudioClip =
     if (end <= start) AudioClip.empty
     else AudioClip(this.drop(start), end - start)
 
   /** Samples this wave at the specified sample rate and returns an iterator of Doubles
     * in the [-1, 1] range.
     */
-  def iterator(sampleRate: Double): Iterator[Double] = {
+  final def iterator(sampleRate: Double): Iterator[Double] = {
     val stepSize = 1.0 / sampleRate
     new Iterator[Double] {
       var position  = 0
       def hasNext() = true
       def next() = {
-        val res = wave(position * stepSize)
+        val res = getAmplitude(position * stepSize)
         position += 1
         res
       }
@@ -61,7 +74,7 @@ final case class AudioWave(wave: Double => Double) extends (Double => Double) {
   /** Samples this wave at the specified sample rate and returns an iterator of Bytes
     * in the [-127, 127] range.
     */
-  def byteIterator(sampleRate: Double): Iterator[Byte] = {
+  final def byteIterator(sampleRate: Double): Iterator[Byte] = {
     iterator(sampleRate)
       .map(x => (math.min(math.max(-1.0, x), 1.0) * 127).toByte)
   }
@@ -72,7 +85,19 @@ final case class AudioWave(wave: Double => Double) extends (Double => Double) {
 object AudioWave {
 
   /** Audio wave with just silence */
-  val silence = AudioWave(_ => 0.0)
+  val silence = new AudioWave {
+    def getAmplitude(t: Double) = 0.0
+  }
+
+  /** Creates an audio wave from a generator function.
+    *
+    * @param generator generator function from a time t to an amplitude
+    */
+  def fromFunction(generator: Double => Double): AudioWave = new AudioWave {
+    def getAmplitude(t: Double): Double = {
+      generator(t)
+    }
+  }
 
   /** Generates an audio wave for a sequence of samples.
     * Every value outside of the sequence is zero.
@@ -81,5 +106,8 @@ object AudioWave {
     * @param sampleRate sample rate used in the sequence
     */
   def fromIndexedSeq(data: IndexedSeq[Double], sampleRate: Double): AudioWave =
-    AudioWave(t => data.applyOrElse((t * sampleRate).toInt, (_: Int) => 0.0))
+    new AudioWave {
+      def getAmplitude(t: Double): Double =
+        data.applyOrElse((t * sampleRate).toInt, (_: Int) => 0.0)
+    }
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
@@ -99,8 +99,19 @@ object AudioWave {
     }
   }
 
+  /** Creates an audio wave from an audio clip.
+    * Every amplitude outside of the clip duration is set to 0.
+    *
+    * @param audioClip reference clip
+    */
+  def fromAudioClip(audioClip: AudioClip): AudioWave = new AudioWave {
+    def getAmplitude(t: Double): Double = {
+      audioClip.getAmplitude(t)
+    }
+  }
+
   /** Generates an audio wave for a sequence of samples.
-    * Every value outside of the sequence is zero.
+    * Every value outside of the sequence is 0.
     *
     * @param data indexed sequence of samples (with amplitude between [-1.0, 1.0])
     * @param sampleRate sample rate used in the sequence

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/Oscillator.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/Oscillator.scala
@@ -55,7 +55,7 @@ object Oscillator {
   val sin: Oscillator =
     Oscillator { frequency =>
       val k = frequency * 2 * math.Pi
-      AudioWave(t => math.sin(k * t))
+      AudioWave.fromFunction(t => math.sin(k * t))
     }
 
   /** Square wave oscilator */
@@ -69,5 +69,5 @@ object Oscillator {
 
   /** Sawtooth wave oscilator */
   val sawtooth: Oscillator =
-    Oscillator(frequency => AudioWave(t => 2 * floorMod(t * frequency, 1) - 1))
+    Oscillator(frequency => AudioWave.fromFunction(t => 2 * floorMod(t * frequency, 1) - 1))
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -18,8 +18,8 @@ trait Plane extends Function2[Int, Int, Color] { outer =>
   }
 
   /** Flatmaps this plane */
-  final def flatMap(f: Color => (Int, Int) => Color): Plane = new Plane {
-    def getPixel(x: Int, y: Int): Color = f(outer.getPixel(x, y)).apply(x, y)
+  final def flatMap(f: Color => Plane): Plane = new Plane {
+    def getPixel(x: Int, y: Int): Color = f(outer.getPixel(x, y)).getPixel(x, y)
   }
 
   /** Contramaps the positions from this plane. */

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -143,12 +143,6 @@ trait Plane extends Function2[Int, Int, Color] { outer =>
 }
 
 object Plane {
-  private val defaultColor: Color = Color(0, 0, 0) // Fallback color used for safety
-  private def floorMod(x: Int, y: Int): Int = {
-    val rem = x % y
-    if (rem >= 0) rem
-    else rem + y
-  }
   private[Plane] final case class MatrixPlane(matrix: Matrix, plane: Plane) extends Plane {
     def getPixel(x: Int, y: Int): Color = {
       val (xx, yy) = matrix(x, y)
@@ -190,20 +184,7 @@ object Plane {
   /** Creates a plane from a surface, by repeating that surface accross both axis.
     * @param surface reference surface
     */
+  @deprecated("Use surface.view.repeating")
   def fromSurfaceWithRepetition(surface: Surface): Plane =
-    if (surface.width <= 0 || surface.height <= 0)
-      new Plane {
-        def getPixel(x: Int, y: Int): Color = defaultColor
-      }
-    else
-      new Plane {
-        def getPixel(x: Int, y: Int): Color = {
-          surface
-            .getPixel(
-              floorMod(x, surface.width),
-              floorMod(y, surface.height)
-            )
-            .getOrElse(defaultColor)
-        }
-      }
+    surface.view.repeating
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -14,8 +14,8 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
   def map(f: Color => Color): SurfaceView = copy(plane.map(f))
 
   /** Flatmaps the inner plane of this surface view */
-  def flatMap(f: Color => (Int, Int) => Color): SurfaceView =
-    copy(plane.flatMap(x => f(x)))
+  def flatMap(f: Color => Plane): SurfaceView =
+    copy(plane = plane.flatMap(f))
 
   /** Contramaps the positions from this surface view. */
   def contramap(f: (Int, Int) => (Int, Int)): Plane =

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
@@ -29,7 +29,7 @@ object PlaneSpec extends BasicTestSuite {
   }
 
   test("Can be created from a surface with repetition") {
-    val plane = Plane.fromSurfaceWithRepetition(surface)
+    val plane = surface.view.repeating
     assert(plane.getPixel(1, 2) == surface.getPixel(1, 2).get)
     assert(plane.getPixel(1 + 8, 2 + 16) == surface.getPixel(1, 2).get)
     assert(plane.getPixel(1 - 8, 2 - 16) == surface.getPixel(1, 2).get)
@@ -37,8 +37,7 @@ object PlaneSpec extends BasicTestSuite {
 
   test("Mapping it updates the colors") {
     val newSurface =
-      Plane
-        .fromSurfaceWithRepetition(surface)
+      surface.view.repeating
         .map(_.invert)
         .toRamSurface(surface.width, surface.height)
     val newPixels      = newSurface.getPixels()
@@ -51,8 +50,7 @@ object PlaneSpec extends BasicTestSuite {
 
   test("Flatmapping it updates the colors based on the position") {
     val newSurface =
-      Plane
-        .fromSurfaceWithRepetition(surface)
+      surface.view.repeating
         .flatMap(color => (x, y) => if (y >= 8) color.invert else color)
         .toRamSurface(surface.width, surface.height)
     val newPixels = newSurface.getPixels()
@@ -66,8 +64,7 @@ object PlaneSpec extends BasicTestSuite {
 
   test("Contramapping updates the positions") {
     val newSurface =
-      Plane
-        .fromSurfaceWithRepetition(surface)
+      surface.view.repeating
         .contramap((x, y) => (y, x))
         .toRamSurface(surface.height, surface.width)
     val newPixels      = newSurface.getPixels()
@@ -79,7 +76,8 @@ object PlaneSpec extends BasicTestSuite {
   }
 
   test("Zipping combines two planes") {
-    val plane = Plane.fromSurfaceWithRepetition(surface)
+    val plane =
+      surface.view.repeating
     val newSurface =
       plane
         .zipWith(plane, (c1: Color, c2: Color) => Color(c1.r - c2.r, c1.g - c2.g, c1.b - c2.b))
@@ -93,7 +91,8 @@ object PlaneSpec extends BasicTestSuite {
   }
 
   test("Zipping combines a plane and a surface") {
-    val plane = Plane.fromSurfaceWithRepetition(surface)
+    val plane =
+      surface.view.repeating
     val newSurface =
       plane
         .zipWith(surface, (c1: Color, c2: Color) => Color(c1.r - c2.r, c1.g - c2.g, c1.b - c2.b))
@@ -108,14 +107,12 @@ object PlaneSpec extends BasicTestSuite {
 
   test("Coflatmapping it updates the colors based on the kernel") {
     val newSurface =
-      Plane
-        .fromSurfaceWithRepetition(surface)
+      surface.view.repeating
         .coflatMap(img => img(1, 2))
         .toRamSurface(surface.width, surface.height)
     val newPixels = newSurface.getPixels()
     val expectedPixels =
-      Plane
-        .fromSurfaceWithRepetition(surface)
+      surface.view.repeating
         .translate(-1, -2)
         .toRamSurface(surface.width, surface.height)
         .getPixels()
@@ -125,7 +122,9 @@ object PlaneSpec extends BasicTestSuite {
 
   test("Clipping clips the view") {
     val newSurface =
-      Plane.fromSurfaceWithRepetition(surface).clip(5, 5, 2, 2).toRamSurface()
+      surface.view.repeating
+        .clip(5, 5, 2, 2)
+        .toRamSurface()
     val newPixels      = newSurface.getPixels()
     val expectedPixels = originalPixels.slice(5, 7).map(_.slice(5, 7))
 
@@ -139,25 +138,29 @@ object PlaneSpec extends BasicTestSuite {
   }
 
   test("Translation moves all pixels") {
-    val original    = Plane.fromSurfaceWithRepetition(surface)
+    val original =
+      surface.view.repeating
     val transformed = original.translate(5, 10)
     assert(original(0, 0) == transformed(5, 10))
   }
 
   test("FlipH mirrors the pixels with the Y axis") {
-    val original    = Plane.fromSurfaceWithRepetition(surface)
+    val original =
+      surface.view.repeating
     val transformed = original.flipH
     assert(original(5, 10) == transformed(-5, 10))
   }
 
   test("FlipV mirrors the pixels with the X axis") {
-    val original    = Plane.fromSurfaceWithRepetition(surface)
+    val original =
+      surface.view.repeating
     val transformed = original.flipV
     assert(original(5, 10) == transformed(5, -10))
   }
 
   test("Scale upscales the plane") {
-    val original    = Plane.fromSurfaceWithRepetition(surface)
+    val original =
+      surface.view.repeating
     val transformed = original.scale(2)
     assert(original(0, 0) == transformed(0, 0))
     assert(original(0, 0) == transformed(1, 0))
@@ -171,21 +174,24 @@ object PlaneSpec extends BasicTestSuite {
   }
 
   test("Scale downscales the plane") {
-    val original    = Plane.fromSurfaceWithRepetition(surface)
+    val original =
+      surface.view.repeating
     val transformed = original.scale(0.5)
     assert(original(0, 0) == transformed(0, 0))
     assert(original(2, 2) == transformed(1, 1))
   }
 
   test("Rotate moves all pixels clockwise") {
-    val original    = Plane.fromSurfaceWithRepetition(surface)
+    val original =
+      surface.view.repeating
     val transformed = original.rotate(math.Pi / 2)
     assert(original(0, 0) == transformed(0, 0))
     assert(original(5, 3) == transformed(-3, 5))
   }
 
   test("Shear moves all pixels") {
-    val original    = Plane.fromSurfaceWithRepetition(surface)
+    val original =
+      surface.view.repeating
     val transformed = original.shear(1, 0)
     assert(original(0, 0) == transformed(0, 0))
     assert(original(0, 1) == transformed(1, 1))
@@ -193,7 +199,8 @@ object PlaneSpec extends BasicTestSuite {
   }
 
   test("Transpose moves all pixels") {
-    val original    = Plane.fromSurfaceWithRepetition(surface)
+    val original =
+      surface.view.repeating
     val transformed = original.transpose
 
     assert(original(0, 0) == transformed(0, 0))

--- a/examples/snapshot/11-audio.sc
+++ b/examples/snapshot/11-audio.sc
@@ -26,7 +26,7 @@ object Audio {
 
   // Here we generate a sin wave with the frequencies from our song
   val arpeggio: AudioClip =
-    AudioWave((t: Double) => math.sin(song(t) * 6.28 * t)).take(1.0)
+    AudioWave.fromFunction((t: Double) => math.sin(song(t) * 6.28 * t)).take(1.0)
 
   // We can also use the provided oscilators
   val bass =


### PR DESCRIPTION
Makes the following changes to the APIs

- `AudioWave` is now a trait
- Methods accept `Plane` instead of `(Int, Int) => Color` and `AudioWave` instead of `Double => Double`
  - Since Scala 2.11 support was dropped, the old syntax should still work due to SAMs, and the API is clearer
  - Added an `AudioClip.fromFunction` helper anyway, if one wants to be explicit
- `AudioClip` doesn't extend `Double => Double` anymore
- `AudioClip#contramap` returns an `AudioWave` (previously returned a clip with the same duration) 
- Deprecated `Plane#fromSurfaceWithRepetition` in favor of a new `SurfaceView#repeating`