### PR TITLE
Improve audio player performance

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioQueue.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioQueue.scala
@@ -21,7 +21,7 @@ sealed trait AudioQueue {
 
 object AudioQueue {
 
-  private val maxBufferSize: Double = 1.0
+  private val maxBufferSize: Double = 10.0
 
   class SingleChannelAudioQueue(sampleRate: Int) extends AudioQueue {
     private val valueQueue = scala.collection.mutable.Queue[Double]()

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
@@ -105,7 +105,7 @@ object AudioWave {
   private[AudioWave] object EmptyAudioWave extends AudioWave {
     def getAmplitude(t: Double)               = 0.0
     override def drop(time: Double)           = this
-    override def iterator(sampleRate: Double) = Iterator.empty
+    override def iterator(sampleRate: Double) = Iterator.continually(0.0)
     override def toString                     = "<silence>"
   }
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
@@ -82,7 +82,7 @@ trait AudioWave extends (Double => Double) { outer =>
 }
 
 object AudioWave {
-  private[this] final class DropAudioWave(inner: AudioWave, shift: Double) extends AudioWave {
+  private[AudioWave] final class DropAudioWave(inner: AudioWave, shift: Double) extends AudioWave {
     def getAmplitude(t: Double): Double = inner.getAmplitude(t + shift)
     override def drop(time: Double)     = new DropAudioWave(inner, shift + time)
     override def iterator(sampleRate: Double) =
@@ -90,7 +90,7 @@ object AudioWave {
     override def toString = s"DropAudioWave($inner, $shift)"
   }
 
-  private[this] final class SampledAudioWave(data: IndexedSeq[Double], sampleRate: Double) extends AudioWave {
+  private[AudioWave] final class SampledAudioWave(data: IndexedSeq[Double], sampleRate: Double) extends AudioWave {
     def getAmplitude(t: Double): Double =
       data.applyOrElse((t * sampleRate).toInt, (_: Int) => 0.0)
     override def drop(time: Double) = new SampledAudioWave(data.drop((time * sampleRate).toInt), sampleRate)
@@ -102,13 +102,15 @@ object AudioWave {
     override def toString = s"SampledAudioWave(<${data.size} samples>, $sampleRate)"
   }
 
-  /** Audio wave with just silence */
-  val silence = new AudioWave {
+  private[AudioWave] object EmptyAudioWave extends AudioWave {
     def getAmplitude(t: Double)               = 0.0
     override def drop(time: Double)           = this
     override def iterator(sampleRate: Double) = Iterator.empty
     override def toString                     = "<silence>"
   }
+
+  /** Audio wave with just silence */
+  val silence = EmptyAudioWave
 
   /** Creates an audio wave from a generator function.
     *


### PR DESCRIPTION
Fixes some of the problems related to https://github.com/JD557/minart/issues/354

I noticed that the problem was more common on long `repeating` clips, and that playing a clip multiple times had no issues.

This PR heavily optimizes operations related to the `drop` called in the audio queue, especially for repeating audio.
It also adds some self-healing to the audio player so that it can get back in sync.