### PR TITLE
Add get*OrElse and clamped methods

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
@@ -97,6 +97,11 @@ final case class AudioClip(
   def repeating(times: Int): AudioClip =
     repeating.take(duration * times)
 
+  /** Returns an audio wave that clamps this clip when out of bounds */
+  def clamped: AudioWave =
+    if (duration <= 0) AudioWave.silence
+    else contramap(t => AudioClip.clamp(0.0, t, duration))
+
   /** Samples this wave at the specified sample rate and returns an iterator of Doubles
     * in the [-1, 1] range.
     */
@@ -136,4 +141,7 @@ object AudioClip {
     if (rem >= 0) rem
     else rem + y
   }
+
+  private def clamp(minValue: Double, value: Double, maxValue: Double): Double =
+    math.max(0, math.min(value, maxValue))
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
@@ -10,9 +10,22 @@ final case class AudioClip(
     duration: Double
 ) { outer =>
 
-  def getAmplitude(t: Double): Double =
-    if (t < 0 || t > duration) 0.0
-    else (wave(t))
+  /** Gets the amplitude at a certain point in time
+    *  @param t time in seconds
+    *  @return amplitude
+    */
+  def getAmplitude(t: Double): Option[Double] =
+    if (t < 0 || t > duration) None
+    else Some(wave(t))
+
+  /** Gets the amplitude at a certain point in time, falling back to a default value when out of bounds.
+    * Similar to `getAmplitude(t).getOrElse(fallback)`, but avoids an allocation.
+    *  @param t time in seconds
+    *  @return amplitude
+    */
+  def getAmplitudeOrElse(t: Double, fallback: Double = 0.0): Double =
+    if (t < 0 || t > duration) fallback
+    else wave(t)
 
   /** Returns the number of samples required to store this wave at a certain
     * sample rate.

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
@@ -106,7 +106,7 @@ object AudioWave {
     */
   def fromAudioClip(audioClip: AudioClip): AudioWave = new AudioWave {
     def getAmplitude(t: Double): Double = {
-      audioClip.getAmplitude(t)
+      audioClip.getAmplitudeOrElse(t)
     }
   }
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -184,7 +184,7 @@ object Plane {
     */
   def fromSurfaceWithFallback(surface: Surface, fallback: Color): Plane = new Plane {
     def getPixel(x: Int, y: Int): Color = {
-      surface.getPixel(x, y).getOrElse(fallback)
+      surface.getPixelOrElse(x, y, fallback)
     }
   }
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
@@ -36,9 +36,21 @@ trait Surface {
     * @param y pixel y position
     * @return pixel color
     */
-  def getPixel(x: Int, y: Int): Option[Color] =
+  final def getPixel(x: Int, y: Int): Option[Color] =
     if (x >= 0 && y >= 0 && x < width && y < height) Some(unsafeGetPixel(x, y))
     else None
+
+  /** Gets the color from the this surface, falling back to a default color when out of bounds.
+    * Similar to `getPixel(x, y).getOrElse(fallback)`, but avoids an allocation.
+    *
+    * @param x pixel x position
+    * @param y pixel y position
+    * @param fallback fallback color
+    * @return pixel color
+    */
+  final def getPixelOrElse(x: Int, y: Int, fallback: Color = Color(0, 0, 0)): Color =
+    if (x >= 0 && y >= 0 && x < width && y < height) unsafeGetPixel(x, y)
+    else fallback
 
   /** Returns the pixels from this surface.
     * This operation can be perfomance intensive, so it might be worthwile

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -94,6 +94,16 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
   def repeating(xTimes: Int, yTimes: Int): SurfaceView =
     repeating.toSurfaceView(width * xTimes, height * yTimes)
 
+  /** Returns a plane that clamps this surface when out of bounds */
+  def clamped: Plane =
+    if (width <= 0 || height <= 0) Plane.fromConstant(SurfaceView.defaultColor)
+    else
+      new Plane {
+        def getPixel(x: Int, y: Int): Color = {
+          outer.plane.getPixel(SurfaceView.clamp(0, x, outer.width - 1), SurfaceView.clamp(0, y, outer.height - 1))
+        }
+      }
+
   /** Forces the surface to be computed and returns a new view.
     * Equivalent to `toRamSurface().view`.
     *
@@ -113,6 +123,8 @@ object SurfaceView {
     if (rem >= 0) rem
     else rem + y
   }
+  private def clamp(minValue: Int, value: Int, maxValue: Int): Int =
+    math.max(0, math.min(value, maxValue))
 
   /** Generates a surface view from a surface */
   def apply(surface: Surface): SurfaceView =


### PR DESCRIPTION
Adds:
- `Surface#getPixelOrElse`
- `AudioClip#getAmplitudeOrElse`
- `SurfaceView#clamped`
- `AudioClip#clamped`

As those can be quite useful for convolutions.
Also changes the `AudioClip#getAmpliutude` signature to return an `Option[Double]` in order to be in line with `Surface`