### PR TITLE
Monomorphize ByteReader/ByteWriter

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/internal/ByteReader.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/internal/ByteReader.scala
@@ -4,64 +4,85 @@ import java.io.InputStream
 
 /** Helper methods to read binary data from an input stream.
   */
-private[minart] trait ByteReader[ByteSeq] {
-  type ParseResult[T]   = Either[String, (ByteSeq, T)]
-  type ParseState[E, T] = State[ByteSeq, E, T]
+private[minart] object ByteReader {
+  type ParseResult[T]   = Either[String, (CustomInputStream, T)]
+  type ParseState[E, T] = State[CustomInputStream, E, T]
 
   /** Generates a sequence of bytes from a byte stream */
-  def fromInputStream(is: InputStream): ByteSeq
+  def fromInputStream(is: InputStream): CustomInputStream = new CustomInputStream(is)
 
   /** Checks if a byte sequence is empty */
-  def isEmpty(seq: ByteSeq): Boolean
+  def isEmpty(seq: CustomInputStream): Boolean = seq.isEmpty()
 
   /** Skip N Bytes */
-  def skipBytes(n: Int): ParseState[Nothing, Unit]
+  def skipBytes(n: Int): ParseState[Nothing, Unit] =
+    State.modify { bytes =>
+      bytes.skip(n)
+      bytes
+    }
 
   /** Read 1 Byte */
-  val readByte: ParseState[String, Option[Int]]
+  val readByte: ParseState[String, Option[Int]] = State { bytes =>
+    val value = bytes.read()
+    bytes -> (if (value >= -1) Some(value) else None)
+  }
 
   /** Read N Bytes */
-  def readBytes(n: Int): ParseState[Nothing, Array[Int]]
+  def readBytes(n: Int): ParseState[Nothing, Array[Int]] = State { bytes =>
+    val byteArr = Array.ofDim[Byte](n)
+    bytes.read(byteArr)
+    bytes -> byteArr.map(b => java.lang.Byte.toUnsignedInt(b))
+  }
 
   /** Read N Bytes */
-  def readRawBytes(n: Int): ParseState[Nothing, Array[Byte]]
+  def readRawBytes(n: Int): ParseState[Nothing, Array[Byte]] = State { bytes =>
+    val byteArr = Array.ofDim[Byte](n)
+    bytes.read(byteArr)
+    bytes -> byteArr
+  }
 
   /** Reads data while a predicate is true */
-  def readWhile(p: Int => Boolean): ParseState[Nothing, List[Int]]
+  def readWhile(p: Int => Boolean): ParseState[Nothing, List[Int]] = State { bytes =>
+    val buffer = List.newBuilder[Int]
+    var value  = bytes.read()
+    while (value != -1 && p(value)) {
+      buffer += value
+      value = bytes.read()
+    }
+    if (value != -1) bytes.setBuffer(value)
+    bytes -> buffer.result()
+  }
 
   /** Does nothing */
-  final val noop: ParseState[Nothing, Unit] = skipBytes(0)
+  val noop: ParseState[Nothing, Unit] = skipBytes(0)
 
   /** Read a String from N Bytes */
-  final def readString(n: Int): ParseState[Nothing, String] =
+  def readString(n: Int): ParseState[Nothing, String] =
     readBytes(n).map { bytes => bytes.map(_.toChar).mkString("") }
 
   /** Read a Integer N Bytes (Little Endian) */
-  final def readLENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
+  def readLENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
     bytes.zipWithIndex.map { case (num, idx) => num.toInt << (idx * 8) }.sum
   }
 
   /** Read a Integer N Bytes as a Long (Little Endian) */
-  final def readLENumberLong(n: Int): ParseState[Nothing, Long] = readBytes(n).map { bytes =>
+  def readLENumberLong(n: Int): ParseState[Nothing, Long] = readBytes(n).map { bytes =>
     bytes.zipWithIndex.map { case (num, idx) => num.toLong << (idx * 8) }.sum
   }
 
   /** Read a Integer N Bytes (Big Endian) */
-  final def readBENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
+  def readBENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
     bytes.reverse.zipWithIndex.map { case (num, idx) => num.toInt << (idx * 8) }.sum
   }
 
   /** Read a Integer N Bytes as a Long (Big Endian) */
-  final def readBENumberLong(n: Int): ParseState[Nothing, Long] = readBytes(n).map { bytes =>
+  def readBENumberLong(n: Int): ParseState[Nothing, Long] = readBytes(n).map { bytes =>
     bytes.reverse.zipWithIndex.map { case (num, idx) => num.toLong << (idx * 8) }.sum
   }
-}
-
-private[minart] object ByteReader {
 
   final class CustomInputStream(inner: InputStream) extends InputStream {
-    var hasBuffer: Boolean                  = false
-    var buffer: Int                         = 0
+    private var hasBuffer: Boolean          = false
+    private var buffer: Int                 = 0
     override def available(): Int           = inner.available() + (if (hasBuffer) 1 else 0)
     override def close(): Unit              = inner.close()
     override def mark(readLimit: Int): Unit = ()
@@ -105,47 +126,6 @@ private[minart] object ByteReader {
     def setBuffer(value: Int): Unit = {
       buffer = value
       hasBuffer = true
-    }
-
-  }
-
-  object InputStreamByteReader extends ByteReader[CustomInputStream] {
-    def fromInputStream(is: InputStream): CustomInputStream = new CustomInputStream(is)
-
-    def isEmpty(seq: CustomInputStream): Boolean = seq.isEmpty()
-
-    def skipBytes(n: Int): ParseState[Nothing, Unit] =
-      State.modify { bytes =>
-        bytes.skip(n)
-        bytes
-      }
-
-    val readByte: ParseState[String, Option[Int]] = State { bytes =>
-      val value = bytes.read()
-      bytes -> (if (value >= -1) Some(value) else None)
-    }
-
-    def readBytes(n: Int): ParseState[Nothing, Array[Int]] = State { bytes =>
-      val byteArr = Array.ofDim[Byte](n)
-      bytes.read(byteArr)
-      bytes -> byteArr.map(b => java.lang.Byte.toUnsignedInt(b))
-    }
-
-    def readRawBytes(n: Int): ParseState[Nothing, Array[Byte]] = State { bytes =>
-      val byteArr = Array.ofDim[Byte](n)
-      bytes.read(byteArr)
-      bytes -> byteArr
-    }
-
-    def readWhile(p: Int => Boolean): ParseState[Nothing, List[Int]] = State { bytes =>
-      val buffer = List.newBuilder[Int]
-      var value  = bytes.read()
-      while (value != -1 && p(value)) {
-        buffer += value
-        value = bytes.read()
-      }
-      if (value != -1) bytes.setBuffer(value)
-      bytes -> buffer.result()
     }
   }
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/internal/ByteReader.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/internal/ByteReader.scala
@@ -30,36 +30,36 @@ private[minart] trait ByteReader[ByteSeq] {
   def readWhile(p: Int => Boolean): ParseState[Nothing, List[Int]]
 
   /** Does nothing */
-  val noop: ParseState[Nothing, Unit] = skipBytes(0)
+  final val noop: ParseState[Nothing, Unit] = skipBytes(0)
 
   /** Read a String from N Bytes */
-  def readString(n: Int): ParseState[Nothing, String] =
+  final def readString(n: Int): ParseState[Nothing, String] =
     readBytes(n).map { bytes => bytes.map(_.toChar).mkString("") }
 
   /** Read a Integer N Bytes (Little Endian) */
-  def readLENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
+  final def readLENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
     bytes.zipWithIndex.map { case (num, idx) => num.toInt << (idx * 8) }.sum
   }
 
   /** Read a Integer N Bytes as a Long (Little Endian) */
-  def readLENumberLong(n: Int): ParseState[Nothing, Long] = readBytes(n).map { bytes =>
+  final def readLENumberLong(n: Int): ParseState[Nothing, Long] = readBytes(n).map { bytes =>
     bytes.zipWithIndex.map { case (num, idx) => num.toLong << (idx * 8) }.sum
   }
 
   /** Read a Integer N Bytes (Big Endian) */
-  def readBENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
+  final def readBENumber(n: Int): ParseState[Nothing, Int] = readBytes(n).map { bytes =>
     bytes.reverse.zipWithIndex.map { case (num, idx) => num.toInt << (idx * 8) }.sum
   }
 
   /** Read a Integer N Bytes as a Long (Big Endian) */
-  def readBENumberLong(n: Int): ParseState[Nothing, Long] = readBytes(n).map { bytes =>
+  final def readBENumberLong(n: Int): ParseState[Nothing, Long] = readBytes(n).map { bytes =>
     bytes.reverse.zipWithIndex.map { case (num, idx) => num.toLong << (idx * 8) }.sum
   }
 }
 
 private[minart] object ByteReader {
 
-  class CustomInputStream(inner: InputStream) extends InputStream {
+  final class CustomInputStream(inner: InputStream) extends InputStream {
     var hasBuffer: Boolean                  = false
     var buffer: Int                         = 0
     override def available(): Int           = inner.available() + (if (hasBuffer) 1 else 0)

--- a/core/shared/src/main/scala/eu/joaocosta/minart/internal/ByteWriter.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/internal/ByteWriter.scala
@@ -11,7 +11,7 @@ private[minart] trait ByteWriter[ByteStream] {
   def toOutputStream[E](data: ByteStreamState[E], os: OutputStream): Either[E, Unit]
 
   /** Empty state */
-  def emptyStream: ByteStreamState[Nothing] = State.pure(())
+  final def emptyStream: ByteStreamState[Nothing] = State.pure(())
 
   /** Appends this byte stream to the current accumulator */
   def append(stream: ByteStream): ByteStreamState[Nothing]
@@ -20,22 +20,22 @@ private[minart] trait ByteWriter[ByteStream] {
   def writeBytes(bytes: Seq[Int]): ByteStreamState[String]
 
   /** Write 1 Byte */
-  def writeByte(byte: Int): ByteStreamState[String] = writeBytes(Seq(byte))
+  final def writeByte(byte: Int): ByteStreamState[String] = writeBytes(Seq(byte))
 
   /** Writes a String */
-  def writeString(string: String): ByteStreamState[String] =
+  final def writeString(string: String): ByteStreamState[String] =
     writeBytes(string.map(_.toInt))
 
   /** Writes a String Line */
-  def writeStringLn(string: String, delimiter: String = "\n"): ByteStreamState[String] =
+  final def writeStringLn(string: String, delimiter: String = "\n"): ByteStreamState[String] =
     writeString(string + delimiter)
 
   /** Writes a Integer in N Bytes (Little Endian) */
-  def writeLENumber(value: Int, bytes: Int): ByteStreamState[String] =
+  final def writeLENumber(value: Int, bytes: Int): ByteStreamState[String] =
     writeBytes((0 until bytes).map { idx => (value >> (idx * 8)) & 0x000000ff })
 
   /** Writes a Integer in N Bytes (Big Endian) */
-  def writeBENumber(value: Int, bytes: Int): ByteStreamState[String] =
+  final def writeBENumber(value: Int, bytes: Int): ByteStreamState[String] =
     writeBytes((0 until bytes).reverse.map { idx => (value >> (idx * 8)) & 0x000000ff })
 }
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/internal/ByteWriter.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/internal/ByteWriter.scala
@@ -4,53 +4,43 @@ import java.io.OutputStream
 
 /** Helper methods to write binary data to an output stream.
   */
-private[minart] trait ByteWriter[ByteStream] {
-  type ByteStreamState[E] = State[ByteStream, E, Unit]
+private[minart] object ByteWriter {
+  type ByteStreamState[E] = State[Iterator[Array[Byte]], E, Unit]
 
-  /** Writes a ByteStream to a output stream */
-  def toOutputStream[E](data: ByteStreamState[E], os: OutputStream): Either[E, Unit]
+  /** Writes a byte stream to a output stream */
+  def toOutputStream[E](data: ByteStreamState[E], os: OutputStream): Either[E, Unit] =
+    data.run(Iterator.empty).map { case (s, _) =>
+      s.foreach(bytes => os.write(bytes))
+    }
 
   /** Empty state */
-  final def emptyStream: ByteStreamState[Nothing] = State.pure(())
+  def emptyStream: ByteStreamState[Nothing] = State.pure(())
 
   /** Appends this byte stream to the current accumulator */
-  def append(stream: ByteStream): ByteStreamState[Nothing]
+  def append(stream: Iterator[Array[Byte]]): ByteStreamState[Nothing] =
+    State.modify[Iterator[Array[Byte]]](s => s ++ stream)
 
   /** Adds a sequence of bytes to the tail of the byte stream */
-  def writeBytes(bytes: Seq[Int]): ByteStreamState[String]
+  def writeBytes(bytes: Seq[Int]): ByteStreamState[String] =
+    if (bytes.forall(b => b >= 0 && b <= 255)) append(Iterator(bytes.map(_.toByte).toArray))
+    else State.error(s"Sequence $bytes contains invalid bytes")
 
   /** Write 1 Byte */
-  final def writeByte(byte: Int): ByteStreamState[String] = writeBytes(Seq(byte))
+  def writeByte(byte: Int): ByteStreamState[String] = writeBytes(Seq(byte))
 
   /** Writes a String */
-  final def writeString(string: String): ByteStreamState[String] =
+  def writeString(string: String): ByteStreamState[String] =
     writeBytes(string.map(_.toInt))
 
   /** Writes a String Line */
-  final def writeStringLn(string: String, delimiter: String = "\n"): ByteStreamState[String] =
+  def writeStringLn(string: String, delimiter: String = "\n"): ByteStreamState[String] =
     writeString(string + delimiter)
 
   /** Writes a Integer in N Bytes (Little Endian) */
-  final def writeLENumber(value: Int, bytes: Int): ByteStreamState[String] =
+  def writeLENumber(value: Int, bytes: Int): ByteStreamState[String] =
     writeBytes((0 until bytes).map { idx => (value >> (idx * 8)) & 0x000000ff })
 
   /** Writes a Integer in N Bytes (Big Endian) */
-  final def writeBENumber(value: Int, bytes: Int): ByteStreamState[String] =
+  def writeBENumber(value: Int, bytes: Int): ByteStreamState[String] =
     writeBytes((0 until bytes).reverse.map { idx => (value >> (idx * 8)) & 0x000000ff })
-}
-
-private[minart] object ByteWriter {
-  object IteratorByteWriter extends ByteWriter[Iterator[Array[Byte]]] {
-    def toOutputStream[E](data: ByteStreamState[E], os: OutputStream): Either[E, Unit] =
-      data.run(Iterator.empty).map { case (s, _) =>
-        s.foreach(bytes => os.write(bytes))
-      }
-
-    def append(stream: Iterator[Array[Byte]]): ByteStreamState[Nothing] =
-      State.modify[Iterator[Array[Byte]]](s => s ++ stream)
-
-    def writeBytes(bytes: Seq[Int]): ByteStreamState[String] =
-      if (bytes.forall(b => b >= 0 && b <= 255)) append(Iterator(bytes.map(_.toByte).toArray))
-      else State.error(s"Sequence $bytes contains invalid bytes")
-  }
 }

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageFormat.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageFormat.scala
@@ -6,13 +6,10 @@ import eu.joaocosta.minart.internal._
   *
   * Supports reading uncompressed 24/32bit Windows BMPs and writing uncompressed 24 bit Windows BMPs.
   */
-final class BmpImageFormat[R, W](val byteReader: ByteReader[R], val byteWriter: ByteWriter[W])
-    extends BmpImageReader[R]
-    with BmpImageWriter[W]
+final class BmpImageFormat[W](val byteWriter: ByteWriter[W]) extends BmpImageReader with BmpImageWriter[W]
 
 object BmpImageFormat {
-  val defaultFormat = new BmpImageFormat[ByteReader.CustomInputStream, Iterator[Array[Byte]]](
-    ByteReader.InputStreamByteReader,
+  val defaultFormat = new BmpImageFormat[Iterator[Array[Byte]]](
     ByteWriter.IteratorByteWriter
   )
 

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageFormat.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageFormat.scala
@@ -1,17 +1,13 @@
 package eu.joaocosta.minart.graphics.image.bmp
 
-import eu.joaocosta.minart.internal._
-
 /** Image reader and writer for BMP files.
   *
   * Supports reading uncompressed 24/32bit Windows BMPs and writing uncompressed 24 bit Windows BMPs.
   */
-final class BmpImageFormat[W](val byteWriter: ByteWriter[W]) extends BmpImageReader with BmpImageWriter[W]
+final class BmpImageFormat() extends BmpImageReader with BmpImageWriter
 
 object BmpImageFormat {
-  val defaultFormat = new BmpImageFormat[Iterator[Array[Byte]]](
-    ByteWriter.IteratorByteWriter
-  )
+  val defaultFormat = new BmpImageFormat()
 
   val supportedFormats = Set("BM")
 

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageReader.scala
@@ -12,9 +12,8 @@ import eu.joaocosta.minart.internal._
   *
   * Supports uncompressed 24/32bit Windows BMPs.
   */
-trait BmpImageReader[ByteSeq] extends ImageReader {
-  val byteReader: ByteReader[ByteSeq]
-  import byteReader._
+trait BmpImageReader extends ImageReader {
+  import ByteReader._
 
   private val loadRgbPixel: ParseState[String, Color] =
     readRawBytes(3)
@@ -33,7 +32,7 @@ trait BmpImageReader[ByteSeq] extends ImageReader {
   @tailrec
   private def loadPixelLine(
       loadColor: ParseState[String, Color],
-      data: ByteSeq,
+      data: CustomInputStream,
       remainingPixels: Int,
       padding: Int,
       acc: List[Color] = Nil
@@ -52,7 +51,7 @@ trait BmpImageReader[ByteSeq] extends ImageReader {
   @tailrec
   private def loadPixels(
       loadColor: ParseState[String, Color],
-      data: ByteSeq,
+      data: CustomInputStream,
       remainingLines: Int,
       width: Int,
       padding: Int,
@@ -68,7 +67,7 @@ trait BmpImageReader[ByteSeq] extends ImageReader {
     }
   }
 
-  private def loadHeader(bytes: ByteSeq): ParseResult[Header] = {
+  private def loadHeader(bytes: CustomInputStream): ParseResult[Header] = {
     (for {
       magic <- readString(2).validate(
         BmpImageFormat.supportedFormats,
@@ -97,9 +96,9 @@ trait BmpImageReader[ByteSeq] extends ImageReader {
       )
       loadColorMask = compressionMethod == 3 || compressionMethod == 6
       _         <- if (loadColorMask) skipBytes(20) else noop
-      redMask   <- if (loadColorMask) readLENumber(4) else State.pure[ByteSeq, Int](0x00ff0000)
-      greenMask <- if (loadColorMask) readLENumber(4) else State.pure[ByteSeq, Int](0x0000ff00)
-      blueMask  <- if (loadColorMask) readLENumber(4) else State.pure[ByteSeq, Int](0x000000ff)
+      redMask   <- if (loadColorMask) readLENumber(4) else State.pure[CustomInputStream, Int](0x00ff0000)
+      greenMask <- if (loadColorMask) readLENumber(4) else State.pure[CustomInputStream, Int](0x0000ff00)
+      blueMask  <- if (loadColorMask) readLENumber(4) else State.pure[CustomInputStream, Int](0x000000ff)
       _         <- if (loadColorMask) skipBytes(4) else noop // Skip alpha mask (or color space)
       _ <- State.check(
         redMask == 0x00ff0000 && greenMask == 0x0000ff00 && blueMask == 0x000000ff,
@@ -110,7 +109,7 @@ trait BmpImageReader[ByteSeq] extends ImageReader {
     } yield header).run(bytes)
   }
 
-  def loadImage(is: InputStream): Either[String, RamSurface] = {
+  final def loadImage(is: InputStream): Either[String, RamSurface] = {
     val bytes = fromInputStream(is)
     loadHeader(bytes).flatMap { case (data, header) =>
       val pixels = header.bitsPerPixel match {

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageWriter.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageWriter.scala
@@ -12,9 +12,8 @@ import eu.joaocosta.minart.internal._
   *
   * Stores data as uncompressed 24bit Windows BMPs.
   */
-trait BmpImageWriter[ByteSeq] extends ImageWriter {
-  val byteWriter: ByteWriter[ByteSeq]
-  import byteWriter._
+trait BmpImageWriter extends ImageWriter {
+  import ByteWriter._
 
   private def storeBgrPixel(color: Color): ByteStreamState[String] =
     writeBytes(List(color.b, color.g, color.r))
@@ -61,7 +60,7 @@ trait BmpImageWriter[ByteSeq] extends ImageWriter {
     } yield ())
   }
 
-  def storeImage(surface: Surface, os: OutputStream): Either[String, Unit] = {
+  final def storeImage(surface: Surface, os: OutputStream): Either[String, Unit] = {
     val state = for {
       _ <- storeHeader(surface)
       _ <- storePixels(storeBgrPixel, surface, surface.width, BmpImageFormat.linePadding(surface.width, 24))

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageFormat.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageFormat.scala
@@ -1,18 +1,14 @@
 package eu.joaocosta.minart.graphics.image.ppm
 
-import eu.joaocosta.minart.internal._
-
 /** Image format and writer for PGM/PPM files.
   *
   * Supports reading P2, P3, P5 and P6 PGM/PPM files with a 8 bit color range
   * and stores data as P6 PPM files with a 8 bit color range.
   */
-final class PpmImageFormat[W](val byteWriter: ByteWriter[W]) extends PpmImageReader with PpmImageWriter[W]
+final class PpmImageFormat() extends PpmImageReader with PpmImageWriter
 
 object PpmImageFormat {
-  val defaultFormat = new PpmImageFormat[Iterator[Array[Byte]]](
-    ByteWriter.IteratorByteWriter
-  )
+  val defaultFormat = new PpmImageFormat()
 
   val supportedFormats = Set("P2", "P3", "P5", "P6")
 }

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageFormat.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageFormat.scala
@@ -7,13 +7,10 @@ import eu.joaocosta.minart.internal._
   * Supports reading P2, P3, P5 and P6 PGM/PPM files with a 8 bit color range
   * and stores data as P6 PPM files with a 8 bit color range.
   */
-final class PpmImageFormat[R, W](val byteReader: ByteReader[R], val byteWriter: ByteWriter[W])
-    extends PpmImageReader[R]
-    with PpmImageWriter[W]
+final class PpmImageFormat[W](val byteWriter: ByteWriter[W]) extends PpmImageReader with PpmImageWriter[W]
 
 object PpmImageFormat {
-  val defaultFormat = new PpmImageFormat[ByteReader.CustomInputStream, Iterator[Array[Byte]]](
-    ByteReader.InputStreamByteReader,
+  val defaultFormat = new PpmImageFormat[Iterator[Array[Byte]]](
     ByteWriter.IteratorByteWriter
   )
 

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageWriter.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageWriter.scala
@@ -12,10 +12,8 @@ import eu.joaocosta.minart.internal._
   *
   * Stores data as P6 PPM files with a 8 bit color range.
   */
-trait PpmImageWriter[ByteSeq] extends ImageWriter {
-  val byteWriter: ByteWriter[ByteSeq]
-
-  import byteWriter._
+trait PpmImageWriter extends ImageWriter {
+  import ByteWriter._
 
   private def storeBinaryRgbPixel(color: Color): ByteStreamState[String] =
     writeBytes(List(color.r, color.g, color.b))
@@ -43,7 +41,7 @@ trait PpmImageWriter[ByteSeq] extends ImageWriter {
       _ <- writeStringLn("255")
     } yield ()
 
-  def storeImage(surface: Surface, os: OutputStream): Either[String, Unit] = {
+  final def storeImage(surface: Surface, os: OutputStream): Either[String, Unit] = {
     val state = for {
       _ <- storeHeader(surface)
       _ <- storePixels(storeBinaryRgbPixel, surface)

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageFormat.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageFormat.scala
@@ -4,13 +4,10 @@ import eu.joaocosta.minart.internal._
 
 /** Image format for QOI files.
   */
-final class QoiImageFormat[R, W](val byteReader: ByteReader[R], val byteWriter: ByteWriter[W])
-    extends QoiImageReader[R]
-    with QoiImageWriter[W]
+final class QoiImageFormat[W](val byteWriter: ByteWriter[W]) extends QoiImageReader with QoiImageWriter[W]
 
 object QoiImageFormat {
-  val defaultFormat = new QoiImageFormat[ByteReader.CustomInputStream, Iterator[Array[Byte]]](
-    ByteReader.InputStreamByteReader,
+  val defaultFormat = new QoiImageFormat[Iterator[Array[Byte]]](
     ByteWriter.IteratorByteWriter
   )
 

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageFormat.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageFormat.scala
@@ -1,15 +1,11 @@
 package eu.joaocosta.minart.graphics.image.qoi
 
-import eu.joaocosta.minart.internal._
-
 /** Image format for QOI files.
   */
-final class QoiImageFormat[W](val byteWriter: ByteWriter[W]) extends QoiImageReader with QoiImageWriter[W]
+final class QoiImageFormat() extends QoiImageReader with QoiImageWriter
 
 object QoiImageFormat {
-  val defaultFormat = new QoiImageFormat[Iterator[Array[Byte]]](
-    ByteWriter.IteratorByteWriter
-  )
+  val defaultFormat = new QoiImageFormat()
 
   val supportedFormats = Set("qoif")
 }

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageWriter.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageWriter.scala
@@ -10,9 +10,8 @@ import eu.joaocosta.minart.internal._
 
 /** Image writer for QOI files.
   */
-trait QoiImageWriter[ByteSeq] extends ImageWriter {
-  val byteWriter: ByteWriter[ByteSeq]
-  import byteWriter._
+trait QoiImageWriter extends ImageWriter {
+  import ByteWriter._
 
   private def storeHeader(surface: Surface): ByteStreamState[String] = {
     (for {
@@ -72,7 +71,7 @@ trait QoiImageWriter[ByteSeq] extends ImageWriter {
 
   private val storeTrail: ByteStreamState[String] = writeBytes(List(0, 0, 0, 0, 0, 0, 0, 1))
 
-  def storeImage(surface: Surface, os: OutputStream): Either[String, Unit] = {
+  final def storeImage(surface: Surface, os: OutputStream): Either[String, Unit] = {
     val state = for {
       _ <- storeHeader(surface)
       _ <- storeOps(toOps(surface))

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageReaderSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageReaderSpec.scala
@@ -37,8 +37,7 @@ class ImageReaderSpec extends munit.FunSuite {
       bmpTest("scala", 128, 128)
       bmpTest("scala-rect", 77, 119)
       testSize(List(Image.loadBmpImage(Resource(s"alpha/bmp-32bit.bmp"))), 507, 200)
-      // Native tests in debug require a large heap here
-      if (Platform() != Platform.Native) bmpTest("lausanne", 640, 480)
+      bmpTest("lausanne", 640, 480)
     }
 
     test("Load a PPM image") {
@@ -50,8 +49,7 @@ class ImageReaderSpec extends munit.FunSuite {
         )
       ppmTest("scala", 128, 128)
       ppmTest("scala-rect", 77, 119)
-      // Native tests in debug require a large heap here
-      if (Platform() != Platform.Native) ppmTest("lausanne", 640, 480)
+      ppmTest("lausanne", 640, 480)
     }
 
     test("Load a PGM image") {
@@ -64,8 +62,6 @@ class ImageReaderSpec extends munit.FunSuite {
       pgmTest("scala", 128, 128)
       pgmTest("scala-rect", 77, 119)
       pgmTest("lausanne", 640, 480)
-      // Native tests in debug require a large heap here
-      if (Platform() != Platform.Native) pgmTest("lausanne", 640, 480)
     }
 
     test("Load a QOI image") {
@@ -81,8 +77,7 @@ class ImageReaderSpec extends munit.FunSuite {
       qoiTest("scala", 128, 128)
       qoiTest("scala-rect", 77, 119)
       testSize(List(Image.loadQoiImage(Resource(s"alpha/qoi-32bit.qoi"))), 507, 200)
-      // Native tests in debug require a large heap here
-      if (Platform() != Platform.Native) qoiTest("lausanne", 640, 480)
+      qoiTest("lausanne", 640, 480)
     }
 
     test("Load the same data from different formats (square image)") {
@@ -113,17 +108,14 @@ class ImageReaderSpec extends munit.FunSuite {
         )
       )
     }
-    // Native tests in debug require a large heap here
-    if (Platform() != Platform.Native) {
-      test("Load the same data from different formats (large image)") {
-        sameImage(
-          List(
-            Image.loadBmpImage(Resource("lausanne/bmp-24bit.bmp")).get,
-            Image.loadPpmImage(Resource("lausanne/ppm-p3.ppm")).get,
-            Image.loadQoiImage(Resource("lausanne/qoi-24bit.qoi")).get
-          )
+    test("Load the same data from different formats (large image)") {
+      sameImage(
+        List(
+          Image.loadBmpImage(Resource("lausanne/bmp-24bit.bmp")).get,
+          Image.loadPpmImage(Resource("lausanne/ppm-p3.ppm")).get,
+          Image.loadQoiImage(Resource("lausanne/qoi-24bit.qoi")).get
         )
-      }
+      )
     }
   }
 }

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageWriterSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageWriterSpec.scala
@@ -22,25 +22,19 @@ class ImageWriterSpec extends munit.FunSuite {
     test("Write a PPM image") {
       roundtripTest(Resource("scala/ppm-p3.ppm"), ppm.PpmImageFormat.defaultFormat)
       roundtripTest(Resource("scala-rect/ppm-p3.ppm"), ppm.PpmImageFormat.defaultFormat)
-      // Native tests in debug require a large heap here
-      if (Platform() != Platform.Native)
-        roundtripTest(Resource("lausanne/ppm-p3.ppm"), ppm.PpmImageFormat.defaultFormat)
+      roundtripTest(Resource("lausanne/ppm-p3.ppm"), ppm.PpmImageFormat.defaultFormat)
     }
 
     test("Write a BMP image") {
       roundtripTest(Resource("scala/bmp-24bit.bmp"), bmp.BmpImageFormat.defaultFormat)
       roundtripTest(Resource("scala-rect/bmp-24bit.bmp"), bmp.BmpImageFormat.defaultFormat)
-      // Native tests in debug require a large heap here
-      if (Platform() != Platform.Native)
-        roundtripTest(Resource("lausanne/bmp-24bit.bmp"), bmp.BmpImageFormat.defaultFormat)
+      roundtripTest(Resource("lausanne/bmp-24bit.bmp"), bmp.BmpImageFormat.defaultFormat)
     }
 
     test("Write a QOI image") {
       roundtripTest(Resource("scala/qoi-24bit.qoi"), qoi.QoiImageFormat.defaultFormat)
       roundtripTest(Resource("scala-rect/qoi-24bit.qoi"), qoi.QoiImageFormat.defaultFormat)
-      // Native tests in debug require a large heap here
-      if (Platform() != Platform.Native)
-        roundtripTest(Resource("lausanne/qoi-24bit.qoi"), qoi.QoiImageFormat.defaultFormat)
+      roundtripTest(Resource("lausanne/qoi-24bit.qoi"), qoi.QoiImageFormat.defaultFormat)
     }
   }
 }

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioFormat.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioFormat.scala
@@ -4,14 +4,13 @@ import eu.joaocosta.minart.internal._
 
 /** Audio format AIFF files.
   */
-final class AiffAudioFormat[R, W](val byteReader: ByteReader[R], val byteWriter: ByteWriter[W], val bitRate: Int)
-    extends AiffAudioReader[R]
+final class AiffAudioFormat[W](val byteWriter: ByteWriter[W], val bitRate: Int)
+    extends AiffAudioReader
     with AiffAudioWriter[W]
 
 object AiffAudioFormat {
   val defaultFormat =
-    new AiffAudioFormat[ByteReader.CustomInputStream, Iterator[Array[Byte]]](
-      ByteReader.InputStreamByteReader,
+    new AiffAudioFormat[Iterator[Array[Byte]]](
       ByteWriter.IteratorByteWriter,
       16
     )

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioFormat.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioFormat.scala
@@ -2,9 +2,11 @@ package eu.joaocosta.minart.audio.sound.aiff
 
 /** Audio format AIFF files.
   */
-final class AiffAudioFormat(val bitRate: Int) extends AiffAudioReader with AiffAudioWriter
+final class AiffAudioFormat(sampleRate: Int, bitRate: Int)
+    extends AiffAudioReader
+    with AiffAudioWriter(sampleRate, bitRate)
 
 object AiffAudioFormat {
   val defaultFormat =
-    new AiffAudioFormat(16)
+    new AiffAudioFormat(sampleRate = 44100, bitRate = 16)
 }

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioFormat.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioFormat.scala
@@ -1,17 +1,10 @@
 package eu.joaocosta.minart.audio.sound.aiff
 
-import eu.joaocosta.minart.internal._
-
 /** Audio format AIFF files.
   */
-final class AiffAudioFormat[W](val byteWriter: ByteWriter[W], val bitRate: Int)
-    extends AiffAudioReader
-    with AiffAudioWriter[W]
+final class AiffAudioFormat(val bitRate: Int) extends AiffAudioReader with AiffAudioWriter
 
 object AiffAudioFormat {
   val defaultFormat =
-    new AiffAudioFormat[Iterator[Array[Byte]]](
-      ByteWriter.IteratorByteWriter,
-      16
-    )
+    new AiffAudioFormat(16)
 }

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioReader.scala
@@ -10,13 +10,11 @@ import eu.joaocosta.minart.internal._
   *
   * https://mmsp.ece.mcgill.ca/Documents/AudioFormats/AIFF/Docs/AIFF-1.3.pdf
   */
-trait AiffAudioReader[ByteSeq] extends AudioClipReader {
+trait AiffAudioReader extends AudioClipReader {
 
-  val byteReader: ByteReader[ByteSeq]
   import AiffAudioReader._
-  private val byteFloatOps = new ByteFloatOps(byteReader)
-  import byteReader._
-  import byteFloatOps._
+  import ByteReader._
+  import ByteFloatOps._
 
   private val readId = readString(4)
 
@@ -110,7 +108,7 @@ trait AiffAudioReader[ByteSeq] extends AudioClipReader {
       }
   }
 
-  def loadClip(is: InputStream): Either[String, AudioClip] = {
+  final def loadClip(is: InputStream): Either[String, AudioClip] = {
     val bytes = fromInputStream(is)
     (for {
       formChunk <- loadChunkHeader.validate(_.id == "FORM", c => s"Invalid FORM chunk id: ${c.id}")
@@ -126,8 +124,8 @@ object AiffAudioReader {
     val paddedSize = size + (size % 2)
   }
 
-  private final class ByteFloatOps[ByteSeq](val byteReader: ByteReader[ByteSeq]) {
-    import byteReader._
+  private object ByteFloatOps {
+    import ByteReader._
     // Ported from https://github.com/python/cpython/blob/dcb342b5f9d931b030ca310bf3e175bbc54df5aa/Lib/aifc.py#L184-L199
     val readExtended: ParseState[String, Double] = for {
       head <- readBENumber(2)

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioWriter.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioWriter.scala
@@ -12,10 +12,8 @@ import eu.joaocosta.minart.internal._
   *
   * https://mmsp.ece.mcgill.ca/Documents/AudioFormats/AIFF/Docs/AIFF-1.3.pdf
   */
-trait AiffAudioWriter extends AudioClipWriter {
-  val sampleRate = 44100
-  val chunkSize  = 128
-  def bitRate: Int
+trait AiffAudioWriter(sampleRate: Int, bitRate: Int) extends AudioClipWriter {
+  private val chunkSize = 128
   require(Set(8, 16, 32).contains(bitRate))
 
   import AiffAudioWriter._

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioWriter.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioWriter.scala
@@ -12,18 +12,15 @@ import eu.joaocosta.minart.internal._
   *
   * https://mmsp.ece.mcgill.ca/Documents/AudioFormats/AIFF/Docs/AIFF-1.3.pdf
   */
-trait AiffAudioWriter[ByteSeq] extends AudioClipWriter {
-  val byteWriter: ByteWriter[ByteSeq]
-
+trait AiffAudioWriter extends AudioClipWriter {
   val sampleRate = 44100
   val chunkSize  = 128
   def bitRate: Int
   require(Set(8, 16, 32).contains(bitRate))
 
   import AiffAudioWriter._
-  private val byteFloatOps = new ByteFloatOps(byteWriter)
-  import byteWriter._
-  import byteFloatOps._
+  import ByteWriter._
+  import ByteFloatOps._
 
   private def convertSample(x: Double): List[Int] = bitRate match {
     case 8 =>
@@ -84,7 +81,7 @@ trait AiffAudioWriter[ByteSeq] extends AudioClipWriter {
     _ <- writeString("AIFF")
   } yield ()
 
-  def storeClip(clip: AudioClip, os: OutputStream): Either[String, Unit] = {
+  final def storeClip(clip: AudioClip, os: OutputStream): Either[String, Unit] = {
     val state = for {
       _ <- storeFormChunk(clip)
       _ <- storeCommChunk(clip)
@@ -95,8 +92,8 @@ trait AiffAudioWriter[ByteSeq] extends AudioClipWriter {
 }
 
 object AiffAudioWriter {
-  private final class ByteFloatOps[ByteSeq](val byteWriter: ByteWriter[ByteSeq]) {
-    import byteWriter._
+  private object ByteFloatOps {
+    import ByteWriter._
 
     def writeExtended(x: Double): ByteStreamState[String] = {
       val (sign, absX) = if (x < 0) (0x8000, -x) else (0, x)

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/qoa/QoaAudioFormat.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/qoa/QoaAudioFormat.scala
@@ -1,14 +1,9 @@
 package eu.joaocosta.minart.audio.sound.qoa
 
-import eu.joaocosta.minart.internal._
-
 /** Audio format QOA files.
   */
-final class QoaAudioFormat[R](val byteReader: ByteReader[R]) extends QoaAudioReader[R]
+final class QoaAudioFormat() extends QoaAudioReader
 
 object QoaAudioFormat {
-  val defaultFormat =
-    new QoaAudioFormat[ByteReader.CustomInputStream](
-      ByteReader.InputStreamByteReader
-    )
+  val defaultFormat = new QoaAudioFormat()
 }

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/qoa/QoaAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/qoa/QoaAudioReader.scala
@@ -12,10 +12,9 @@ import eu.joaocosta.minart.internal._
   *
   * https://qoaformat.org/qoa-specification.pdf
   */
-trait QoaAudioReader[ByteSeq] extends AudioClipReader {
+trait QoaAudioReader extends AudioClipReader {
 
-  val byteReader: ByteReader[ByteSeq]
-  import byteReader._
+  import ByteReader._
 
   @tailrec
   private def extractResiduals(res: Long, acc: List[Int] = Nil): List[Int] =
@@ -109,7 +108,7 @@ trait QoaAudioReader[ByteSeq] extends AudioClipReader {
     samples <- readBENumber(4).validate(_ > 0, _ => "Streaming QOA files are not supported.")
   } yield samples
 
-  def loadClip(is: InputStream): Either[String, AudioClip] = {
+  final def loadClip(is: InputStream): Either[String, AudioClip] = {
     val bytes = fromInputStream(is)
     (for {
       samples <- loadQoaHeader

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioFormat.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioFormat.scala
@@ -1,13 +1,12 @@
 package eu.joaocosta.minart.audio.sound.rtttl
 
 import eu.joaocosta.minart.audio._
-import eu.joaocosta.minart.internal._
 
 /** Audio format RTTTL files.
   */
-final class RtttlAudioFormat[R](val oscilator: Oscillator, val byteReader: ByteReader[R]) extends RtttlAudioReader[R]
+final class RtttlAudioFormat(val oscilator: Oscillator) extends RtttlAudioReader
 
 object RtttlAudioFormat {
   val defaultFormat =
-    new RtttlAudioFormat[ByteReader.CustomInputStream](Oscillator.sin, ByteReader.InputStreamByteReader)
+    new RtttlAudioFormat(Oscillator.sin)
 }

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioReader.scala
@@ -8,14 +8,12 @@ import eu.joaocosta.minart.internal._
 
 /** Audio reader for RTTTL files.
   */
-trait RtttlAudioReader[ByteSeq] extends AudioClipReader {
+trait RtttlAudioReader extends AudioClipReader {
 
-  val byteReader: ByteReader[ByteSeq]
   val oscilator: Oscillator
   import RtttlAudioReader._
-  private val byteStringOps = new ByteStringOps(byteReader)
-  import byteReader._
-  import byteStringOps._
+  import ByteReader._
+  import ByteStringOps._
 
   private def parseHeader(jintu: String, defaultValue: String): Either[String, Header] = {
     val defaultSection = defaultValue.split(",").map(_.split("="))
@@ -86,7 +84,7 @@ trait RtttlAudioReader[ByteSeq] extends AudioClipReader {
       }
   }
 
-  def loadClip(is: InputStream): Either[String, AudioClip] = {
+  final def loadClip(is: InputStream): Either[String, AudioClip] = {
     val bytes = fromInputStream(is)
     (for {
       jintu    <- readNextSection
@@ -109,8 +107,8 @@ object RtttlAudioReader {
     }
   }
 
-  private final class ByteStringOps[ByteSeq](val byteReader: ByteReader[ByteSeq]) {
-    import byteReader._
+  private object ByteStringOps {
+    import ByteReader._
     private val separator = ':'.toInt
 
     val readNextSection: ParseState[String, String] =

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioFormat.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioFormat.scala
@@ -2,11 +2,11 @@ package eu.joaocosta.minart.audio.sound.wav
 
 /** Audio format WAV files.
   */
-final class WavAudioFormat(val bitRate: Int) extends WavAudioReader with WavAudioWriter
+final class WavAudioFormat(sampleRate: Int, bitRate: Int)
+    extends WavAudioReader
+    with WavAudioWriter(sampleRate, bitRate)
 
 object WavAudioFormat {
   val defaultFormat =
-    new WavAudioFormat(
-      16
-    )
+    new WavAudioFormat(sampleRate = 44100, bitRate = 16)
 }

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioFormat.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioFormat.scala
@@ -4,14 +4,13 @@ import eu.joaocosta.minart.internal._
 
 /** Audio format WAV files.
   */
-final class WavAudioFormat[R, W](val byteReader: ByteReader[R], val byteWriter: ByteWriter[W], val bitRate: Int)
-    extends WavAudioReader[R]
+final class WavAudioFormat[W](val byteWriter: ByteWriter[W], val bitRate: Int)
+    extends WavAudioReader
     with WavAudioWriter[W]
 
 object WavAudioFormat {
   val defaultFormat =
-    new WavAudioFormat[ByteReader.CustomInputStream, Iterator[Array[Byte]]](
-      ByteReader.InputStreamByteReader,
+    new WavAudioFormat[Iterator[Array[Byte]]](
       ByteWriter.IteratorByteWriter,
       16
     )

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioFormat.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioFormat.scala
@@ -1,17 +1,12 @@
 package eu.joaocosta.minart.audio.sound.wav
 
-import eu.joaocosta.minart.internal._
-
 /** Audio format WAV files.
   */
-final class WavAudioFormat[W](val byteWriter: ByteWriter[W], val bitRate: Int)
-    extends WavAudioReader
-    with WavAudioWriter[W]
+final class WavAudioFormat(val bitRate: Int) extends WavAudioReader with WavAudioWriter
 
 object WavAudioFormat {
   val defaultFormat =
-    new WavAudioFormat[Iterator[Array[Byte]]](
-      ByteWriter.IteratorByteWriter,
+    new WavAudioFormat(
       16
     )
 }

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioReader.scala
@@ -10,10 +10,9 @@ import eu.joaocosta.minart.internal._
   *
   * http://tiny.systems/software/soundProgrammer/WavFormatDocs.pdf
   */
-trait WavAudioReader[ByteSeq] extends AudioClipReader {
+trait WavAudioReader extends AudioClipReader {
 
-  val byteReader: ByteReader[ByteSeq]
-  import byteReader._
+  import ByteReader._
 
   private val readId = readString(4)
 
@@ -103,7 +102,7 @@ trait WavAudioReader[ByteSeq] extends AudioClipReader {
     _ <- readString(4).validate(_ == "WAVE", m => s"Unsupported format: $m. Expected WAVE")
   } yield ()
 
-  def loadClip(is: InputStream): Either[String, AudioClip] = {
+  final def loadClip(is: InputStream): Either[String, AudioClip] = {
     val bytes = fromInputStream(is)
     (for {
       _    <- loadRiffHeader

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioWriter.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioWriter.scala
@@ -12,15 +12,13 @@ import eu.joaocosta.minart.internal._
   *
   * http://tiny.systems/software/soundProgrammer/WavFormatDocs.pdf
   */
-trait WavAudioWriter[ByteSeq] extends AudioClipWriter {
-  val byteWriter: ByteWriter[ByteSeq]
-
+trait WavAudioWriter extends AudioClipWriter {
   val sampleRate = 44100
   val chunkSize  = 128
   def bitRate: Int
   require(Set(8, 16, 32).contains(bitRate))
 
-  import byteWriter._
+  import ByteWriter._
 
   private def convertSample(x: Double): List[Int] = bitRate match {
     case 8 =>
@@ -70,7 +68,7 @@ trait WavAudioWriter[ByteSeq] extends AudioClipWriter {
     _ <- writeString("WAVE")
   } yield ()
 
-  def storeClip(clip: AudioClip, os: OutputStream): Either[String, Unit] = {
+  final def storeClip(clip: AudioClip, os: OutputStream): Either[String, Unit] = {
     val state = for {
       _ <- storeRiffHeader(clip)
       _ <- storeFmtChunk

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioWriter.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioWriter.scala
@@ -12,10 +12,8 @@ import eu.joaocosta.minart.internal._
   *
   * http://tiny.systems/software/soundProgrammer/WavFormatDocs.pdf
   */
-trait WavAudioWriter extends AudioClipWriter {
-  val sampleRate = 44100
-  val chunkSize  = 128
-  def bitRate: Int
+trait WavAudioWriter(sampleRate: Int, bitRate: Int) extends AudioClipWriter {
+  final val chunkSize = 128
   require(Set(8, 16, 32).contains(bitRate))
 
   import ByteWriter._


### PR DESCRIPTION
There was currently a single `ByteReader`/`ByteWriter` implementation and things will probably stay this way. However, the code was going out of it's way to accommodate pluggable implementations.

This PR removes all the generics, which should improve performance.
This also enables the Scala native image tests, as those should work now.