### PR TITLE
Cleanup imports

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsAudioPlayer.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsAudioPlayer.scala
@@ -1,7 +1,5 @@
 package eu.joaocosta.minart.backend
 
-import scala.scalajs.js
-
 import org.scalajs.dom._
 
 import eu.joaocosta.minart.audio._

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -10,14 +10,12 @@ import java.awt.event.{
 }
 import java.awt.image.BufferedImage
 import java.awt.{Canvas => JavaCanvas, Color => JavaColor, Dimension, Graphics, GraphicsEnvironment, MouseInfo}
-import java.util.concurrent.ConcurrentLinkedQueue
 import javax.swing.{JFrame, WindowConstants}
 
 import scala.collection.JavaConverters._
 
 import eu.joaocosta.minart.graphics.LowLevelCanvas.ExtendedSettings
 import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.input.KeyboardInput.Key
 import eu.joaocosta.minart.input._
 
 /** A low level Canvas implementation that shows the image in an AWT/Swing window.

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaAudioPlayer.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaAudioPlayer.scala
@@ -1,6 +1,5 @@
 package eu.joaocosta.minart.backend
 
-import java.io._
 import javax.sound.sampled._
 
 import scala.concurrent._

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlAudioPlayer.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlAudioPlayer.scala
@@ -1,8 +1,6 @@
 package eu.joaocosta.minart.backend
 
 import scala.concurrent._
-import scala.scalanative.libc._
-import scala.scalanative.libc.stdlib.malloc
 import scala.scalanative.runtime.ByteArray
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlLoopRunner.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlLoopRunner.scala
@@ -1,6 +1,5 @@
 package eu.joaocosta.minart.backend
 
-import scala.annotation.tailrec
 import scala.concurrent._
 import scala.scalanative.libc.stdlib._
 import scala.scalanative.unsafe._

--- a/build.sbt
+++ b/build.sbt
@@ -24,11 +24,10 @@ ThisBuild / scalacOptions ++= Seq(
   "-language:higherKinds",
   "-unchecked"
 )
-ThisBuild / scalafmtOnCompile                              := true
-ThisBuild / semanticdbEnabled                              := true
-ThisBuild / semanticdbVersion                              := scalafixSemanticdb.revision
-ThisBuild / scalafixOnCompile                              := true
-ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.6.0"
+ThisBuild / scalafmtOnCompile := true
+ThisBuild / semanticdbEnabled := true
+ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
+ThisBuild / scalafixOnCompile := true
 
 val siteSettings = Seq(
   Compile / doc / scalacOptions ++= (

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/MutableSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/MutableSurface.scala
@@ -1,7 +1,5 @@
 package eu.joaocosta.minart.graphics
 
-import scala.annotation.tailrec
-
 /** A surface that can be drawn on using mutable operations.
   */
 trait MutableSurface extends Surface {

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/AppLoop.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/AppLoop.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.runtime
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.backend.defaults._

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/Resource.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/Resource.scala
@@ -4,7 +4,6 @@ import java.io.{InputStream, OutputStream}
 
 import scala.concurrent.Future
 import scala.io.Source
-import scala.util.Using.Releasable
 import scala.util.{Try, Using}
 
 import eu.joaocosta.minart.backend.defaults._

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
@@ -3,7 +3,6 @@ package eu.joaocosta.minart.graphics.image.ppm
 import java.io.InputStream
 
 import scala.annotation.tailrec
-import scala.collection.compat._
 
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.image._

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
@@ -3,6 +3,7 @@ package eu.joaocosta.minart.graphics.image.ppm
 import java.io.InputStream
 
 import scala.annotation.tailrec
+import scala.collection.compat._
 
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.image._

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageReader.scala
@@ -2,8 +2,6 @@ package eu.joaocosta.minart.graphics.image.qoi
 
 import java.io.InputStream
 
-import scala.collection.compat.immutable.LazyList
-
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.image._
 import eu.joaocosta.minart.internal._

--- a/pure/shared/src/main/scala/eu/joaocosta/minart/audio/pure/AudioPlayerIOOps.scala
+++ b/pure/shared/src/main/scala/eu/joaocosta/minart/audio/pure/AudioPlayerIOOps.scala
@@ -1,7 +1,6 @@
 package eu.joaocosta.minart.audio.pure
 
 import eu.joaocosta.minart.audio._
-import eu.joaocosta.minart.input._
 import eu.joaocosta.minart.runtime.pure._
 
 /** Representation of an audio player operation, with the common Monad operations.

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioFormat.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioFormat.scala
@@ -1,6 +1,5 @@
 package eu.joaocosta.minart.audio.sound.aiff
 
-import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.internal._
 
 /** Audio format AIFF files.

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioReader.scala
@@ -2,10 +2,6 @@ package eu.joaocosta.minart.audio.sound.aiff
 
 import java.io.InputStream
 
-import scala.annotation.tailrec
-import scala.io.Source
-import scala.math.BigDecimal.apply
-
 import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.audio.sound._
 import eu.joaocosta.minart.internal._

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/qoa/QoaAudioFormat.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/qoa/QoaAudioFormat.scala
@@ -1,6 +1,5 @@
 package eu.joaocosta.minart.audio.sound.qoa
 
-import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.internal._
 
 /** Audio format QOA files.

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/qoa/QoaAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/qoa/QoaAudioReader.scala
@@ -3,8 +3,6 @@ package eu.joaocosta.minart.audio.sound.qoa
 import java.io.InputStream
 
 import scala.annotation.tailrec
-import scala.io.Source
-import scala.math.BigDecimal.apply
 
 import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.audio.sound._

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioReader.scala
@@ -2,6 +2,8 @@ package eu.joaocosta.minart.audio.sound.rtttl
 
 import java.io.InputStream
 
+import scala.collection.compat._
+
 import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.audio.sound._
 import eu.joaocosta.minart.internal._

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioReader.scala
@@ -2,11 +2,6 @@ package eu.joaocosta.minart.audio.sound.rtttl
 
 import java.io.InputStream
 
-import scala.annotation.tailrec
-import scala.collection.compat._
-import scala.io.Source
-import scala.util.Try
-
 import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.audio.sound._
 import eu.joaocosta.minart.internal._

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioFormat.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioFormat.scala
@@ -1,6 +1,5 @@
 package eu.joaocosta.minart.audio.sound.wav
 
-import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.internal._
 
 /** Audio format WAV files.

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioReader.scala
@@ -2,10 +2,6 @@ package eu.joaocosta.minart.audio.sound.wav
 
 import java.io.InputStream
 
-import scala.annotation.tailrec
-import scala.io.Source
-import scala.math.BigDecimal.apply
-
 import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.audio.sound._
 import eu.joaocosta.minart.internal._


### PR DESCRIPTION
Removes the scalafix organize-imports dependency (it's included in scalafix 0.11.0).

Also removes unused imports (I haven't done that in a while)