### PR TITLE
Surface view and audio clip coflatMap

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
@@ -8,7 +8,7 @@ package eu.joaocosta.minart.audio
 final case class AudioClip(
     wave: AudioWave,
     duration: Double
-) {
+) { outer =>
 
   def getAmplitude(t: Double): Double =
     if (t < 0 || t > duration) 0.0
@@ -57,6 +57,18 @@ final case class AudioClip(
     */
   def zipWith(that: AudioWave, f: (Double, Double) => Double): AudioClip =
     AudioClip(this.wave.zipWith(that, f), duration)
+
+  /** Coflatmaps this clip with a AudioClip => Double function.
+    * Effectively, each sample of the new clip is computed from a translated clip, which can be used to
+    * implement convolutions.
+    */
+  final def coflatMap(f: AudioClip => Double): AudioClip =
+    AudioClip(
+      new AudioWave {
+        def getAmplitude(t: Double): Double = f(outer.drop(t))
+      },
+      duration
+    )
 
   /** Appends an AudioClip to this one */
   def append(that: AudioClip): AudioClip =

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -61,6 +61,13 @@ trait Plane extends Function2[Int, Int, Color] { outer =>
         f((dx: Int, dy: Int) => outer.getPixel(x + dx, y + dy))
     }
 
+  /** Clips this plane to a chosen rectangle
+    *
+    * @param cx leftmost pixel on the surface
+    * @param cy topmost pixel on the surface
+    * @param cw clip width
+    * @param ch clip height
+    */
   final def clip(cx: Int, cy: Int, cw: Int, ch: Int): SurfaceView =
     if (cx == 0 && cy == 0) toSurfaceView(cw, ch)
     else

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -94,6 +94,15 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
   def repeating(xTimes: Int, yTimes: Int): SurfaceView =
     repeating.toSurfaceView(width * xTimes, height * yTimes)
 
+  /** Forces the surface to be computed and returns a new view.
+    * Equivalent to `toRamSurface().view`.
+    *
+    * This can be particularly useful to force the computation before a heavy
+    * coflatMap (e.g. a convolution with a large kernel) to avoid recomputing
+    * the same pixel multiple times.
+    */
+  def precompute: SurfaceView = toRamSurface().view
+
   override def view: SurfaceView = this
 }
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -34,6 +34,16 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
   def zipWith(that: Plane, f: (Color, Color) => Color): SurfaceView =
     copy(plane = plane.zipWith(that, f))
 
+  /** Coflatmaps this plane with a SurfaceView => Color function.
+    * Effectively, each pixel of the new view is computed from a translated view, which can be used to
+    * implement convolutions.
+    */
+  def coflatMap(f: SurfaceView => Color): SurfaceView =
+    copy(plane = new Plane {
+      def getPixel(x: Int, y: Int): Color =
+        f(outer.clip(x, y, width - x, height - y))
+    })
+
   /** Clips this view to a chosen rectangle
     *
     * @param cx leftmost pixel on the surface
@@ -45,7 +55,7 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
     val newWidth  = math.min(cw, this.width - cx)
     val newHeight = math.min(ch, this.height - cy)
     if (cx == 0 && cy == 0 && newWidth == width && newHeight == height) this
-    else plane.clip(cx, cy, cw, ch)
+    else plane.clip(cx, cy, newWidth, newHeight)
   }
 
   /** Inverts a surface color. */

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/SurfaceViewSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/SurfaceViewSpec.scala
@@ -66,6 +66,22 @@ object SurfaceViewSpec extends BasicTestSuite {
     assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
   }
 
+  test("Coflatmapping it updates the colors based on the kernel") {
+    val newSurface =
+      surface.view
+        .coflatMap(img => img.getPixel(1, 2).getOrElse(Color(50, 150, 200)))
+        .toRamSurface()
+    val newPixels = newSurface.getPixels()
+    val expectedPixels =
+      Plane
+        .fromSurfaceWithFallback(surface, Color(50, 150, 200))
+        .translate(-1, -2)
+        .toRamSurface(surface.width, surface.height)
+        .getPixels()
+
+    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+  }
+
   test("The clip view clips a surface") {
     val newSurface =
       surface.view.clip(5, 5, 2, 2).toRamSurface()


### PR DESCRIPTION
Follow up to #346 

After #347 it became trivial to implement safe `coflatMap` operations for `SurfaceView` and `AudioClip`, so this PR does just that.

This also adds a fix to `SurfaceView#clip` and a new `SurfaceView#precompute` operation, which can be useful in some situations.