### PR TITLE
Replace scala.math with java.lang.Math

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
@@ -25,10 +25,10 @@ final class ImageDataSurface(val data: ImageData) extends MutableSurface {
   }
 
   def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
-    val _x = math.max(x, 0)
-    val _y = math.max(y, 0)
-    val _w = math.min(w, width - _x)
-    val _h = math.min(h, height - _y)
+    val _x = Math.max(x, 0)
+    val _y = Math.max(y, 0)
+    val _w = Math.min(w, width - _x)
+    val _h = Math.min(h, height - _y)
     var yy = 0
     while (yy < _h) {
       val start = (yy + _y) * width + _x

--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsAudioPlayer.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsAudioPlayer.scala
@@ -27,7 +27,7 @@ class JsAudioPlayer() extends LowLevelAudioPlayer {
   private val callback: (Double) => () => Unit = (startTime: Double) =>
     () => {
       if (playQueue.nonEmpty()) {
-        val batchSize   = math.min(settings.bufferSize, playQueue.size)
+        val batchSize   = Math.min(settings.bufferSize, playQueue.size)
         val duration    = batchSize.toDouble / settings.sampleRate
         val audioSource = audioCtx.createBufferSource()
         val buffer      = audioCtx.createBuffer(1, batchSize, settings.sampleRate)
@@ -37,7 +37,7 @@ class JsAudioPlayer() extends LowLevelAudioPlayer {
         }
         audioSource.buffer = buffer
         audioSource.connect(audioCtx.destination)
-        val clampedStart = math.max(audioCtx.currentTime, startTime)
+        val clampedStart = Math.max(audioCtx.currentTime, startTime)
         audioSource.start(clampedStart)
         val nextTarget    = clampedStart + duration
         val sleepDuration = 1000 * (nextTarget - audioCtx.currentTime) - preemptiveCallback

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
@@ -25,10 +25,10 @@ final class BufferedImageSurface(val bufferedImage: BufferedImage) extends Mutab
   }
 
   def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
-    val _x = math.max(x, 0)
-    val _y = math.max(y, 0)
-    val _w = math.min(w, width - _x)
-    val _h = math.min(h, height - _y)
+    val _x = Math.max(x, 0)
+    val _y = Math.max(y, 0)
+    val _w = Math.min(w, width - _x)
+    val _h = Math.min(h, height - _y)
     var yy = 0
     while (yy < _h) {
       val lineBase = (yy + _y) * width

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaAudioPlayer.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaAudioPlayer.scala
@@ -35,11 +35,11 @@ class JavaAudioPlayer() extends LowLevelAudioPlayer {
     while (playQueue.nonEmpty()) {
       val available = sourceDataLine.available()
       if (available > 0) {
-        val samples = math.min(playQueue.size, available / 2)
+        val samples = Math.min(playQueue.size, available / 2)
         val buf = Iterator
           .fill(samples) {
             val next  = playQueue.dequeue()
-            val short = (math.min(math.max(-1.0, next), 1.0) * Short.MaxValue).toInt
+            val short = (Math.min(Math.max(-1.0, next), 1.0) * Short.MaxValue).toInt
             List((short & 0xff).toByte, ((short >> 8) & 0xff).toByte)
           }
           .flatten
@@ -47,7 +47,7 @@ class JavaAudioPlayer() extends LowLevelAudioPlayer {
         sourceDataLine.write(buf, 0, samples * 2)
         val bufferedMillis = (1000 * samples) / settings.sampleRate
         blocking {
-          Thread.sleep(math.max(0, bufferedMillis - preemptiveCallback))
+          Thread.sleep(Math.max(0, bufferedMillis - preemptiveCallback))
         }
       }
     }

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlAudioPlayer.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlAudioPlayer.scala
@@ -57,11 +57,11 @@ class SdlAudioPlayer() extends LowLevelAudioPlayer {
       if (
         System.currentTimeMillis() > nextSchedule && SDL_GetQueuedAudioSize(device).toInt < (settings.bufferSize * 2)
       ) {
-        val samples = scala.math.min(settings.bufferSize, playQueue.size)
+        val samples = Math.min(settings.bufferSize, playQueue.size)
         val buf = Iterator
           .fill(samples) {
             val next  = playQueue.dequeue()
-            val short = (scala.math.min(scala.math.max(-1.0, next), 1.0) * Short.MaxValue).toInt
+            val short = (Math.min(Math.max(-1.0, next), 1.0) * Short.MaxValue).toInt
             List((short & 0xff).toByte, ((short >> 8) & 0xff).toByte)
           }
           .flatten

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
@@ -31,10 +31,10 @@ final class SdlSurface(val data: Ptr[SDL_Surface]) extends MutableSurface with A
   }
 
   def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
-    val _x = math.max(x, 0)
-    val _y = math.max(y, 0)
-    val _w = math.min(w, width - _x)
-    val _h = math.min(h, height - _y)
+    val _x = Math.max(x, 0)
+    val _y = Math.max(y, 0)
+    val _w = Math.min(w, width - _x)
+    val _h = Math.min(h, height - _y)
     SDL_SetRenderDrawColor(renderer, color.r.toUByte, color.g.toUByte, color.b.toUByte, 0.toUByte)
     val rect = stackalloc[SDL_Rect]().init(_x, _y, _w, _h)
     SDL_RenderFillRect(renderer, rect)

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
@@ -30,14 +30,14 @@ final case class AudioClip(
   /** Returns a new Audio Clip with the first `time` seconds of this audio clip
     */
   def take(time: Double): AudioClip = {
-    val newDuration = math.max(0.0, math.min(time, duration))
+    val newDuration = Math.max(0.0, Math.min(time, duration))
     AudioClip(wave, newDuration)
   }
 
   /** Returns a new Audio Clip without the first `time` seconds of this audio clip
     */
   def drop(time: Double): AudioClip = {
-    val delta = math.max(0.0, math.min(time, duration))
+    val delta = Math.max(0.0, Math.min(time, duration))
     AudioClip(wave.drop(delta), duration - delta)
   }
 
@@ -57,7 +57,7 @@ final case class AudioClip(
   /** Combines this clip with another by combining their values using the given function.
     */
   def zipWith(that: AudioClip, f: (Double, Double) => Double): AudioClip = {
-    val newDuration = math.min(this.duration, that.duration)
+    val newDuration = Math.min(this.duration, that.duration)
     AudioClip(this.wave.zipWith(that.wave, f), newDuration)
   }
 
@@ -151,5 +151,5 @@ object AudioClip {
   }
 
   private def clamp(minValue: Double, value: Double, maxValue: Double): Double =
-    math.max(0, math.min(value, maxValue))
+    Math.max(0, Math.min(value, maxValue))
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioQueue.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioQueue.scala
@@ -14,7 +14,7 @@ sealed trait AudioQueue {
   def enqueue(clip: AudioClip): this.type
   def dequeue(): Double
   def dequeueByte(): Byte = {
-    (math.min(math.max(-1.0, dequeue()), 1.0) * 127).toByte
+    (Math.min(Math.max(-1.0, dequeue()), 1.0) * 127).toByte
   }
   def clear(): this.type
 }
@@ -82,7 +82,7 @@ object AudioQueue {
       this
     }
     def dequeue(): Double = synchronized {
-      math.max(-1.0, math.min(channels.values.map(_.dequeue()).sum, 1.0))
+      Math.max(-1.0, Math.min(channels.values.map(_.dequeue()).sum, 1.0))
     }
 
     def clear(): this.type = synchronized {

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioWave.scala
@@ -121,7 +121,7 @@ object AudioWave {
         res += waveArray(i).getAmplitude(t)
         i += 1
       }
-      math.max(-1.0, math.min(res, 1.0))
+      Math.max(-1.0, Math.min(res, 1.0))
     }
   }
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/Oscillator.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/Oscillator.scala
@@ -54,12 +54,12 @@ object Oscillator {
   /** Sin wave oscillator */
   val sin: Oscillator =
     Oscillator { frequency =>
-      val k = frequency * 2 * math.Pi
-      AudioWave.fromFunction(t => math.sin(k * t))
+      val k = frequency * 2 * Math.PI
+      AudioWave.fromFunction(t => Math.sin(k * t))
     }
 
   /** Square wave oscilator */
-  val square: Oscillator = sin.map(math.signum)
+  val square: Oscillator = sin.map(Math.signum)
 
   private def floorMod(x: Double, y: Double): Double = {
     val rem = x % y

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Blitter.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Blitter.scala
@@ -110,8 +110,8 @@ private[graphics] object Blitter {
     else if (cx < 0) fullBlit(dest, source, mask, x - cx, y, 0, cy, cw + cx, ch)
     else if (cy < 0) fullBlit(dest, source, mask, x, y - cy, cx, 0, cw, ch + cy)
     else {
-      val maxX = math.min(cw, math.min(source.width - cx, dest.width - x))
-      val maxY = math.min(ch, math.min(source.height - cy, dest.height - y))
+      val maxX = Math.min(cw, Math.min(source.width - cx, dest.width - x))
+      val maxY = Math.min(ch, Math.min(source.height - cy, dest.height - y))
 
       if (maxX > 0 && maxY > 0) {
         source match {

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Color.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Color.scala
@@ -26,9 +26,9 @@ final class Color private (val argb: Int) {
     */
   def +(that: Color): Color =
     Color(
-      math.min(this.r + that.r, 255).toInt,
-      math.min(this.g + that.g, 255).toInt,
-      math.min(this.b + that.b, 255).toInt
+      Math.min(this.r + that.r, 255).toInt,
+      Math.min(this.g + that.g, 255).toInt,
+      Math.min(this.b + that.b, 255).toInt
     )
 
   /** Combines this with another color by subtracting each RGB value.
@@ -36,9 +36,9 @@ final class Color private (val argb: Int) {
     */
   def -(that: Color): Color =
     Color(
-      math.max(this.r - that.r, 0).toInt,
-      math.max(this.g - that.g, 0).toInt,
-      math.max(this.b - that.b, 0).toInt
+      Math.max(this.r - that.r, 0).toInt,
+      Math.max(this.g - that.g, 0).toInt,
+      Math.max(this.b - that.b, 0).toInt
     )
 
   /** Combines this with another color by multiplying each RGB value (on the [0.0, 1.0] range).

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/LowLevelCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/LowLevelCanvas.scala
@@ -37,7 +37,7 @@ object LowLevelCanvas {
       case _ =>
         val wScale = windowWidth / settings.width
         val hScale = windowHeight / settings.height
-        math.max(1, math.min(wScale, hScale))
+        Math.max(1, Math.min(wScale, hScale))
     }
     val scaledWidth  = settings.width * scale
     val scaledHeight = settings.height * scale

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -121,8 +121,8 @@ trait Plane extends Function2[Int, Int, Color] { outer =>
 
   /** Rotates a plane by a certain angle (clockwise). */
   def rotate(theta: Double): Plane = {
-    val ct = math.cos(-theta)
-    val st = math.sin(-theta)
+    val ct = Math.cos(-theta)
+    val st = Math.sin(-theta)
     contramapMatrix(Matrix(ct, -st, 0, st, ct, 0))
   }
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
@@ -22,10 +22,10 @@ final class RamSurface(val dataBuffer: Vector[Array[Color]]) extends MutableSurf
   def unsafePutPixel(x: Int, y: Int, color: Color): Unit = dataBuffer(y)(x) = color
 
   def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
-    val _x = math.max(x, 0)
-    val _y = math.max(y, 0)
-    val _w = math.min(w, width - _x)
-    val _h = math.min(h, height - _y)
+    val _x = Math.max(x, 0)
+    val _y = Math.max(y, 0)
+    val _w = Math.min(w, width - _x)
+    val _h = Math.min(h, height - _y)
     var yy = 0
     while (yy < _h) {
       var xx   = 0

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -26,8 +26,8 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
     plane
       .zipWith(that, f)
       .copy(
-        width = math.min(that.width, width),
-        height = math.min(that.height, height)
+        width = Math.min(that.width, width),
+        height = Math.min(that.height, height)
       )
 
   /** Combines this view with a plane by combining their colors with the given function. */
@@ -52,8 +52,8 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
     * @param ch clip height
     */
   def clip(cx: Int, cy: Int, cw: Int, ch: Int): SurfaceView = {
-    val newWidth  = math.min(cw, this.width - cx)
-    val newHeight = math.min(ch, this.height - cy)
+    val newWidth  = Math.min(cw, this.width - cx)
+    val newHeight = Math.min(ch, this.height - cy)
     if (cx == 0 && cy == 0 && newWidth == width && newHeight == height) this
     else plane.clip(cx, cy, newWidth, newHeight)
   }
@@ -124,7 +124,7 @@ object SurfaceView {
     else rem + y
   }
   private def clamp(minValue: Int, value: Int, maxValue: Int): Int =
-    math.max(0, math.min(value, maxValue))
+    Math.max(0, Math.min(value, maxValue))
 
   /** Generates a surface view from a surface */
   def apply(surface: Surface): SurfaceView =

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
@@ -184,7 +184,7 @@ object PlaneSpec extends BasicTestSuite {
   test("Rotate moves all pixels clockwise") {
     val original =
       surface.view.repeating
-    val transformed = original.rotate(math.Pi / 2)
+    val transformed = original.rotate(Math.PI / 2)
     assert(original(0, 0) == transformed(0, 0))
     assert(original(5, 3) == transformed(-3, 5))
   }

--- a/examples/snapshot/03-fire-animation.sc
+++ b/examples/snapshot/03-fire-animation.sc
@@ -25,7 +25,7 @@ val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = Some(4))
 def automata(backbuffer: Vector[Array[Color]], x: Int, y: Int): Color = {
   // For each pixel, we fetch the colors 3 pixels below (SW, S, SE)
   val neighbors =
-    (math.max(0, x - 1) to math.min(x + 1, canvasSettings.width - 1)).toList.map { xx =>
+    (Math.max(0, x - 1) to Math.min(x + 1, canvasSettings.width - 1)).toList.map { xx =>
       backbuffer(y + 1)(xx)
     }
   // We compute some random loss
@@ -36,7 +36,7 @@ def automata(backbuffer: Vector[Array[Color]], x: Int, y: Int): Color = {
 
   // Then we generate a nice yelow-red tint based on the temperature
   Color(
-    math.min(255, temperature * 1.6).toInt,
+    Math.min(255, temperature * 1.6).toInt,
     (temperature * 0.8).toInt,
     (temperature * 0.6).toInt
   )
@@ -63,7 +63,7 @@ AppLoop
     for {
       x <- (0 until canvas.width)
       y <- (0 until canvas.height)
-      dist = math.pow(x - canvas.width / 2, 2) + math.pow(y - canvas.height / 2, 2)
+      dist = Math.pow(x - canvas.width / 2, 2) + Math.pow(y - canvas.height / 2, 2)
     } {
       if (dist > 25 && dist <= 100) canvas.putPixel(x, y, Color(255, 255, 255))
     }

--- a/examples/snapshot/05-snake-game.sc
+++ b/examples/snapshot/05-snake-game.sc
@@ -59,7 +59,7 @@ final case class GameState(
       else snakeSize
     val newBoard = board
         .updated(snakeHead.y, board(snakeHead.y).updated(snakeHead.x, snakeSize))
-        .map(_.map(life => math.max(0, life - 1)))
+        .map(_.map(life => Math.max(0, life - 1)))
     copy(
       board = newBoard,
       snakeHead = Position(mod(snakeHead.x + snakeDir.x, boardWidth), mod(snakeHead.y + snakeDir.y, boardHeight)),

--- a/examples/snapshot/10-surface-view.sc
+++ b/examples/snapshot/10-surface-view.sc
@@ -43,8 +43,8 @@ val updatedBitmap = bitmap.view
 AppLoop
   .statefulRenderLoop((t: Double) =>
     (canvas: Canvas) => {
-      val frameSin = math.sin(t)
-      val frameCos = math.cos(t)
+      val frameSin = Math.sin(t)
+      val frameCos = Math.cos(t)
       val zoom     = 1.0 / (frameSin + 2.0)
       val convolutionWindow = for {
         x <- (-1 to 1)
@@ -61,7 +61,7 @@ AppLoop
             }
         }
         .rotate(t)                                                        // Rotate
-        .contramap((x, y) => (x + (5 * math.sin(t + y / 10.0)).toInt, y)) // Wobbly effect
+        .contramap((x, y) => (x + (5 * Math.sin(t + y / 10.0)).toInt, y)) // Wobbly effect
         .flatMap(color =>
           (x, y) => // Add a crazy checkerboard effect
             if (x % 32 < 16 != y % 32 < 16) color.invert

--- a/examples/snapshot/11-audio.sc
+++ b/examples/snapshot/11-audio.sc
@@ -21,12 +21,12 @@ object Audio {
       else if (t < 0.5) 4          // C#
       else if (t < 0.7) 7          // E
       else 12                      // A
-    math.pow(2, note / 12.0) * 440 // Convert the notes to frequencies (equal temperament)
+    Math.pow(2, note / 12.0) * 440 // Convert the notes to frequencies (equal temperament)
   }
 
   // Here we generate a sin wave with the frequencies from our song
   val arpeggio: AudioClip =
-    AudioWave.fromFunction((t: Double) => math.sin(song(t) * 6.28 * t)).take(1.0)
+    AudioWave.fromFunction((t: Double) => Math.sin(song(t) * 6.28 * t)).take(1.0)
 
   // We can also use the provided oscilators
   val bass =

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioWriter.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioWriter.scala
@@ -27,12 +27,12 @@ trait AiffAudioWriter[ByteSeq] extends AudioClipWriter {
 
   private def convertSample(x: Double): List[Int] = bitRate match {
     case 8 =>
-      List(java.lang.Byte.toUnsignedInt((math.min(math.max(-1.0, x), 1.0) * Byte.MaxValue).toByte))
+      List(java.lang.Byte.toUnsignedInt((Math.min(Math.max(-1.0, x), 1.0) * Byte.MaxValue).toByte))
     case 16 =>
-      val short = (math.min(math.max(-1.0, x), 1.0) * Short.MaxValue).toInt
+      val short = (Math.min(Math.max(-1.0, x), 1.0) * Short.MaxValue).toInt
       List((short >> 8) & 0xff, short & 0xff)
     case 32 =>
-      val int = (math.min(math.max(-1.0, x), 1.0) * Int.MaxValue).toInt
+      val int = (Math.min(Math.max(-1.0, x), 1.0) * Int.MaxValue).toInt
       List((int >> 24) & 0xff, (int >> 16) & 0xff, (int >> 8) & 0xff, int & 0xff)
   }
 

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/qoa/QoaAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/qoa/QoaAudioReader.scala
@@ -27,13 +27,13 @@ trait QoaAudioReader[ByteSeq] extends AudioClipReader {
     residuals match {
       case Nil => (state, acc.reverse)
       case r :: rs =>
-        val sample = math.min(math.max(Short.MinValue, state.prediction + r), Short.MaxValue).toShort
+        val sample = Math.min(Math.max(Short.MinValue, state.prediction + r), Short.MaxValue).toShort
         predict(rs, state.update(sample, r), sample :: acc)
     }
 
   private def loadSlice(state: QoaState): ParseState[String, (QoaState, List[Short])] = readBytes(8).map { bytes =>
     val sfQuant          = (bytes(0) & 0xf0) >> 4
-    val dequantizedScale = math.round(math.pow(sfQuant + 1, 2.75))
+    val dequantizedScale = Math.round(Math.pow(sfQuant + 1, 2.75))
     val longResiduals =
       (bytes(0) & 0x0f).toLong << (8 * 7) |
         (bytes(1) & 0xff).toLong << (8 * 6) |
@@ -49,7 +49,7 @@ trait QoaAudioReader[ByteSeq] extends AudioClipReader {
     }
     val scaledResiduals = dequantizedResiduals.map { res =>
       val scaled = dequantizedScale * res
-      (if (scaled < 0) math.ceil(scaled - 0.5) else math.floor(scaled + 0.5)).toInt
+      (if (scaled < 0) Math.ceil(scaled - 0.5) else Math.floor(scaled + 0.5)).toInt
     }
     predict(scaledResiduals, state)
   }
@@ -94,7 +94,7 @@ trait QoaAudioReader[ByteSeq] extends AudioClipReader {
           s => s"Sample rate changed mid file. Expected $sampleRate, got $s"
         )
         samples <- readBENumber(2)
-        numSlices = math.min(math.ceil(samples / 20.0).toInt, 256)
+        numSlices = Math.min(Math.ceil(samples / 20.0).toInt, 256)
         frameSize <- readBENumber(2)
         state     <- loadState
         slices    <- loadSlices(state, numSlices)
@@ -113,7 +113,7 @@ trait QoaAudioReader[ByteSeq] extends AudioClipReader {
     val bytes = fromInputStream(is)
     (for {
       samples <- loadQoaHeader
-      frames = math.ceil(samples / (256.0 * 20)).toInt
+      frames = Math.ceil(samples / (256.0 * 20)).toInt
       clip <- loadFrames(frames)
     } yield clip).run(bytes).map(_._2)
   }

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioReader.scala
@@ -107,7 +107,7 @@ object RtttlAudioReader {
       case None => 0.0
       case Some(n) =>
         val a1 = 55
-        math.pow(2, (octave - 1) + n / 12.0) * 55
+        Math.pow(2, (octave - 1) + n / 12.0) * 55
     }
   }
 

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioWriter.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioWriter.scala
@@ -24,12 +24,12 @@ trait WavAudioWriter[ByteSeq] extends AudioClipWriter {
 
   private def convertSample(x: Double): List[Int] = bitRate match {
     case 8 =>
-      List((math.min(math.max(-1.0, x), 1.0) * Byte.MaxValue).toInt + 127)
+      List((Math.min(Math.max(-1.0, x), 1.0) * Byte.MaxValue).toInt + 127)
     case 16 =>
-      val short = (math.min(math.max(-1.0, x), 1.0) * Short.MaxValue).toInt
+      val short = (Math.min(Math.max(-1.0, x), 1.0) * Short.MaxValue).toInt
       List(short & 0xff, (short >> 8) & 0xff)
     case 32 =>
-      val int = (math.min(math.max(-1.0, x), 1.0) * Int.MaxValue).toInt
+      val int = (Math.min(Math.max(-1.0, x), 1.0) * Int.MaxValue).toInt
       List(int & 0xff, (int >> 8) & 0xff, (int >> 16) & 0xff, (int >> 24) & 0xff)
   }
 

--- a/sound/shared/src/test/scala/eu/joaocosta/minart/audio/sound/AudioClipWriterSpec.scala
+++ b/sound/shared/src/test/scala/eu/joaocosta/minart/audio/sound/AudioClipWriterSpec.scala
@@ -20,7 +20,7 @@ object AudioClipWriterSpec extends BasicTestSuite {
     } yield (originalWave, loadedWave)).toOption.get
 
     assert(oldWave.size == newWave.size)
-    assert(oldWave.zip(newWave).forall { case (oldS, newS) => math.abs(oldS - newS) <= 1 })
+    assert(oldWave.zip(newWave).forall { case (oldS, newS) => Math.abs(oldS - newS) <= 1 })
   }
 
   // Can't load resources in JS tests


### PR DESCRIPTION
Close #397 

I did some benchmarks with the surface view example (since it has blitting with clipping and rotation) and didn't actually see any difference.
Still, I guess it doesn't hurt to change it, the code stays pretty much the same.