### PR TITLE
Use munit instead of verify

### DIFF
--- a/backend/jvm/src/test/scala/eu/joaocosta/minart/graphics/BufferedImageSurfaceSpec.scala
+++ b/backend/jvm/src/test/scala/eu/joaocosta/minart/graphics/BufferedImageSurfaceSpec.scala
@@ -4,7 +4,7 @@ import java.awt.image.BufferedImage
 
 import eu.joaocosta.minart.backend._
 
-object BufferedImageSurfaceSpec extends MutableSurfaceTests {
+class BufferedImageSurfaceSpec extends MutableSurfaceTests {
   lazy val image   = new BufferedImage(64, 48, BufferedImage.TYPE_INT_ARGB)
   lazy val surface = new BufferedImageSurface(image)
 

--- a/backend/native/src/test/scala/eu/joaocosta/minart/graphics/SdlSurfaceSpec.scala
+++ b/backend/native/src/test/scala/eu/joaocosta/minart/graphics/SdlSurfaceSpec.scala
@@ -6,7 +6,7 @@ import sdl2.SDL._
 
 import eu.joaocosta.minart.backend._
 
-object SdlImageSurfaceSpec extends MutableSurfaceTests {
+class SdlImageSurfaceSpec extends MutableSurfaceTests {
   lazy val surface = new SdlSurface(
     SDL_CreateRGBSurface(
       0.toUInt,

--- a/backend/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/backend/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -1,8 +1,6 @@
 package eu.joaocosta.minart.graphics
 
-import verify._
-
-trait MutableSurfaceTests extends BasicTestSuite {
+trait MutableSurfaceTests extends munit.FunSuite {
 
   def surface: MutableSurface
 

--- a/backend/shared/src/test/scala/eu/joaocosta/minart/runtime/AppLoopSpec.scala
+++ b/backend/shared/src/test/scala/eu/joaocosta/minart/runtime/AppLoopSpec.scala
@@ -2,15 +2,13 @@ package eu.joaocosta.minart.runtime
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import verify._
-
 import eu.joaocosta.minart.backend._
 import eu.joaocosta.minart.backend.defaults._
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.input._
 import eu.joaocosta.minart.runtime._
 
-object AppLoopLoopSpec extends BasicTestSuite {
+class AppLoopSpec extends munit.FunSuite {
 
   object TestCanvas extends SurfaceBackedCanvas {
     protected var surface: RamSurface = _
@@ -28,28 +26,31 @@ object AppLoopLoopSpec extends BasicTestSuite {
     def getPointerInput(): PointerInput   = PointerInput.empty
   }
 
-  testAsync("Have a statefulRenderLoop operation that ends when a certain state is reached") {
-    var renderCount: Int = 0
-    AppLoop
-      .statefulRenderLoop(
-        renderFrame = (state: Int) =>
-          (canvas: Canvas) => {
-            renderCount += 1
-            state + 1
-          },
-        terminateWhen = (state: Int) => state >= 5
-      )
-      .configure(
-        initialSettings = Canvas.Settings(4, 4),
-        frameRate = LoopFrequency.Uncapped,
-        initialState = 0
-      )
-      .run(
-        runner = LoopRunner(),
-        createSubsystems = () => TestCanvas
-      )
-      .map { _ =>
-        assert(renderCount == 5)
-      }
+  // See https://github.com/scala-native/scala-native/issues/3464
+  if (Platform() != Platform.Native) {
+    test("Have a statefulRenderLoop operation that ends when a certain state is reached") {
+      var renderCount: Int = 0
+      AppLoop
+        .statefulRenderLoop(
+          renderFrame = (state: Int) =>
+            (canvas: Canvas) => {
+              renderCount += 1
+              state + 1
+            },
+          terminateWhen = (state: Int) => state >= 5
+        )
+        .configure(
+          initialSettings = Canvas.Settings(4, 4),
+          frameRate = LoopFrequency.Uncapped,
+          initialState = 0
+        )
+        .run(
+          runner = LoopRunner(),
+          createSubsystems = () => TestCanvas
+        )
+        .map { _ =>
+          assert(renderCount == 5)
+        }
+    }
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -47,9 +47,9 @@ val sharedSettings = Seq()
 
 val testSettings = Seq(
   libraryDependencies ++= Seq(
-    "com.eed3si9n.verify" %%% "verify" % "1.0.0" % Test
+    "org.scalameta" %%% "munit" % "1.0.0-M8" % Test
   ),
-  testFrameworks += new TestFramework("verify.runner.Framework"),
+  testFrameworks += new TestFramework("munit.Framework"),
   Test / scalacOptions ++= Seq("-Yrangepos")
 )
 

--- a/core/shared/src/test/scala/eu/joaocosta/minart/audio/AudioClipSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/audio/AudioClipSpec.scala
@@ -1,8 +1,6 @@
 package eu.joaocosta.minart.audio
 
-import verify._
-
-object AudioClipSpec extends BasicTestSuite {
+class AudioClipSpec extends munit.FunSuite {
 
   test("An audio clip is correctly sampled") {
     val clip = AudioClip(x => x / 2.0, 2.0)

--- a/core/shared/src/test/scala/eu/joaocosta/minart/audio/AudioQueueSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/audio/AudioQueueSpec.scala
@@ -1,8 +1,6 @@
 package eu.joaocosta.minart.audio
 
-import verify._
-
-object AudioQueueSpec extends BasicTestSuite {
+class AudioQueueSpec extends munit.FunSuite {
 
   test("An empty single channel audio queue returns 0") {
     val queue = new AudioQueue.SingleChannelAudioQueue(1)

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/ColorSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/ColorSpec.scala
@@ -2,9 +2,7 @@ package eu.joaocosta.minart.graphics
 
 import scala.util.Random
 
-import verify._
-
-object ColorSpec extends BasicTestSuite {
+class ColorSpec extends munit.FunSuite {
 
   test("Can be created from RGB values") {
     val colorInt  = Color(110, 120, 130)

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MatrixSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MatrixSpec.scala
@@ -2,9 +2,7 @@ package eu.joaocosta.minart.graphics
 
 import scala.util.Random
 
-import verify._
-
-object MatrixSpec extends BasicTestSuite {
+class MatrixSpec extends munit.FunSuite {
 
   test("Can be applied") {
     // [1 2 3] [3] = [10] (1*3 + 2*2 + 3*1)

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -1,8 +1,6 @@
 package eu.joaocosta.minart.graphics
 
-import verify._
-
-trait MutableSurfaceTests extends BasicTestSuite {
+trait MutableSurfaceTests extends munit.FunSuite {
 
   def surface: MutableSurface
 

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
@@ -2,9 +2,7 @@ package eu.joaocosta.minart.graphics
 
 import scala.util.Random
 
-import verify._
-
-object PlaneSpec extends BasicTestSuite {
+class PlaneSpec extends munit.FunSuite {
 
   lazy val surface = new RamSurface(
     Vector.fill(16)(Array.fill(8)(Color(Random.nextInt(255), Random.nextInt(255), Random.nextInt(255))))

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/RamSurfaceSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/RamSurfaceSpec.scala
@@ -1,5 +1,5 @@
 package eu.joaocosta.minart.graphics
 
-object RamSurfaceSpec extends MutableSurfaceTests {
+class RamSurfaceSpec extends MutableSurfaceTests {
   lazy val surface = new RamSurface(48, 64, Color(0, 0, 0))
 }

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/SurfaceViewSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/SurfaceViewSpec.scala
@@ -2,9 +2,7 @@ package eu.joaocosta.minart.graphics
 
 import scala.util.Random
 
-import verify._
-
-object SurfaceViewSpec extends BasicTestSuite {
+class SurfaceViewSpec extends munit.FunSuite {
 
   lazy val surface = new RamSurface(
     Vector.fill(16)(Array.fill(8)(Color(Random.nextInt(255), Random.nextInt(255), Random.nextInt(255))))

--- a/core/shared/src/test/scala/eu/joaocosta/minart/input/KeyboardInputSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/input/KeyboardInputSpec.scala
@@ -1,8 +1,6 @@
 package eu.joaocosta.minart.input
 
-import verify._
-
-object KeyboardInputSpec extends BasicTestSuite {
+class KeyboardInputSpec extends munit.FunSuite {
 
   test("Correctly captures key presses and releases") {
     val input = KeyboardInput.empty

--- a/core/shared/src/test/scala/eu/joaocosta/minart/input/PointerInputSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/input/PointerInputSpec.scala
@@ -1,8 +1,6 @@
 package eu.joaocosta.minart.input
 
-import verify._
-
-object PointerInputSpec extends BasicTestSuite {
+class PointerInputSpec extends munit.FunSuite {
 
   test("Correctly captures pointer presses and releases") {
     val input = PointerInput.empty

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageReaderSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageReaderSpec.scala
@@ -2,13 +2,11 @@ package eu.joaocosta.minart.graphics.image
 
 import scala.util.Try
 
-import verify._
-
 import eu.joaocosta.minart.backend.defaults._
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.runtime._
 
-object ImageReaderSpec extends BasicTestSuite {
+class ImageReaderSpec extends munit.FunSuite {
 
   def sameImage(results: List[RamSurface]): Unit = {
     results.sliding(2).foreach {

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageWriterSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageWriterSpec.scala
@@ -2,12 +2,10 @@ package eu.joaocosta.minart.graphics.image
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
-import verify._
-
 import eu.joaocosta.minart.backend.defaults._
 import eu.joaocosta.minart.runtime._
 
-object ImageWriterSpec extends BasicTestSuite {
+class ImageWriterSpec extends munit.FunSuite {
 
   def roundtripTest(baseResource: Resource, imageFormat: ImageReader with ImageWriter) = {
     val (oldPixels, newPixels) = (for {

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/SpriteSheetSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/SpriteSheetSpec.scala
@@ -1,10 +1,8 @@
 package eu.joaocosta.minart.graphics.image
 
-import verify._
-
 import eu.joaocosta.minart.graphics._
 
-object SpriteSheetSpec extends BasicTestSuite {
+class SpriteSheetSpec extends munit.FunSuite {
   val surface = new RamSurface(
     List(
       List(Color(255, 0, 0), Color(0, 255, 0), Color(0, 0, 255)),

--- a/sound/shared/src/test/scala/eu/joaocosta/minart/audio/sound/AudioClipReaderSpec.scala
+++ b/sound/shared/src/test/scala/eu/joaocosta/minart/audio/sound/AudioClipReaderSpec.scala
@@ -2,13 +2,11 @@ package eu.joaocosta.minart.audio.sound
 
 import scala.util.Try
 
-import verify._
-
 import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.backend.defaults._
 import eu.joaocosta.minart.runtime._
 
-object AudioClipReaderSpec extends BasicTestSuite {
+class AudioClipReaderSpec extends munit.FunSuite {
 
   def approx(x: Double, y: Double, epsilon: Double = 0.01): Boolean =
     x >= y - epsilon && x <= y + epsilon

--- a/sound/shared/src/test/scala/eu/joaocosta/minart/audio/sound/AudioClipWriterSpec.scala
+++ b/sound/shared/src/test/scala/eu/joaocosta/minart/audio/sound/AudioClipWriterSpec.scala
@@ -2,13 +2,11 @@ package eu.joaocosta.minart.audio.sound
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
-import verify._
-
 import eu.joaocosta.minart.audio.Sampler
 import eu.joaocosta.minart.backend.defaults._
 import eu.joaocosta.minart.runtime._
 
-object AudioClipWriterSpec extends BasicTestSuite {
+class AudioClipWriterSpec extends munit.FunSuite {
 
   def roundtripTest(baseResource: Resource, audioClipFormat: AudioClipReader with AudioClipWriter) = {
     val (oldWave, newWave) = (for {


### PR DESCRIPTION
Migrates the tests to munit.

Done mostly to avoid https://github.com/lampepfl/dotty/issues/18460, but also to use the same dependencies in Minart and InterIm.

Some tests are currently disabled due to https://github.com/scala-native/scala-native/issues/3464, but it's easier for me to fix them later.