### PR TITLE
Fix RamSurface#fillRegion

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
@@ -25,9 +25,9 @@ final class RamSurface(val dataBuffer: Vector[Array[Color]]) extends MutableSurf
     var yy = 0
     while (yy < h) {
       var xx   = 0
-      val line = dataBuffer(yy)
+      val line = dataBuffer(y + yy)
       while (xx < w) {
-        line(xx) = color
+        line(x + xx) = color
         xx += 1
       }
       yy += 1


### PR DESCRIPTION
`RamSurface#fillRegion` was ignoring the `x` and `y` parameters.