### PR TITLE
Add AudioWave.mix/AudioClip.mix operations

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
@@ -134,6 +134,15 @@ object AudioClip {
     AudioWave.fromIndexedSeq(data, sampleRate).take(duration)
   }
 
+  /** Generates an audio clip by mixing a sequence of clips.
+    *
+    *  The duration is defined by the smallest clip.
+    *
+    * @param clips clips to mix
+    */
+  def mix(clips: Seq[AudioClip]): AudioClip =
+    AudioWave.mix(clips.map(_.wave)).take(clips.map(_.duration).minOption.getOrElse(0))
+
   private def floorMod(x: Double, y: Double): Double = {
     val rem = x % y
     if (rem >= 0) rem

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
@@ -141,7 +141,8 @@ object AudioClip {
     * @param clips clips to mix
     */
   def mix(clips: Seq[AudioClip]): AudioClip =
-    AudioWave.mix(clips.map(_.wave)).take(clips.map(_.duration).minOption.getOrElse(0))
+    if (clips.isEmpty) AudioClip.empty
+    else AudioWave.mix(clips.map(_.wave)).take(clips.map(_.duration).min)
 
   private def floorMod(x: Double, y: Double): Double = {
     val rem = x % y

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
@@ -107,4 +107,21 @@ object AudioWave {
     * @param sampleRate sample rate used in the sequence
     */
   def fromIndexedSeq(data: IndexedSeq[Double], sampleRate: Double): AudioWave = new SampledAudioWave(data, sampleRate)
+
+  /** Generates an audio wave by mixing a sequence of waves.
+    *
+    * @param waves waves to mix
+    */
+  def mix(waves: Seq[AudioWave]): AudioWave = new AudioWave {
+    private val waveArray = waves.toArray
+    def getAmplitude(t: Double): Double = {
+      var res: Double = 0.0
+      var i: Int      = 0
+      while (i < waveArray.size) {
+        res += waveArray(i).getAmplitude(t)
+        i += 1
+      }
+      math.max(-1.0, math.min(res, 1.0))
+    }
+  }
 }

--- a/core/shared/src/test/scala/eu/joaocosta/minart/audio/AudioClipSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/audio/AudioClipSpec.scala
@@ -51,4 +51,17 @@ object AudioClipSpec extends BasicTestSuite {
     val clipA = AudioClip(x => x / 2.0, 2.0)
     assert(clipA.repeating(5).duration == 10.0)
   }
+
+  test("The mix operation combines multiple clips") {
+    val clipA = AudioClip(x => x / 4.0, 2.0)
+    val clipB = AudioClip(x => x / 8.0, 3.0)
+
+    val newClip = AudioClip.mix(List(clipA, clipB))
+    assert(newClip.duration == 2.0)
+    assert(
+      Sampler
+        .sampleClip(newClip, 1)
+        .toList == Sampler.sampleClip(clipA, 1).zip(Sampler.sampleClip(clipB, 1)).map { case (x, y) => x + y }.toList
+    )
+  }
 }


### PR DESCRIPTION
Adds new `AudioWave.mix` and `AudioClip.mix` operations.

Those can be quite useful when mixing multiple clips, to avoid a huge chain of `zipWith`