### PR TITLE
Remove Scala 2 support

### DIFF
--- a/.github/workflows/compile_test.yml
+++ b/.github/workflows/compile_test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        scala: ["2.12", "2.13", "3.3"]
+        scala: ["3.3"]
         platform: [JVM, JS, Native]
 
     env:

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -12,7 +12,7 @@ import java.awt.image.BufferedImage
 import java.awt.{Canvas => JavaCanvas, Color => JavaColor, Dimension, Graphics, GraphicsEnvironment, MouseInfo}
 import javax.swing.{JFrame, WindowConstants}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import eu.joaocosta.minart.graphics.LowLevelCanvas.ExtendedSettings
 import eu.joaocosta.minart.graphics._

--- a/build.sbt
+++ b/build.sbt
@@ -3,12 +3,11 @@ import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
 name := "minart"
 
-ThisBuild / organization       := "eu.joaocosta"
-ThisBuild / publishTo          := sonatypePublishToBundle.value
-ThisBuild / scalaVersion       := "3.3.0"
-ThisBuild / crossScalaVersions := Seq("2.12.18", "2.13.11", "3.3.0")
-ThisBuild / licenses           := Seq("MIT License" -> url("http://opensource.org/licenses/MIT"))
-ThisBuild / homepage           := Some(url("https://github.com/JD557/minart"))
+ThisBuild / organization := "eu.joaocosta"
+ThisBuild / publishTo    := sonatypePublishToBundle.value
+ThisBuild / scalaVersion := "3.3.0"
+ThisBuild / licenses     := Seq("MIT License" -> url("http://opensource.org/licenses/MIT"))
+ThisBuild / homepage     := Some(url("https://github.com/JD557/minart"))
 ThisBuild / scmInfo := Some(
   ScmInfo(
     url("https://github.com/JD557/minart"),
@@ -30,32 +29,21 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 ThisBuild / scalafixOnCompile := true
 
 val siteSettings = Seq(
-  Compile / doc / scalacOptions ++= (
-    if (scalaBinaryVersion.value.startsWith("3"))
-      Seq("-siteroot", "docs")
-    else Seq()
-  )
+  Compile / doc / scalacOptions ++= Seq("-siteroot", "docs")
 )
 
 def docSettings(projectName: String) = Seq(
-  Compile / doc / scalacOptions ++= (
-    if (scalaBinaryVersion.value.startsWith("3"))
-      Seq(
-        "-project",
-        projectName,
-        "-project-version",
-        version.value,
-        "-social-links:" +
-          "github::https://github.com/JD557/Minart"
-      )
-    else Seq()
+  Compile / doc / scalacOptions ++= Seq(
+    "-project",
+    projectName,
+    "-project-version",
+    version.value,
+    "-social-links:" +
+      "github::https://github.com/JD557/Minart"
   )
 )
 
-val sharedSettings = Seq(
-  libraryDependencies ++=
-    Seq("org.scala-lang.modules" %%% "scala-collection-compat" % "2.11.0")
-)
+val sharedSettings = Seq()
 
 val testSettings = Seq(
   libraryDependencies ++= Seq(
@@ -73,8 +61,7 @@ val publishSettings = Seq(
 
 val jsSettings = Seq(
   libraryDependencies ++= Seq(
-    "org.scala-lang.modules" %%% "scala-collection-compat" % "2.11.0",
-    "org.scala-js"           %%% "scalajs-dom"             % "2.6.0"
+    "org.scala-js" %%% "scalajs-dom" % "2.6.0"
   )
 )
 
@@ -156,7 +143,7 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  releaseStepCommandAndRemaining("+publishSigned"),
+  releaseStepCommandAndRemaining("publishSigned"),
   releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
   commitNextVersion,

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioQueue.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioQueue.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.audio
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /** Internal AudioQueue abstraction.
   *

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
@@ -3,7 +3,6 @@ package eu.joaocosta.minart.graphics.image.ppm
 import java.io.InputStream
 
 import scala.annotation.tailrec
-import scala.collection.compat._
 
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.graphics.image._

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioReader.scala
@@ -2,8 +2,6 @@ package eu.joaocosta.minart.audio.sound.rtttl
 
 import java.io.InputStream
 
-import scala.collection.compat._
-
 import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.audio.sound._
 import eu.joaocosta.minart.internal._


### PR DESCRIPTION
Experimental change for 0.6.0

Removes Scala 2 support.

Main reasons:
- Some performance optimizations can only be implemented in Scala 3
- Depending on scala-collections-compat makes some tasks (e.g. experimenting with Scala-native 0.5.0-SNAPSHOT) cumbersome
- Warnings cannot be fatal due to deprecation warnings required for Scala 2 support
- I don't have the capacity to test changes in Scala 2 and check for performance regressions (all my tests are in Scala 3)
- The main reason to support Scala 2 was notebook support (e.g. Polynote), but with the advent of Scala-cli and some of it's new features, I don't think this is so important