### PR TITLE
Make AllSubsystems a cake

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/AllSubsystems.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/AllSubsystems.scala
@@ -6,17 +6,6 @@ import eu.joaocosta.minart.input._
 
 /** Internal object with an intersection of all subsystems.
   */
-private[minart] class AllSubsystems(canvas: LowLevelCanvas, audioPlayer: LowLevelAudioPlayer)
-    extends LowLevelSubsystem.Composite[Canvas.Settings, AudioPlayer.Settings, LowLevelCanvas, LowLevelAudioPlayer](
-      canvas,
-      audioPlayer
-    )
-    with Canvas
-    with AudioPlayer {
-
-  private val _canvas: Canvas = canvas // Export only Canvas methods
-  export _canvas.*
-
-  private val _audioPlayer: AudioPlayer = audioPlayer // Export only AudioPlayer methods
-  export _audioPlayer.*
-}
+private[minart] class AllSubsystems(_canvas: LowLevelCanvas, _audioPlayer: LowLevelAudioPlayer)
+    extends CanvasSubsystem(_canvas)
+    with AudioPlayerSubsystem(_audioPlayer)

--- a/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/AudioPlayerSubsystem.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/AudioPlayerSubsystem.scala
@@ -1,0 +1,7 @@
+package eu.joaocosta.minart.backend.subsystem
+
+import eu.joaocosta.minart.audio.AudioPlayer
+
+/** Subsystem cake with an AudioPlayer
+  */
+trait AudioPlayerSubsystem(val audioPlayer: AudioPlayer)

--- a/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/CanvasSubsystem.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/CanvasSubsystem.scala
@@ -1,0 +1,7 @@
+package eu.joaocosta.minart.backend.subsystem
+
+import eu.joaocosta.minart.graphics.Canvas
+
+/** Subsystem cake with a Canvas
+  */
+trait CanvasSubsystem(val canvas: Canvas)

--- a/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/LowLevelAllSubsystems.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/LowLevelAllSubsystems.scala
@@ -1,0 +1,38 @@
+package eu.joaocosta.minart.backend.subsystem
+
+import eu.joaocosta.minart.audio._
+import eu.joaocosta.minart.backend.defaults.DefaultBackend
+import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.input._
+
+/** Aggregation of all subsystems.
+  */
+case class LowLevelAllSubsystems(
+    lowLevelCanvas: LowLevelCanvas,
+    lowLevelAudioPlayer: LowLevelAudioPlayer
+) extends AllSubsystems(lowLevelCanvas, lowLevelAudioPlayer)
+    with LowLevelSubsystem[(Canvas.Settings, AudioPlayer.Settings)] {
+  def settings: (Canvas.Settings, AudioPlayer.Settings) = (lowLevelCanvas.settings, lowLevelAudioPlayer.settings)
+  def isCreated(): Boolean                              = lowLevelCanvas.isCreated() && lowLevelAudioPlayer.isCreated()
+  def init(settings: (Canvas.Settings, AudioPlayer.Settings)): this.type = {
+    lowLevelCanvas.init(settings._1)
+    lowLevelAudioPlayer.init(settings._2)
+    this
+  }
+  def changeSettings(newSettings: (Canvas.Settings, AudioPlayer.Settings)): Unit = {
+    lowLevelCanvas.changeSettings(newSettings._1)
+    lowLevelAudioPlayer.changeSettings(newSettings._2)
+  }
+  def close(): Unit = {
+    lowLevelCanvas.close()
+    lowLevelAudioPlayer.close()
+  }
+}
+
+object LowLevelAllSubsystems {
+  implicit def defaultLowLevelAllSubsystems(implicit
+      c: DefaultBackend[Any, LowLevelCanvas],
+      a: DefaultBackend[Any, LowLevelAudioPlayer]
+  ): DefaultBackend[Any, LowLevelAllSubsystems] =
+    DefaultBackend.fromFunction((_) => LowLevelAllSubsystems(c.defaultValue(), a.defaultValue()))
+}

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/AppLoop.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/AppLoop.scala
@@ -164,9 +164,6 @@ object AppLoop {
       renderFrame
     )
 
-  type LowLevelAllSubsystems =
-    LowLevelSubsystem.Composite[Canvas.Settings, AudioPlayer.Settings, LowLevelCanvas, LowLevelAudioPlayer]
-
   /** Creates an app loop with a canvas and an audio player that keeps and updates a state on every iteration,
     *  terminating when a certain condition is reached.
     *
@@ -174,13 +171,11 @@ object AppLoop {
     * @param terminateWhen loop termination check
     */
   def statefulAppLoop[State](
-      renderFrame: State => (Canvas with AudioPlayer) => State,
+      renderFrame: State => (CanvasSubsystem with AudioPlayerSubsystem) => State,
       terminateWhen: State => Boolean = (_: State) => false
   ): AppLoop.Definition[State, (Canvas.Settings, AudioPlayer.Settings), LowLevelAllSubsystems] =
     statefulLoop[State, (Canvas.Settings, AudioPlayer.Settings), LowLevelAllSubsystems](
-      (state: State) => { case LowLevelSubsystem.Composite(canvas, audioPlayer) =>
-        renderFrame(state)(new AllSubsystems(canvas, audioPlayer))
-      },
+      renderFrame,
       terminateWhen
     )
 
