### PR TITLE
Add more strict scalac warnings

### DIFF
--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -9,16 +9,7 @@ import java.awt.event.{
   WindowEvent
 }
 import java.awt.image.BufferedImage
-import java.awt.{
-  AlphaComposite,
-  Canvas => JavaCanvas,
-  Color => JavaColor,
-  Dimension,
-  Graphics,
-  Graphics2D,
-  GraphicsEnvironment,
-  MouseInfo
-}
+import java.awt.{Canvas => JavaCanvas, Color => JavaColor, Dimension, Graphics, GraphicsEnvironment, MouseInfo}
 import javax.swing.{JFrame, WindowConstants}
 
 import scala.jdk.CollectionConverters._

--- a/backend/native/src/main/scala/sdl2/SDL.scala
+++ b/backend/native/src/main/scala/sdl2/SDL.scala
@@ -3349,7 +3349,6 @@ object aliases:
 object structs:
   import _root_.sdl2.enumerations.*
   import _root_.sdl2.aliases.*
-  import _root_.sdl2.structs.*
   import _root_.sdl2.unions.*
 
   /** [bindgen] header: ./SDL_system.h
@@ -6510,10 +6509,8 @@ object structs:
     given _tag: Tag[_SDL_iconv_t] = Tag.materializeCStruct0Tag
 
 object unions:
-  import _root_.sdl2.enumerations.*
   import _root_.sdl2.aliases.*
   import _root_.sdl2.structs.*
-  import _root_.sdl2.unions.*
 
   /** General event structure
     *

--- a/backend/shared/src/test/scala/eu/joaocosta/minart/runtime/AppLoopSpec.scala
+++ b/backend/shared/src/test/scala/eu/joaocosta/minart/runtime/AppLoopSpec.scala
@@ -6,7 +6,6 @@ import eu.joaocosta.minart.backend._
 import eu.joaocosta.minart.backend.defaults._
 import eu.joaocosta.minart.graphics._
 import eu.joaocosta.minart.input._
-import eu.joaocosta.minart.runtime._
 
 class AppLoopSpec extends munit.FunSuite {
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,10 +18,19 @@ ThisBuild / versionScheme := Some("semver-spec")
 
 ThisBuild / autoAPIMappings := true
 ThisBuild / scalacOptions ++= Seq(
+  "-encoding",
+  "utf8",
   "-deprecation",
   "-feature",
+  "-unchecked",
   "-language:higherKinds",
-  "-unchecked"
+  "-Wunused:implicits",
+  "-Wunused:explicits",
+  "-Wunused:imports",
+  "-Wunused:locals",
+  "-Wunused:params",
+  "-Wunused:privates",
+  //"-Xfatal-warnings"
 )
 ThisBuild / scalafmtOnCompile := true
 ThisBuild / semanticdbEnabled := true
@@ -49,8 +58,7 @@ val testSettings = Seq(
   libraryDependencies ++= Seq(
     "org.scalameta" %%% "munit" % "1.0.0-M8" % Test
   ),
-  testFrameworks += new TestFramework("munit.Framework"),
-  Test / scalacOptions ++= Seq("-Yrangepos")
+  testFrameworks += new TestFramework("munit.Framework")
 )
 
 val publishSettings = Seq(

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioClip.scala
@@ -151,5 +151,5 @@ object AudioClip {
   }
 
   private def clamp(minValue: Double, value: Double, maxValue: Double): Double =
-    Math.max(0, Math.min(value, maxValue))
+    Math.max(minValue, Math.min(value, maxValue))
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/AllSubsystems.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/AllSubsystems.scala
@@ -2,7 +2,6 @@ package eu.joaocosta.minart.backend.subsystem
 
 import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.input._
 
 /** Internal object with an intersection of all subsystems.
   */

--- a/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/LowLevelAllSubsystems.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/LowLevelAllSubsystems.scala
@@ -3,7 +3,6 @@ package eu.joaocosta.minart.backend.subsystem
 import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.backend.defaults.DefaultBackend
 import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.input._
 
 /** Aggregation of all subsystems.
   */

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -143,7 +143,7 @@ object SurfaceView {
     else rem + y
   }
   private def clamp(minValue: Int, value: Int, maxValue: Int): Int =
-    Math.max(0, Math.min(value, maxValue))
+    Math.max(minValue, Math.min(value, maxValue))
 
   /** Generates a surface view from a surface */
   def apply(surface: Surface): SurfaceView =

--- a/core/shared/src/main/scala/eu/joaocosta/minart/internal/ByteReader.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/internal/ByteReader.scala
@@ -126,14 +126,14 @@ private[minart] object ByteReader {
     }
 
     def readBytes(n: Int): ParseState[Nothing, Array[Int]] = State { bytes =>
-      val byteArr    = Array.ofDim[Byte](n)
-      val resultSize = bytes.read(byteArr)
+      val byteArr = Array.ofDim[Byte](n)
+      bytes.read(byteArr)
       bytes -> byteArr.map(b => java.lang.Byte.toUnsignedInt(b))
     }
 
     def readRawBytes(n: Int): ParseState[Nothing, Array[Byte]] = State { bytes =>
-      val byteArr    = Array.ofDim[Byte](n)
-      val resultSize = bytes.read(byteArr)
+      val byteArr = Array.ofDim[Byte](n)
+      bytes.read(byteArr)
       bytes -> byteArr
     }
 

