### PR TITLE
Make canvas scale optional

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
@@ -30,8 +30,8 @@ class HtmlCanvas(parentNode: => dom.Node = dom.document.body) extends SurfaceBac
       val canvasRect = jsCanvas.getBoundingClientRect()
       (canvasRect.left.toInt, canvasRect.top.toInt)
     }
-    val xx = (x - offsetX) / settings.scale
-    val yy = (y - offsetY) / settings.scale
+    val xx = (x - offsetX) / extendedSettings.scale
+    val yy = (y - offsetY) / extendedSettings.scale
     if (xx >= 0 && yy >= 0 && xx < settings.width && yy < settings.height)
       Some(PointerInput.Position(xx, yy))
     else None

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -183,8 +183,8 @@ object AwtCanvas {
         else canvas.getMousePosition()
       Option(point).map { p =>
         PointerInput.Position(
-          (p.x - extendedSettings.canvasX) / extendedSettings.settings.scale,
-          (p.y - extendedSettings.canvasY) / extendedSettings.settings.scale
+          (p.x - extendedSettings.canvasX) / extendedSettings.scale,
+          (p.y - extendedSettings.canvasY) / extendedSettings.scale
         )
       }
     }

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -30,8 +30,8 @@ class SdlCanvas() extends SurfaceBackedCanvas {
   private[this] def cleanPointerPos: Option[PointerInput.Position] = if (isCreated())
     Option(rawPointerPos).map { case (x, y) =>
       PointerInput.Position(
-        (x - extendedSettings.canvasX) / settings.scale,
-        (y - extendedSettings.canvasY) / settings.scale
+        (x - extendedSettings.canvasX) / extendedSettings.scale,
+        (y - extendedSettings.canvasY) / extendedSettings.scale
       )
     }
   else None

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Canvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Canvas.scala
@@ -74,7 +74,7 @@ object Canvas {
     *
     * @param width The canvas width
     * @param height The canvas height
-    * @param scale The canvas integer scaling factor
+    * @param scale The canvas integer scaling factor. If None, it will automatically pick 1 for non-fullscreen and fill the screen on full screen
     * @param fullscreen Whether the canvas should be rendered in a full screen window
     * @param clearColor The color to be used when the canvas is cleared
     * @param title The title to use if this Canvas needs to create a window
@@ -82,7 +82,7 @@ object Canvas {
   case class Settings(
       width: Int,
       height: Int,
-      scale: Int = 1,
+      scale: Option[Int] = None,
       fullScreen: Boolean = false,
       clearColor: Color = Color(255, 255, 255),
       title: String = "Minart"

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/LowLevelCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/LowLevelCanvas.scala
@@ -31,14 +31,26 @@ object LowLevelCanvas {
       windowWidth: Int,
       windowHeight: Int
   ) {
-    val scaledWidth  = settings.width * settings.scale
-    val scaledHeight = settings.height * settings.scale
+    val scale = settings.scale match {
+      case Some(scale)                  => scale
+      case None if !settings.fullScreen => 1
+      case _ =>
+        val wScale = windowWidth / settings.width
+        val hScale = windowHeight / settings.height
+        math.max(1, math.min(wScale, hScale))
+    }
+    val scaledWidth  = settings.width * scale
+    val scaledHeight = settings.height * scale
     val canvasX      = (windowWidth - scaledWidth) / 2
     val canvasY      = (windowHeight - scaledHeight) / 2
   }
 
   object ExtendedSettings {
     def apply(settings: Canvas.Settings): ExtendedSettings =
-      ExtendedSettings(settings, settings.width * settings.scale, settings.height * settings.scale)
+      ExtendedSettings(
+        settings,
+        settings.width * settings.scale.getOrElse(1),
+        settings.height * settings.scale.getOrElse(1)
+      )
   }
 }

--- a/examples/snapshot/01-color-square.sc
+++ b/examples/snapshot/01-color-square.sc
@@ -26,7 +26,7 @@ import eu.joaocosta.minart.graphics._
  * Those will be covered in more detail in a future example. Right now, you can see that this will create a 512x512
  * window with a 128x128 canvas (each pixel in the canvas will be a 4x4 square on the screen).
  */
-val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = 4)
+val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = Some(4))
 
 /*
  * Then we need to create our Canvas.

--- a/examples/snapshot/02-portable-color-square.sc
+++ b/examples/snapshot/02-portable-color-square.sc
@@ -12,7 +12,7 @@ import eu.joaocosta.minart.backend.defaults._
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.runtime._
 
-val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = 4)
+val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = Some(4))
 
 /*
  * Now, here's the different bit.

--- a/examples/snapshot/03-fire-animation.sc
+++ b/examples/snapshot/03-fire-animation.sc
@@ -17,7 +17,7 @@ import eu.joaocosta.minart.backend.defaults._
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.runtime._
 
-val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = 4)
+val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = Some(4))
 
 /*
  * This is just the function to define the fire animation, you can skip over this step.

--- a/examples/snapshot/04-pointer.sc
+++ b/examples/snapshot/04-pointer.sc
@@ -19,7 +19,7 @@ import eu.joaocosta.minart.runtime._
 /** Note the adition of clearColor here.
   * This is the color of the canvas when nothing is drawn.
   */
-val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = 4, clearColor = Color(255, 255, 255))
+val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = Some(4), clearColor = Color(255, 255, 255))
 
 AppLoop
   .statelessRenderLoop((canvas: Canvas) => {

--- a/examples/snapshot/05-snake-game.sc
+++ b/examples/snapshot/05-snake-game.sc
@@ -21,7 +21,7 @@ import eu.joaocosta.minart.runtime._
  * Again, let's define our canvas settings.
  * This time we'll use a smaller resolution with a larger scale.
  */
-val canvasSettings = Canvas.Settings(width = 32, height = 32, scale = 16, clearColor = Color(0, 0, 0))
+val canvasSettings = Canvas.Settings(width = 32, height = 32, scale = Some(16), clearColor = Color(0, 0, 0))
 
 /**
  * Then we define our game logic, this is an implementation of the classic snake game.

--- a/examples/snapshot/06-surface-blit.sc
+++ b/examples/snapshot/06-surface-blit.sc
@@ -11,7 +11,7 @@ import eu.joaocosta.minart.backend.defaults._
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.runtime._
 
-val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = 4)
+val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = Some(4))
 
 /*
  * We start by allocating a surface in RAM.

--- a/examples/snapshot/07-canvas-settings.sc
+++ b/examples/snapshot/07-canvas-settings.sc
@@ -12,11 +12,11 @@ import eu.joaocosta.minart.runtime._
 /** Let's define some settings.
   * Note that one of those will actually go fullScreen.
   */
-val settingsA = Canvas.Settings(width = 128, height = 128, scale = 4, clearColor = Color(128, 255, 128))
-val settingsB = Canvas.Settings(width = 640, height = 480, scale = 1, clearColor = Color(128, 255, 128))
+val settingsA = Canvas.Settings(width = 128, height = 128, scale = Some(4), clearColor = Color(128, 255, 128))
+val settingsB = Canvas.Settings(width = 640, height = 480, scale = None, clearColor = Color(128, 255, 128))
 val settingsC =
-  Canvas.Settings(width = 128, height = 128, scale = 4, fullScreen = true, clearColor = Color(128, 255, 128))
-val settingsD = Canvas.Settings(width = 640, height = 480, scale = 1, fullScreen = true, clearColor = Color(0, 0, 0))
+  Canvas.Settings(width = 128, height = 128, scale = Some(4), fullScreen = true, clearColor = Color(128, 255, 128))
+val settingsD = Canvas.Settings(width = 640, height = 480, scale = None, fullScreen = true, clearColor = Color(0, 0, 0))
 
 AppLoop
   .statelessRenderLoop((canvas: Canvas) => {

--- a/examples/snapshot/08-pure-color-square.scala
+++ b/examples/snapshot/08-pure-color-square.scala
@@ -52,5 +52,5 @@ object PureColorSquare extends MinartApp[Unit, LowLevelCanvas] {
           .flatMap(CanvasIO.sequence)
           .andThen(CanvasIO.redraw)
       )
-      .configure(Canvas.Settings(width = 128, height = 128, scale = 4), LoopFrequency.Never)
+      .configure(Canvas.Settings(width = 128, height = 128, scale = Some(4)), LoopFrequency.Never)
 }

--- a/examples/snapshot/09-image.sc
+++ b/examples/snapshot/09-image.sc
@@ -10,7 +10,7 @@ import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.image._
 import eu.joaocosta.minart.runtime._
 
-val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = 4)
+val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = Some(4))
 
 /*
  * Notice the use of Resource here.

--- a/examples/snapshot/10-surface-view.sc
+++ b/examples/snapshot/10-surface-view.sc
@@ -15,7 +15,7 @@ import eu.joaocosta.minart.graphics.image._
 import eu.joaocosta.minart.runtime._
 
 // First, let's load our example scala logo image
-val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = 4, clearColor = Color(0, 0, 0))
+val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = Some(4), clearColor = Color(0, 0, 0))
 val bitmap         = Image.loadBmpImage(Resource("assets/scala.bmp")).get
 
 /*


### PR DESCRIPTION
Makes the `Canvas.Settings` scale an `Option[Int]`.

When undefined, it uses `1` on windows and stretches as much as possible in fullscreen.

Unfortunately, this is a breaking change, but at least it's trivial to update the code.

Close #213 