@@ -189,10 +184,10 @@ object AppLoop {
     * @param renderFrame operation to render the frame
     */
   def statelessAppLoop(
-      renderFrame: (Canvas with AudioPlayer) => Unit
+      renderFrame: (CanvasSubsystem with AudioPlayerSubsystem) => Unit
   ): AppLoop.Definition[Unit, (Canvas.Settings, AudioPlayer.Settings), LowLevelAllSubsystems] =
     statelessLoop[(Canvas.Settings, AudioPlayer.Settings), LowLevelAllSubsystems](
-      { case LowLevelSubsystem.Composite(canvas, audioPlayer) => renderFrame(new AllSubsystems(canvas, audioPlayer)) }
+      renderFrame
     )
 
 }

--- a/examples/snapshot/11-audio.sc
+++ b/examples/snapshot/11-audio.sc
@@ -6,10 +6,11 @@
   * Note: This is an experimental API, it might break in a future version
   */
 import eu.joaocosta.minart.audio._
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.runtime._
-import eu.joaocosta.minart.input._
 import eu.joaocosta.minart.backend.defaults._
+import eu.joaocosta.minart.backend.subsystem._
+import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.input._
+import eu.joaocosta.minart.runtime._
 
 /** First, let's define a simple song
   */
@@ -44,18 +45,19 @@ object Audio {
 
 // Here we use `statelessAppLoop` so that we get an object with a `canvas` and an `audioPlayer`
 AppLoop
-  .statelessAppLoop((system: Canvas with AudioPlayer) => {
+  .statelessAppLoop((system: CanvasSubsystem with AudioPlayerSubsystem) => {
+    import system._
     // When someone presses "Space", we send our sound wave to the queue
-    if (system.getKeyboardInput().keysPressed.contains(KeyboardInput.Key.Space))
-      system.play(Audio.testSample)
+    if (canvas.getKeyboardInput().keysPressed.contains(KeyboardInput.Key.Space))
+      audioPlayer.play(Audio.testSample)
     // When someone presses "Backspace", we stop the audio player
-    if (system.getKeyboardInput().keysPressed.contains(KeyboardInput.Key.Backspace))
-      system.stop()
-    system.clear()
+    if (canvas.getKeyboardInput().keysPressed.contains(KeyboardInput.Key.Backspace))
+      audioPlayer.stop()
+    canvas.clear()
     // Paint green when nothing is playing and red otherwise
-    if (!system.isPlaying()) system.fill(Color(0, 128, 0))
-    else system.fill(Color(128, 0, 0))
-    system.redraw()
+    if (!audioPlayer.isPlaying()) canvas.fill(Color(0, 128, 0))
+    else canvas.fill(Color(128, 0, 0))
+    canvas.redraw()
   })
   .configure((Canvas.Settings(width = 128, height = 128), AudioPlayer.Settings()), LoopFrequency.hz60)
   .run()

--- a/examples/snapshot/12-audio-clip.sc
+++ b/examples/snapshot/12-audio-clip.sc
@@ -8,10 +8,11 @@
   */
 import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.audio.sound._
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.runtime._
-import eu.joaocosta.minart.input._
 import eu.joaocosta.minart.backend.defaults._
+import eu.joaocosta.minart.backend.subsystem._
+import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.input._
+import eu.joaocosta.minart.runtime._
 
 /** Just like loading an image, we can load sound resources
   */
@@ -19,15 +20,16 @@ val clip = Sound.loadAiffClip(Resource("assets/sample.aiff")).get
 
 // Same logic as the audio example
 AppLoop
-  .statelessAppLoop((system: Canvas with AudioPlayer) => {
-    if (system.getKeyboardInput().keysPressed.contains(KeyboardInput.Key.Space))
-      system.play(clip)
-    if (system.getKeyboardInput().keysPressed.contains(KeyboardInput.Key.Backspace))
-      system.stop()
-    system.clear()
-    if (!system.isPlaying()) system.fill(Color(0, 128, 0))
-    else system.fill(Color(128, 0, 0))
-    system.redraw()
+  .statelessAppLoop((system: CanvasSubsystem with AudioPlayerSubsystem) => {
+    import system._
+    if (canvas.getKeyboardInput().keysPressed.contains(KeyboardInput.Key.Space))
+      audioPlayer.play(clip)
+    if (canvas.getKeyboardInput().keysPressed.contains(KeyboardInput.Key.Backspace))
+      audioPlayer.stop()
+    canvas.clear()
+    if (!audioPlayer.isPlaying()) canvas.fill(Color(0, 128, 0))
+    else canvas.fill(Color(128, 0, 0))
+    canvas.redraw()
   })
   .configure((Canvas.Settings(width = 128, height = 128), AudioPlayer.Settings()), LoopFrequency.hz60)
   .run()


### PR DESCRIPTION
This simplifies the code quite a bit, avoids an allocation per frame and, IMO, actually ends up making the application code less confusing.

I think it might be possible to simplify the `AppLoop` logic even further now, but I haven't yet looked into it.