### PR TITLE
Make Color an opaque type

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,6 @@
 version = 3.7.12
 
-runner.dialect = "scala213"
+runner.dialect = "scala3"
 align.preset = more
 docstrings.wrap = no
 maxColumn = 120

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Color.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Color.scala
@@ -1,231 +1,225 @@
 package eu.joaocosta.minart.graphics
 
-/** Representation of a RGB Color.
-  * @param argb this color packed as a 32 bit integer in ARGB.
-  */
-final class Color private (val argb: Int) {
-
-  /** The alpha channel value. */
-  @inline def a: Int = (argb >> 24) & 0x000000ff
-
-  /** The red channel value. */
-  @inline def r: Int = (argb >> 16) & 0x000000ff
-
-  /** The green channel value. */
-  @inline def g: Int = (argb >> 8) & 0x000000ff
-
-  /** The green channel value. */
-  @inline def b: Int = (argb & 0x000000ff)
-
-  /** This color packed as a 24 bit integer in RGB (with the first byte set to 0). */
-  @inline def rgb: Int = (argb & 0x00ffffff)
-
-  /** This color packed as a 32 bit integer in ABGR. */
-  @inline def abgr: Int =
-    (argb & 0xff00ff00) | (b << 16) | r
-
-  /** Combines this with another color by summing each RGB value.
-    * Values are clamped on overflow.
-    *
-    * The resulting alpha is set to 255.
-    */
-  def +(that: Color): Color =
-    Color(
-      Math.min(this.r + that.r, 255).toInt,
-      Math.min(this.g + that.g, 255).toInt,
-      Math.min(this.b + that.b, 255).toInt
-    )
-
-  /** Combines this with another color by summing each RGB value.
-    * Values are clamped on overflow.
-    *
-    * The alpha of the left-side argument is kept.
-    */
-  def :+(that: Color): Color =
-    Color(
-      Math.min(this.r + that.r, 255).toInt,
-      Math.min(this.g + that.g, 255).toInt,
-      Math.min(this.b + that.b, 255).toInt,
-      this.a
-    )
-
-  /** Combines this with another color by summing each RGB value.
-    * Values are clamped on overflow.
-    *
-    * The alpha of the right-side argument is kept.
-    */
-  def +:(that: Color): Color =
-    Color(
-      Math.min(this.r + that.r, 255).toInt,
-      Math.min(this.g + that.g, 255).toInt,
-      Math.min(this.b + that.b, 255).toInt,
-      this.a
-    )
-
-  /** Combines this with another color by subtracting each RGB value.
-    * Values are clamped on underflow.
-    *
-    * The resulting alpha is set to 255.
-    */
-  def -(that: Color): Color =
-    Color(
-      Math.max(this.r - that.r, 0).toInt,
-      Math.max(this.g - that.g, 0).toInt,
-      Math.max(this.b - that.b, 0).toInt
-    )
-
-  /** Combines this with another color by subtracting each RGB value.
-    * Values are clamped on underflow.
-    *
-    * The alpha of the left-side argument is kept.
-    */
-  def :-(that: Color): Color =
-    Color(
-      Math.max(this.r - that.r, 0).toInt,
-      Math.max(this.g - that.g, 0).toInt,
-      Math.max(this.b - that.b, 0).toInt,
-      this.a
-    )
-
-  /** Combines this with another color by subtracting each RGB value.
-    * Values are clamped on underflow.
-    *
-    * The alpha of the right-side argument is kept.
-    */
-  def -:(that: Color): Color =
-    Color(
-      Math.max(this.r - that.r, 0).toInt,
-      Math.max(this.g - that.g, 0).toInt,
-      Math.max(this.b - that.b, 0).toInt,
-      this.a
-    )
-
-  /** Combines this with another color by multiplying each RGB value (on the [0.0, 1.0] range).
-    * Values are clamped on overflow.
-    *
-    * The resulting alpha is set to 255.
-    */
-  def *(that: Color): Color =
-    Color(
-      (this.r * that.r) / 255,
-      (this.g * that.g) / 255,
-      (this.b * that.b) / 255
-    )
-
-  /** Combines this with another color by multiplying each RGB value (on the [0.0, 1.0] range).
-    * Values are clamped on overflow.
-    *
-    * The alpha of the left-side argument is kept.
-    */
-  def :*(that: Color): Color =
-    Color(
-      (this.r * that.r) / 255,
-      (this.g * that.g) / 255,
-      (this.b * that.b) / 255,
-      this.a
-    )
-
-  /** Combines this with another color by multiplying each RGB value (on the [0.0, 1.0] range).
-    * Values are clamped on overflow.
-    *
-    * The alpha of the right-side argument is kept.
-    */
-  def *:(that: Color): Color =
-    Color(
-      (this.r * that.r) / 255,
-      (this.g * that.g) / 255,
-      (this.b * that.b) / 255,
-      this.a
-    )
-
-  /** Inverts this color by inverting every RGB channel.
-    *
-    *  The alpha is preserved
-    */
-  def invert: Color = Color(255 - r, 255 - g, 255 - b, a)
-
-  /** Multiplies all channels by the alpha.
-    */
-  def premultiplyAlpha: Color =
-    this :* Color.grayscale(a)
-
-  def copy(r: Int = this.r, g: Int = this.g, b: Int = this.b, a: Int = this.a) =
-    Color(r, g, b, a)
-
-  override def toString: String =
-    if (a == 255) s"Color($r,$g,$b)"
-    else s"Color($r,$g,$b,$a)"
-  override def hashCode(): Int = argb.hashCode()
-  override def equals(that: Any): Boolean =
-    (that.isInstanceOf[Color] && this.argb == that.asInstanceOf[Color].argb)
-}
+/** Representation of a RGB Color. */
+opaque type Color = Int
 
 object Color {
+  extension (color: Color) {
+
+    /** The alpha channel value. */
+    inline def a: Int = (color >> 24) & 0x000000ff
+
+    /** The red channel value. */
+    inline def r: Int = (color >> 16) & 0x000000ff
+
+    /** The green channel value. */
+    inline def g: Int = (color >> 8) & 0x000000ff
+
+    /** The green channel value. */
+    inline def b: Int = (color & 0x000000ff)
+
+    /** This color packed as a 24 bit integer in RGB (with the first byte set to 0). */
+    inline def rgb: Int = (color & 0x00ffffff)
+
+    /** this color packed as a 32 bit integer in ARGB. */
+    inline def argb: Int = color
+
+    /** This color packed as a 32 bit integer in ABGR. */
+    inline def abgr: Int =
+      (color & 0xff00ff00) | (b << 16) | r
+
+    /** Combines this with another color by summing each RGB value.
+      * Values are clamped on overflow.
+      *
+      * The resulting alpha is set to 255.
+      */
+    def +(that: Color): Color =
+      Color(
+        Math.min(color.r + that.r, 255).toInt,
+        Math.min(color.g + that.g, 255).toInt,
+        Math.min(color.b + that.b, 255).toInt
+      )
+
+    /** Combines this with another color by summing each RGB value.
+      * Values are clamped on overflow.
+      *
+      * The alpha of the left-side argument is kept.
+      */
+    def :+(that: Color): Color =
+      Color(
+        Math.min(color.r + that.r, 255).toInt,
+        Math.min(color.g + that.g, 255).toInt,
+        Math.min(color.b + that.b, 255).toInt,
+        color.a
+      )
+
+    /** Combines this with another color by summing each RGB value.
+      * Values are clamped on overflow.
+      *
+      * The alpha of the right-side argument is kept.
+      */
+    def +:(that: Color): Color =
+      Color(
+        Math.min(color.r + that.r, 255).toInt,
+        Math.min(color.g + that.g, 255).toInt,
+        Math.min(color.b + that.b, 255).toInt,
+        that.a
+      )
+
+    /** Combines this with another color by subtracting each RGB value.
+      * Values are clamped on underflow.
+      *
+      * The resulting alpha is set to 255.
+      */
+    def -(that: Color): Color =
+      Color(
+        Math.max(color.r - that.r, 0).toInt,
+        Math.max(color.g - that.g, 0).toInt,
+        Math.max(color.b - that.b, 0).toInt
+      )
+
+    /** Combines this with another color by subtracting each RGB value.
+      * Values are clamped on underflow.
+      *
+      * The alpha of the left-side argument is kept.
+      */
+    def :-(that: Color): Color =
+      Color(
+        Math.max(color.r - that.r, 0).toInt,
+        Math.max(color.g - that.g, 0).toInt,
+        Math.max(color.b - that.b, 0).toInt,
+        color.a
+      )
+
+    /** Combines this with another color by subtracting each RGB value.
+      * Values are clamped on underflow.
+      *
+      * The alpha of the right-side argument is kept.
+      */
+    def -:(that: Color): Color =
+      Color(
+        Math.max(color.r - that.r, 0).toInt,
+        Math.max(color.g - that.g, 0).toInt,
+        Math.max(color.b - that.b, 0).toInt,
+        that.a
+      )
+
+    /** Combines this with another color by multiplying each RGB value (on the [0.0, 1.0] range).
+      * Values are clamped on overflow.
+      *
+      * The resulting alpha is set to 255.
+      */
+    def *(that: Color): Color =
+      Color(
+        (color.r * that.r) / 255,
+        (color.g * that.g) / 255,
+        (color.b * that.b) / 255
+      )
+
+    /** Combines this with another color by multiplying each RGB value (on the [0.0, 1.0] range).
+      * Values are clamped on overflow.
+      *
+      * The alpha of the left-side argument is kept.
+      */
+    def :*(that: Color): Color =
+      Color(
+        (color.r * that.r) / 255,
+        (color.g * that.g) / 255,
+        (color.b * that.b) / 255,
+        color.a
+      )
+
+    /** Combines this with another color by multiplying each RGB value (on the [0.0, 1.0] range).
+      * Values are clamped on overflow.
+      *
+      * The alpha of the right-side argument is kept.
+      */
+    def *:(that: Color): Color =
+      Color(
+        (color.r * that.r) / 255,
+        (color.g * that.g) / 255,
+        (color.b * that.b) / 255,
+        that.a
+      )
+
+    /** Inverts this color by inverting every RGB channel.
+      *
+      *  The alpha is preserved
+      */
+    def invert: Color = Color(255 - r, 255 - g, 255 - b, a)
+
+    /** Multiplies all channels by the alpha.
+      */
+    def premultiplyAlpha: Color =
+      color :* Color.grayscale(a)
+
+    def copy(r: Int = color.r, g: Int = color.g, b: Int = color.b, a: Int = color.a) =
+      Color(r, g, b, a)
+
+    def toString: String =
+      if (a == 255) s"Color($r,$g,$b)"
+      else s"Color($r,$g,$b,$a)"
+  }
 
   /** Creates a new color from RGB values (on the [0-255] range).
     *  Overflow/Underflow will wrap around.
     */
   def apply(r: Int, g: Int, b: Int): Color =
-    new Color((255 << 24) | ((r & 255) << 16) | ((g & 255) << 8) | (b & 255))
+    (255 << 24) | ((r & 255) << 16) | ((g & 255) << 8) | (b & 255)
 
   /** Creates a new color from RGBA values (on the [0-255] range).
     *  Overflow/Underflow will wrap around.
     */
   def apply(r: Int, g: Int, b: Int, a: Int): Color =
-    new Color((a << 24) | ((r & 255) << 16) | ((g & 255) << 8) | (b & 255))
+    (a << 24) | ((r & 255) << 16) | ((g & 255) << 8) | (b & 255)
 
   /** Creates a new color from RGB values (assuming unsinged bytes on the [0-255] range).
     */
   def apply(r: Byte, g: Byte, b: Byte): Color =
-    new Color((255 << 24) | ((r & 255) << 16) | ((g & 255) << 8) | (b & 255))
+    (255 << 24) | ((r & 255) << 16) | ((g & 255) << 8) | (b & 255)
 
   /** Creates a new color from RGBA values (assuming unsinged bytes on the [0-255] range).
     */
   def apply(r: Byte, g: Byte, b: Byte, a: Byte): Color =
-    new Color(((a & 255) << 24) | ((r & 255) << 16) | ((g & 255) << 8) | (b & 255))
+    ((a & 255) << 24) | ((r & 255) << 16) | ((g & 255) << 8) | (b & 255)
 
   /** Creates a new color from a grayscale value (on the [0-255] range).
     * Overflow/Underflow will wrap around.
     */
   def grayscale(gray: Int): Color =
-    new Color((255 << 24) | ((gray & 255) << 16) | ((gray & 255) << 8) | (gray & 255))
+    (255 << 24) | ((gray & 255) << 16) | ((gray & 255) << 8) | (gray & 255)
 
   /** Creates a new color from a grayscale value (assuming unsigned bytes on the [0-255] range).
     */
   def grayscale(gray: Byte): Color =
-    new Color((255 << 24) | ((gray & 255) << 16) | ((gray & 255) << 8) | (gray & 255))
+    (255 << 24) | ((gray & 255) << 16) | ((gray & 255) << 8) | (gray & 255)
 
   /** Creates a new color from a 24bit backed RGB integer.
     * Ignores the first byte of a 32bit number.
     */
-  @inline def fromRGB(rgb: Int): Color =
-    new Color(0xff000000 | rgb)
+  inline def fromRGB(rgb: Int): Color =
+    0xff000000 | rgb
 
   /** Creates a new color from a 32bit backed ARGB integer.
     */
-  @inline def fromARGB(argb: Int): Color =
-    new Color(argb)
+  inline def fromARGB(argb: Int): Color = argb
 
   /** Creates a new color from a 24bit backed BGR integer.
     * Ignores the first byte of a 32bit number.
     */
-  @inline def fromBGR(bgr: Int): Color =
-    new Color(
-      0xff000000 |
-        ((bgr & 0x00ff0000) >> 16) |
-        (bgr & 0x0000ff00) |
-        ((bgr & 0x000000ff)) << 16
-    )
+  inline def fromBGR(bgr: Int): Color =
+    0xff000000 |
+      ((bgr & 0x00ff0000) >> 16) |
+      (bgr & 0x0000ff00) |
+      ((bgr & 0x000000ff)) << 16
 
   /** Creates a new color from a 32bit backed ABGR integer.
     */
-  @inline def fromABGR(abgr: Int): Color =
-    new Color(
-      (abgr & 0xff000000) |
-        ((abgr & 0x00ff0000) >> 16) |
-        (abgr & 0x0000ff00) |
-        ((abgr & 0x000000ff)) << 16
-    )
+  inline def fromABGR(abgr: Int): Color =
+    (abgr & 0xff000000) |
+      ((abgr & 0x00ff0000) >> 16) |
+      (abgr & 0x0000ff00) |
+      ((abgr & 0x000000ff)) << 16
 
   /** Extracts the RGB channels of a color.
     */


### PR DESCRIPTION
Makes `Color` an opaque type to avoid allocations.

I did some quick benchmarks and this looks like an improvement on all backends.
It's a bit hard to quantify how this will impact real apps, but at least this doesn't appear to introduce any regression.