### PR TITLE
Add Plane#overlay and SurfaceView#overlay

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/BlendMode.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/BlendMode.scala
@@ -1,7 +1,18 @@
 package eu.joaocosta.minart.graphics
 
-/** Blend strategy to be used by the blitter */
-sealed trait BlendMode {
+/** Blend strategy to be used to combine two colors
+  *
+  * Note that while this trait is unsealed, backends can provide opimized implementations
+  * for the default blend modes.
+  * As such, those should always be prefered to custom ones.
+  */
+trait BlendMode {
+
+  /** Blends two colors
+    *
+    * @param src the color to overlay
+    * @param dst the color to blend into
+    */
   def blend(src: => Color, dst: => Color): Color
 }
 object BlendMode {

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/BlendMode.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/BlendMode.scala
@@ -1,20 +1,45 @@
 package eu.joaocosta.minart.graphics
 
 /** Blend strategy to be used by the blitter */
-sealed trait BlendMode
+sealed trait BlendMode {
+  def blend(src: => Color, dst: => Color): Color
+}
 object BlendMode {
 
   /** Simply copy the pixel values */
-  case object Copy extends BlendMode
+  case object Copy extends BlendMode {
+    def blend(src: => Color, dst: => Color): Color =
+      src
+  }
 
   /** Copy all pixels except the ones with the same value as the mask */
-  final case class ColorMask(mask: Color) extends BlendMode
+  final case class ColorMask(mask: Color) extends BlendMode {
+    def blend(src: => Color, dst: => Color): Color = {
+      val colorSource = src
+      if (colorSource != mask) src else dst
+    }
+  }
 
   /** Copy all pixels with alpha greater than the provided value */
-  final case class AlphaTest(alpha: Int) extends BlendMode
+  final case class AlphaTest(alpha: Int) extends BlendMode {
+    def blend(src: => Color, dst: => Color): Color = {
+      val colorSource = src
+      if (colorSource.a > alpha) src else dst
+    }
+  }
 
   /** Blends the surfaces using weighted adition: dstColor * (1-srcAlpha) + srcColor
     *  This behaves as normal alpha blending if the source uses premultiplied alpha.
     */
-  case object AlphaAdd extends BlendMode
+  case object AlphaAdd extends BlendMode {
+    def blend(src: => Color, dst: => Color): Color = {
+      val colorSource = src
+      val colorDest   = dst
+      Color(
+        Math.min((colorDest.r * (255 - colorSource.a)) / 255 + colorSource.r, 255),
+        Math.min((colorDest.g * (255 - colorSource.a)) / 255 + colorSource.g, 255),
+        Math.min((colorDest.b * (255 - colorSource.a)) / 255 + colorSource.b, 255)
+      )
+    }
+  }
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Blitter.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Blitter.scala
@@ -77,6 +77,19 @@ private[graphics] object Blitter {
           }
           dy += 1
         }
+      case blendMode => // Custom BlendMode
+        while (dy < maxY) {
+          val srcY  = dy + cy
+          val destY = dy + y
+          var dx    = 0
+          while (dx < maxX) {
+            val destX = dx + x
+            val color = blendMode.blend(source.unsafeGetPixel(dx + cx, srcY), dest.unsafeGetPixel(destX, destY))
+            dest.unsafePutPixel(destX, destY, color)
+            dx += 1
+          }
+          dy += 1
+        }
     }
   }
 
@@ -150,6 +163,20 @@ private[graphics] object Blitter {
               Math.min((colorDest.g * (255 - colorSource.a)) / 255 + colorSource.g, 255),
               Math.min((colorDest.b * (255 - colorSource.a)) / 255 + colorSource.b, 255)
             )
+            dest.unsafePutPixel(destX, destY, color)
+            dx += 1
+          }
+          dy += 1
+        }
+      case blendMode => // Custom BlendMode
+        while (dy < maxY) {
+          val srcY  = dy + cy
+          val destY = dy + y
+          val line  = source(srcY)
+          var dx    = 0
+          while (dx < maxX) {
+            val destX = dx + x
+            val color = blendMode.blend(line(dx + cx), dest.unsafeGetPixel(destX, destY))
             dest.unsafePutPixel(destX, destY, color)
             dx += 1
           }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -77,6 +77,25 @@ trait Plane extends Function2[Int, Int, Color] { outer =>
         }
       }.toSurfaceView(cw, ch)
 