--- a/core/shared/src/test/scala/eu/joaocosta/minart/audio/AudioQueueSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/audio/AudioQueueSpec.scala
@@ -59,7 +59,7 @@ class AudioQueueSpec extends munit.FunSuite {
   }
 
   test("A single channel audio queue can be cleared") {
-    val clip = AudioClip(x => 1.0, 2.0)
+    val clip = AudioClip(_ => 1.0, 2.0)
 
     val queue = new AudioQueue.SingleChannelAudioQueue(2)
 
@@ -72,7 +72,7 @@ class AudioQueueSpec extends munit.FunSuite {
 
   test("A multi channel audio queue correctly mixes audio from two clips with the same duration") {
     val clipA = AudioClip(x => x / 4.0, 2.0)
-    val clipB = AudioClip(x => 0.25, 2.0)
+    val clipB = AudioClip(_ => 0.25, 2.0)
 
     val queue = new AudioQueue.MultiChannelAudioQueue(1)
 
@@ -87,7 +87,7 @@ class AudioQueueSpec extends munit.FunSuite {
 
   test("A multi channel audio queue correctly mixes audio from two clips with different durations") {
     val clipA = AudioClip(x => x / 4.0, 2.0)
-    val clipB = AudioClip(x => 0.25, 1.0)
+    val clipB = AudioClip(_ => 0.25, 1.0)
 
     val queue = new AudioQueue.MultiChannelAudioQueue(1)
 
@@ -118,7 +118,7 @@ class AudioQueueSpec extends munit.FunSuite {
   }
 
   test("A single channel audio queue can be cleared") {
-    val clip = AudioClip(x => 1.0, 2.0)
+    val clip = AudioClip(_ => 1.0, 2.0)
 
     val queue = new AudioQueue.MultiChannelAudioQueue(2)
 

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/ColorSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/ColorSpec.scala
@@ -1,7 +1,5 @@
 package eu.joaocosta.minart.graphics
 
-import scala.util.Random
-
 class ColorSpec extends munit.FunSuite {
 
   test("Can be created from RGB values") {

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MatrixSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MatrixSpec.scala
@@ -1,7 +1,5 @@
 package eu.joaocosta.minart.graphics
 
-import scala.util.Random
-
 class MatrixSpec extends munit.FunSuite {
 
   test("Can be applied") {

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageReader.scala
@@ -113,7 +113,6 @@ trait BmpImageReader[ByteSeq] extends ImageReader {
   def loadImage(is: InputStream): Either[String, RamSurface] = {
     val bytes = fromInputStream(is)
     loadHeader(bytes).flatMap { case (data, header) =>
-      val numPixels = header.width * header.height
       val pixels = header.bitsPerPixel match {
         case 24 =>
           loadPixels(

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
@@ -105,7 +105,6 @@ trait PpmImageReader[ByteSeq] extends ImageReader {
   def loadImage(is: InputStream): Either[String, RamSurface] = {
     val bytes = fromInputStream(is)
     loadHeader(bytes).flatMap { case (data, header) =>
-      val numPixels = header.width * header.height
       val pixels = header.magic match {
         case "P2" =>
           loadPixels(loadStringGrayscalePixel, data, header.height, header.width)

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageWriterSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageWriterSpec.scala
@@ -1,7 +1,5 @@
 package eu.joaocosta.minart.graphics.image
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
-
 import eu.joaocosta.minart.backend.defaults._
 import eu.joaocosta.minart.runtime._
 

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioReader.scala
@@ -105,7 +105,7 @@ object RtttlAudioReader {
       case None => 0.0
       case Some(n) =>
         val a1 = 55
-        Math.pow(2, (octave - 1) + n / 12.0) * 55
+        Math.pow(2, (octave - 1) + n / 12.0) * a1
     }
   }
 

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioWriter.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioWriter.scala
@@ -52,7 +52,7 @@ trait WavAudioWriter[ByteSeq] extends AudioClipWriter {
       _ <- storeData(Sampler.sampleClip(clip, sampleRate).grouped(chunkSize))
     } yield ()
 
-  private def storeFmtChunk(clip: AudioClip): ByteStreamState[String] =
+  private val storeFmtChunk: ByteStreamState[String] =
     for {
       _ <- writeString("fmt ")
       _ <- writeLENumber(16, 4)
@@ -73,7 +73,7 @@ trait WavAudioWriter[ByteSeq] extends AudioClipWriter {
   def storeClip(clip: AudioClip, os: OutputStream): Either[String, Unit] = {
     val state = for {
       _ <- storeRiffHeader(clip)
-      _ <- storeFmtChunk(clip)
+      _ <- storeFmtChunk
       _ <- storeDataChunk(clip)
     } yield ()
     toOutputStream(state, os)

--- a/sound/shared/src/test/scala/eu/joaocosta/minart/audio/sound/AudioClipReaderSpec.scala
+++ b/sound/shared/src/test/scala/eu/joaocosta/minart/audio/sound/AudioClipReaderSpec.scala
@@ -1,7 +1,5 @@
 package eu.joaocosta.minart.audio.sound
 
-import scala.util.Try
-
 import eu.joaocosta.minart.audio._
 import eu.joaocosta.minart.backend.defaults._
 import eu.joaocosta.minart.runtime._

--- a/sound/shared/src/test/scala/eu/joaocosta/minart/audio/sound/AudioClipWriterSpec.scala
+++ b/sound/shared/src/test/scala/eu/joaocosta/minart/audio/sound/AudioClipWriterSpec.scala
@@ -1,7 +1,5 @@
 package eu.joaocosta.minart.audio.sound
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
-
 import eu.joaocosta.minart.audio.Sampler
 import eu.joaocosta.minart.backend.defaults._
 import eu.joaocosta.minart.runtime._


### PR DESCRIPTION
Adds multiple warning flags and fixes the corresponding warnings.

Now that everything is in Scala 3 there's no reason to ignore warnings. The only reason to not enable fatal warnings is to ease development.