### PR TITLE
Disable blending on Canvas surfaces

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
@@ -18,7 +18,7 @@ class HtmlCanvas(parentNode: => dom.Node = dom.document.body) extends SurfaceBac
   private[this] var jsCanvas: JsCanvas                = _
   private[this] var ctx: dom.CanvasRenderingContext2D = _
   private[this] var childNode: dom.Node               = _
-  protected var surface: ImageDataSurface             = _
+  protected var surface: ImageDataOpaqueSurface       = _
 
   // Input resources
 
@@ -109,7 +109,7 @@ class HtmlCanvas(parentNode: => dom.Node = dom.document.body) extends SurfaceBac
       if (newSettings.fullScreen)
         s"display:flex;justify-content:center;align-items:center;background:$clearColorStr;"
       else ""
-    surface = new ImageDataSurface(ctx.getImageData(0, 0, newSettings.width, newSettings.height))
+    surface = new ImageDataOpaqueSurface(ctx.getImageData(0, 0, newSettings.width, newSettings.height))
 
     if (oldSettings.fullScreen != newSettings.fullScreen) {
       if (newSettings.fullScreen) {

--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataOpaqueSurface.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataOpaqueSurface.scala
@@ -1,0 +1,39 @@
+package eu.joaocosta.minart.backend
+
+import scala.scalajs.js.typedarray._
+
+import org.scalajs.dom.ImageData
+
+import eu.joaocosta.minart.graphics.{Color, MutableSurface}
+
+/** A mutable surface backed by an ImageData that drops the alpha channel when puting pixels.
+  *
+  *  @param imageData imageData that backs this surface
+  */
+final class ImageDataOpaqueSurface(val data: ImageData) extends MutableSurface {
+
+  val width: Int         = data.width
+  val height: Int        = data.height
+  private val dataBuffer = new Int32Array(data.data.asInstanceOf[Uint8ClampedArray].buffer)
+
+  def unsafeGetPixel(x: Int, y: Int): Color = Color.fromBGR(dataBuffer(y * width + x))
+
+  def unsafePutPixel(x: Int, y: Int, color: Color): Unit = dataBuffer(y * width + x) = color.abgr | 0xff000000
+
+  override def fill(color: Color): Unit = {
+    dataBuffer.fill(color.abgr | 0xff000000)
+  }
+
+  def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
+    val _x = Math.max(x, 0)
+    val _y = Math.max(y, 0)
+    val _w = Math.min(w, width - _x)
+    val _h = Math.min(h, height - _y)
+    var yy = 0
+    while (yy < _h) {
+      val start = (yy + _y) * width + _x
+      dataBuffer.fill(color.abgr | 0xff000000, start, start + _w)
+      yy += 1
+    }
+  }
+}

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -9,7 +9,16 @@ import java.awt.event.{
   WindowEvent
 }
 import java.awt.image.BufferedImage
-import java.awt.{Canvas => JavaCanvas, Color => JavaColor, Dimension, Graphics, GraphicsEnvironment, MouseInfo}
+import java.awt.{
+  AlphaComposite,
+  Canvas => JavaCanvas,
+  Color => JavaColor,
+  Dimension,
+  Graphics,
+  Graphics2D,
+  GraphicsEnvironment,
+  MouseInfo
+}
 import javax.swing.{JFrame, WindowConstants}
 
 import scala.jdk.CollectionConverters._
@@ -62,7 +71,7 @@ class AwtCanvas() extends SurfaceBackedCanvas {
 
   protected def unsafeApplySettings(newSettings: Canvas.Settings): LowLevelCanvas.ExtendedSettings = {
     val extendedSettings = LowLevelCanvas.ExtendedSettings(newSettings)
-    val image            = new BufferedImage(newSettings.width, newSettings.height, BufferedImage.TYPE_INT_ARGB)
+    val image            = new BufferedImage(newSettings.width, newSettings.height, BufferedImage.TYPE_INT_RGB)
     surface = new BufferedImageSurface(image)
     if (javaCanvas != null) javaCanvas.frame.dispose()
     javaCanvas = new AwtCanvas.InnerCanvas(

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -89,6 +89,7 @@ class SdlCanvas() extends SurfaceBackedCanvas {
       )
     }
     windowSurface = SDL_GetWindowSurface(window)
+    SDL_SetSurfaceBlendMode(windowSurface, SDL_BLENDMODE_NONE)
     surface = new SdlSurface(
       SDL_CreateRGBSurface(
         0.toUInt,
@@ -101,6 +102,7 @@ class SdlCanvas() extends SurfaceBackedCanvas {
         0xff000000.toUInt
       )
     )
+    SDL_SetSurfaceBlendMode(surface.data, SDL_BLENDMODE_NONE)
     val fullExtendedSettings = extendedSettings.copy(
       windowWidth = windowSurface.w,
       windowHeight = windowSurface.h

--- a/backend/native/src/main/scala/sdl2/SDL.scala
+++ b/backend/native/src/main/scala/sdl2/SDL.scala
@@ -483,6 +483,7 @@ object SDL {
       dst: Ptr[SDL_Surface],
       dstrect: Ptr[SDL_Rect]
   ): Int = extern
+  def SDL_SetSurfaceBlendMode(surface: Ptr[SDL_Surface], blendMode: SDL_BlendMode): Int = extern
 
   /** ************************************
     * *********** SDL_render.h *************


### PR DESCRIPTION
Disables the blending in Canvas surfaces.

While putting non-opaque pixels in the Canvas is considered undefined behavior, the backends differed too much, with very weird results.
This should not only be more consistent, but probably also faster.