+  /** Overlays a surface on top of this plane.
+    *
+    * Similar to MutableSurface#blit, but for surface views and planes.
+    *
+    * @param that surface to overlay
+    * @param blendMode blend strategy to use
+    * @param x leftmost pixel on the destination plane
+    * @param y topmost pixel on the destination plane
+    */
+  final def overlay(that: Surface, blendMode: BlendMode = BlendMode.Copy)(x: Int, y: Int): Plane =
+    new Plane {
+      def getPixel(dx: Int, dy: Int): Color = {
+        if (dx >= x && dx < x + that.width && dy >= y && dy < y + that.height)
+          blendMode.blend(that.unsafeGetPixel(dx - x, dy - y), outer.getPixel(dx, dy))
+        else
+          outer.getPixel(dx, dy)
+      }
+    }
+
   /** Inverts a plane color. */
   def invertColor: Plane = map(_.invert)
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -58,6 +58,18 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
     else plane.clip(cx, cy, newWidth, newHeight)
   }
 
+  /** Overlays a surface on top of this view.
+    *
+    * Similar to MutableSurface#blit, but for surface views.
+    *
+    * @param that surface to overlay
+    * @param blendMode blend strategy to use
+    * @param x leftmost pixel on the destination plane
+    * @param y topmost pixel on the destination plane
+    */
+  final def overlay(that: Surface, blendMode: BlendMode = BlendMode.Copy)(x: Int, y: Int): SurfaceView =
+    copy(plane = plane.overlay(that, blendMode)(x, y))
+
   /** Inverts a surface color. */
   def invertColor: SurfaceView = map(_.invert)
 

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
@@ -133,6 +133,18 @@ object PlaneSpec extends BasicTestSuite {
     assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
   }
 
+  test("Overlay combines a plane and a surface") {
+    val plane =
+      surface.view.repeating
+    val newPlane =
+      plane.overlay(surface)(2, 2)
+
+    assert(newPlane(0, 0) == surface.unsafeGetPixel(0, 0))
+    assert(newPlane(1, 1) == surface.unsafeGetPixel(1, 1))
+    assert(newPlane(2, 2) == surface.unsafeGetPixel(0, 0))
+    assert(newPlane(3, 3) == surface.unsafeGetPixel(1, 1))
+  }
+
   test("Inverting the color updates all colors with the inverse") {
     assert(Plane.fromConstant(Color(110, 120, 130)).invertColor(100, 100) == Color(110, 120, 130).invert)
   }

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/SurfaceViewSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/SurfaceViewSpec.scala
@@ -93,6 +93,22 @@ object SurfaceViewSpec extends BasicTestSuite {
     assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
   }
 
+  test("Overlay combines two surfaces") {
+    val newSurface =
+      surface.view.overlay(surface)(2, 2).toRamSurface()
+
+    val newPixels = newSurface.getPixels()
+    val expectedPixels =
+      originalPixels.take(2) ++
+        originalPixels.drop(2).zip(originalPixels).map { case (oldLine, newLine) =>
+          oldLine.take(2) ++ newLine.dropRight(2)
+        }
+
+    assert(newSurface.width == surface.width)
+    assert(newSurface.height == surface.height)
+    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+  }
+
   test("FlipH mirrors the surface horizontally") {
     val newSurface =
       surface.view.flipH.toRamSurface()


### PR DESCRIPTION
Adds a `overlay` operation to both `Plane`s and `SurfaceView`s that is similar to `MutableSurface#blit`.

Unlike `blit`, this method does not take clipping coordinates (if one is already working with views, it's better to just use the `clip` operation).

This PR also adds support for custom `BlendMode`s. While those might not be optimized in the backend, it's still a useful feature.