### PR TITLE
Remove null check from SDL surface

### DIFF
--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
@@ -24,7 +24,7 @@ final class SdlSurface(val data: Ptr[SDL_Surface]) extends MutableSurface with A
   }
 
   def putPixel(x: Int, y: Int, color: Color): Unit =
-    if (data.pixels != null && x >= 0 && y >= 0 && x < width && y < height) {
+    if (x >= 0 && y >= 0 && x < width && y < height) {
       dataBuffer(y * width + x) = color.argb
     }
 


### PR DESCRIPTION
This null check wasn't really doing anything (it's not as if I checked in other places, and other backends also don't check for nulls) and this actually brings a huge speed up on blitting in `release-fast` (~10x speedup on twotm8 native)