### PR TITLE
Work directly with the samples when loading QOA files

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
@@ -70,7 +70,7 @@ final case class AudioClip(
     * Effectively, each sample of the new clip is computed from a translated clip, which can be used to
     * implement convolutions.
     */
-  final def coflatMap(f: AudioClip => Double): AudioClip =
+  def coflatMap(f: AudioClip => Double): AudioClip =
     AudioClip(
       new AudioWave {
         def getAmplitude(t: Double): Double = f(outer.drop(t))


### PR DESCRIPTION
The QOA reader was building an `AudioClip` out of multiple clips in order to support variable sample rates.

The spec actually guarantee that this will never happen on non-streaming files, so by just storing the samples directly and building the clip on the end we get a nice performance boost.
Otherwise, loading large audio files (~1 minute) was quite slow.