### PR TITLE
Add busy waiting to the JavaLoopRunner

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsLoopRunner.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsLoopRunner.scala
@@ -25,8 +25,8 @@ object JsLoopRunner extends LoopRunner {
         new NeverLoop(operation).run(initialState)
       case LoopFrequency.Uncapped =>
         new UncappedLoop(operation, terminateWhen, cleanup).run(initialState)
-      case LoopFrequency.LoopDuration(iterationMillis) =>
-        new CappedLoop(operation, terminateWhen, iterationMillis, cleanup).run(initialState)
+      case freq @ LoopFrequency.LoopDuration(_) =>
+        new CappedLoop(operation, terminateWhen, freq.millis, cleanup).run(initialState)
     }
   }
 

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlLoopRunner.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlLoopRunner.scala
@@ -25,8 +25,8 @@ object SdlLoopRunner extends LoopRunner {
         new NeverLoop(operation, cleanup).run(initialState)
       case LoopFrequency.Uncapped =>
         new UncappedLoop(operation, terminateWhen, cleanup).run(initialState)
-      case LoopFrequency.LoopDuration(iterationMillis) =>
-        new CappedLoop(operation, terminateWhen, iterationMillis, cleanup).run(initialState)
+      case freq @ LoopFrequency.LoopDuration(_) =>
+        new CappedLoop(operation, terminateWhen, freq.millis, cleanup).run(initialState)
     }
   }
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/LoopFrequency.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/LoopFrequency.scala
@@ -16,9 +16,10 @@ object LoopFrequency {
 
   /** Frequency defined by duration.
     *
-    * @param millis duration in millis
+    * @param nanos duration in nanoseconds
     */
-  final case class LoopDuration(millis: Long) extends LoopFrequency {
+  final case class LoopDuration(nanos: Long) extends LoopFrequency {
+    val millis                     = nanos / 1000000
     def toDuration: FiniteDuration = millis.milliseconds
   }
 
@@ -61,6 +62,6 @@ object LoopFrequency {
   def fromHz(hz: Int): LoopFrequency = {
     if (hz <= 0) Never
     else if (1000 / hz == 0) Uncapped
-    else LoopDuration(1000 / hz)
+    else LoopDuration(1000000000 / hz)
   }
 }


### PR DESCRIPTION
I noticed some very inconsistent frame rates on some examples (~40 FPS with a 60 FPS limit, ~90 FPS with no limit).

I think there's something wrong with the `Thread.sleep` precision, so this PR adds up to 10ms of busy loop to the `JavaLoopRunner`.

This value was from trial and error. I also tried an adaptive solution, but it didn't seem to work too well.

Surprisingly, I didn't see a huge increase in CPU usage.