### PR TITLE
Apply some scala 3 automatic rewrites

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
@@ -3,11 +3,11 @@ package eu.joaocosta.minart.backend
 import scala.scalajs.js
 
 import org.scalajs.dom
-import org.scalajs.dom.html.{Canvas => JsCanvas}
+import org.scalajs.dom.html.{Canvas as JsCanvas}
 import org.scalajs.dom.{Event, KeyboardEvent, PointerEvent}
 
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.input._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.input.*
 
 /** A low level Canvas implementation that shows the image in an HTML Canvas element.
   */

--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataOpaqueSurface.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataOpaqueSurface.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.backend
 
-import scala.scalajs.js.typedarray._
+import scala.scalajs.js.typedarray.*
 
 import org.scalajs.dom.ImageData
 

--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.backend
 
-import scala.scalajs.js.typedarray._
+import scala.scalajs.js.typedarray.*
 
 import org.scalajs.dom.ImageData
 

--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsAudioPlayer.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsAudioPlayer.scala
@@ -1,9 +1,9 @@
 package eu.joaocosta.minart.backend
 
-import org.scalajs.dom._
+import org.scalajs.dom.*
 
-import eu.joaocosta.minart.audio._
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.audio.*
+import eu.joaocosta.minart.runtime.*
 
 final class JsAudioPlayer() extends LowLevelAudioPlayer {
   private lazy val audioCtx      = new AudioContext();

--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsKeyMapping.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsKeyMapping.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.backend
 
-import eu.joaocosta.minart.input.KeyboardInput._
+import eu.joaocosta.minart.input.KeyboardInput.*
 
 /** Key mappings for the JavaScript backend.
   */

--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsLoopRunner.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsLoopRunner.scala
@@ -1,12 +1,12 @@
 package eu.joaocosta.minart.backend
 
-import scala.concurrent._
+import scala.concurrent.*
 import scala.scalajs.js.{isUndefined, timers}
 import scala.util.Try
 
 import org.scalajs.dom
 
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.runtime.*
 
 /** Loop runner for the JavaScript backend.
   */

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -2,21 +2,21 @@ package eu.joaocosta.minart.backend
 
 import java.awt.event.{
   KeyEvent,
-  KeyListener => JavaKeyListener,
+  KeyListener as JavaKeyListener,
   MouseEvent,
-  MouseListener => JavaMouseListener,
+  MouseListener as JavaMouseListener,
   WindowAdapter,
   WindowEvent
 }
 import java.awt.image.BufferedImage
-import java.awt.{Canvas => JavaCanvas, Color => JavaColor, Dimension, Graphics, GraphicsEnvironment, MouseInfo}
+import java.awt.{Canvas as JavaCanvas, Color as JavaColor, Dimension, Graphics, GraphicsEnvironment, MouseInfo}
 import javax.swing.{JFrame, WindowConstants}
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 import eu.joaocosta.minart.graphics.LowLevelCanvas.ExtendedSettings
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.input._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.input.*
 
 /** A low level Canvas implementation that shows the image in an AWT/Swing window.
   */

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtKeyMapping.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtKeyMapping.scala
@@ -2,7 +2,7 @@ package eu.joaocosta.minart.backend
 
 import java.awt.event.KeyEvent
 
-import eu.joaocosta.minart.input.KeyboardInput._
+import eu.joaocosta.minart.input.KeyboardInput.*
 
 /** Key mappings for the Java platform, backed by AWT.
   */

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaAudioPlayer.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaAudioPlayer.scala
@@ -1,11 +1,11 @@
 package eu.joaocosta.minart.backend
 
-import javax.sound.sampled._
+import javax.sound.sampled.*
 
-import scala.concurrent._
+import scala.concurrent.*
 
-import eu.joaocosta.minart.audio._
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.audio.*
+import eu.joaocosta.minart.runtime.*
 
 final class JavaAudioPlayer() extends LowLevelAudioPlayer {
   private val preemptiveCallback             = LoopFrequency.hz15.millis

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaLoopRunner.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaLoopRunner.scala
@@ -1,9 +1,9 @@
 package eu.joaocosta.minart.backend
 
 import scala.annotation.tailrec
-import scala.concurrent._
+import scala.concurrent.*
 
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.runtime.*
 
 /** Loop Runner for the Java platform.
   */

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaResource.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaResource.scala
@@ -2,7 +2,7 @@ package eu.joaocosta.minart.backend
 
 import java.io.{BufferedInputStream, File, FileInputStream, FileOutputStream, InputStream, OutputStream}
 
-import scala.concurrent._
+import scala.concurrent.*
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 

--- a/backend/jvm/src/test/scala/eu/joaocosta/minart/graphics/BufferedImageSurfaceSpec.scala
+++ b/backend/jvm/src/test/scala/eu/joaocosta/minart/graphics/BufferedImageSurfaceSpec.scala
@@ -2,7 +2,7 @@ package eu.joaocosta.minart.graphics
 
 import java.awt.image.BufferedImage
 
-import eu.joaocosta.minart.backend._
+import eu.joaocosta.minart.backend.*
 
 class BufferedImageSurfaceSpec extends MutableSurfaceTests {
   lazy val image   = new BufferedImage(64, 48, BufferedImage.TYPE_INT_ARGB)

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlAudioPlayer.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlAudioPlayer.scala
@@ -1,16 +1,16 @@
 package eu.joaocosta.minart.backend
 
-import scala.concurrent._
+import scala.concurrent.*
 import scala.scalanative.runtime.ByteArray
-import scala.scalanative.unsafe._
-import scala.scalanative.unsigned._
+import scala.scalanative.unsafe.*
+import scala.scalanative.unsigned.*
 
-import sdl2.all._
-import sdl2.enumerations.SDL_AudioFormat._
-import sdl2.enumerations.SDL_InitFlag._
+import sdl2.all.*
+import sdl2.enumerations.SDL_AudioFormat.*
+import sdl2.enumerations.SDL_InitFlag.*
 
-import eu.joaocosta.minart.audio._
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.audio.*
+import eu.joaocosta.minart.runtime.*
 
 final class SdlAudioPlayer() extends LowLevelAudioPlayer {
   private val preemptiveCallback        = LoopFrequency.hz15.millis

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -1,17 +1,17 @@
 package eu.joaocosta.minart.backend
 
-import scala.scalanative.unsafe._
-import scala.scalanative.unsigned._
+import scala.scalanative.unsafe.*
+import scala.scalanative.unsigned.*
 
-import sdl2.all._
-import sdl2.enumerations.SDL_BlendMode._
-import sdl2.enumerations.SDL_EventType._
-import sdl2.enumerations.SDL_InitFlag._
-import sdl2.enumerations.SDL_KeyCode._
-import sdl2.enumerations.SDL_WindowFlags._
+import sdl2.all.*
+import sdl2.enumerations.SDL_BlendMode.*
+import sdl2.enumerations.SDL_EventType.*
+import sdl2.enumerations.SDL_InitFlag.*
+import sdl2.enumerations.SDL_KeyCode.*
+import sdl2.enumerations.SDL_WindowFlags.*
 
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.input._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.input.*
 
 /** A low level Canvas implementation that shows the image in a SDL Window.
   */

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlKeyMapping.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlKeyMapping.scala
@@ -1,9 +1,9 @@
 package eu.joaocosta.minart.backend
 
-import sdl2.all._
-import sdl2.enumerations.SDL_KeyCode._
+import sdl2.all.*
+import sdl2.enumerations.SDL_KeyCode.*
 
-import eu.joaocosta.minart.input.KeyboardInput._
+import eu.joaocosta.minart.input.KeyboardInput.*
 
 /** Key mappings for the Native platform, backed by SDL.
   */

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlLoopRunner.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlLoopRunner.scala
@@ -1,14 +1,14 @@
 package eu.joaocosta.minart.backend
 
-import scala.concurrent._
-import scala.scalanative.libc.stdlib._
-import scala.scalanative.unsafe._
-import scala.scalanative.unsigned._
+import scala.concurrent.*
+import scala.scalanative.libc.stdlib.*
+import scala.scalanative.unsafe.*
+import scala.scalanative.unsigned.*
 
-import sdl2.all._
-import sdl2.enumerations.SDL_EventType._
+import sdl2.all.*
+import sdl2.enumerations.SDL_EventType.*
 
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.runtime.*
 
 /** Loop Runner for the native backend, backed by SDL.
   */

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
@@ -1,10 +1,10 @@
 package eu.joaocosta.minart.backend
 
-import scala.scalanative.unsafe._
-import scala.scalanative.unsigned._
+import scala.scalanative.unsafe.*
+import scala.scalanative.unsigned.*
 
-import sdl2.all._
-import sdl2.enumerations.SDL_BlendMode._
+import sdl2.all.*
+import sdl2.enumerations.SDL_BlendMode.*
 
 import eu.joaocosta.minart.graphics.{BlendMode, Color, MutableSurface, Surface}
 

--- a/backend/native/src/test/scala/eu/joaocosta/minart/graphics/SdlSurfaceSpec.scala
+++ b/backend/native/src/test/scala/eu/joaocosta/minart/graphics/SdlSurfaceSpec.scala
@@ -1,10 +1,10 @@
 package eu.joaocosta.minart.graphics
 
-import scala.scalanative.unsigned._
+import scala.scalanative.unsigned.*
 
-import sdl2.all._
+import sdl2.all.*
 
-import eu.joaocosta.minart.backend._
+import eu.joaocosta.minart.backend.*
 
 class SdlImageSurfaceSpec extends MutableSurfaceTests {
   lazy val surface = new SdlSurface(

--- a/backend/shared/src/test/scala/eu/joaocosta/minart/runtime/AppLoopSpec.scala
+++ b/backend/shared/src/test/scala/eu/joaocosta/minart/runtime/AppLoopSpec.scala
@@ -2,10 +2,10 @@ package eu.joaocosta.minart.runtime
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import eu.joaocosta.minart.backend._
+import eu.joaocosta.minart.backend.*
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.input._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.input.*
 
 class AppLoopSpec extends munit.FunSuite {
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioPlayer.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioPlayer.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.audio
 
-import eu.joaocosta.minart.backend.defaults._
+import eu.joaocosta.minart.backend.defaults.*
 
 /** Multi-channel mono audio player.
   *

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioQueue.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioQueue.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.audio
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 /** Internal AudioQueue abstraction.
   *

--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/LowLevelAudioPlayer.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/LowLevelAudioPlayer.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.audio
 
-import eu.joaocosta.minart.backend.defaults._
+import eu.joaocosta.minart.backend.defaults.*
 import eu.joaocosta.minart.backend.subsystem.LowLevelSubsystem
 
 /** A low-level version of a audio player with init and close methods.

--- a/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/AllSubsystems.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/AllSubsystems.scala
@@ -1,7 +1,7 @@
 package eu.joaocosta.minart.backend.subsystem
 
-import eu.joaocosta.minart.audio._
-import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.audio.*
+import eu.joaocosta.minart.graphics.*
 
 /** Internal object with an intersection of all subsystems.
   */

--- a/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/LowLevelAllSubsystems.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/backend/subsystem/LowLevelAllSubsystems.scala
@@ -1,8 +1,8 @@
 package eu.joaocosta.minart.backend.subsystem
 
-import eu.joaocosta.minart.audio._
+import eu.joaocosta.minart.audio.*
 import eu.joaocosta.minart.backend.defaults.DefaultBackend
-import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.graphics.*
 
 /** Aggregation of all subsystems.
   */

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Canvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Canvas.scala
@@ -1,7 +1,7 @@
 package eu.joaocosta.minart.graphics
 
-import eu.joaocosta.minart.backend.defaults._
-import eu.joaocosta.minart.input._
+import eu.joaocosta.minart.backend.defaults.*
+import eu.joaocosta.minart.input.*
 
 /** Window with a canvas that can be painted.
   *

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/LowLevelCanvas.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/LowLevelCanvas.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.graphics
 
-import eu.joaocosta.minart.backend.defaults._
+import eu.joaocosta.minart.backend.defaults.*
 import eu.joaocosta.minart.backend.subsystem.LowLevelSubsystem
 
 /** A low-level version of a canvas with init and close methods.

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/AppLoop.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/AppLoop.scala
@@ -2,11 +2,11 @@ package eu.joaocosta.minart.runtime
 
 import scala.concurrent.Future
 
-import eu.joaocosta.minart.audio._
-import eu.joaocosta.minart.backend.defaults._
-import eu.joaocosta.minart.backend.subsystem._
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.audio.*
+import eu.joaocosta.minart.backend.defaults.*
+import eu.joaocosta.minart.backend.subsystem.*
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.runtime.*
 
 /** App loop that keeps an internal state that is passed to every iteration.
   */

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/LoopFrequency.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/LoopFrequency.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.runtime
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 /** Definition of a loop iteration frequency.
   *

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/LoopRunner.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/LoopRunner.scala
@@ -2,7 +2,7 @@ package eu.joaocosta.minart.runtime
 
 import scala.concurrent.Future
 
-import eu.joaocosta.minart.backend.defaults._
+import eu.joaocosta.minart.backend.defaults.*
 
 /** Abstraction that allows to run loops at a certain frequency in a platforrm agnostic way.
   *

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/Resource.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/Resource.scala
@@ -6,7 +6,7 @@ import scala.concurrent.Future
 import scala.io.Source
 import scala.util.{Try, Using}
 
-import eu.joaocosta.minart.backend.defaults._
+import eu.joaocosta.minart.backend.defaults.*
 
 /** Resource that can be loaded.
   */

--- a/examples/snapshot/01-color-square.sc
+++ b/examples/snapshot/01-color-square.sc
@@ -19,7 +19,7 @@
  * Since we want to work with graphics, we also need to import eu.joaocosta.minart.graphics._
  */
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.graphics.*
 
 /*
  * The Canvas.Settings are the settings of our window.

--- a/examples/snapshot/02-portable-color-square.sc
+++ b/examples/snapshot/02-portable-color-square.sc
@@ -9,8 +9,8 @@
  * We start with the same imports and canvas settings
  */
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.runtime.*
 
 val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = Some(4))
 

--- a/examples/snapshot/03-fire-animation.sc
+++ b/examples/snapshot/03-fire-animation.sc
@@ -14,8 +14,8 @@
  * render loops, such as the LoopFrequency.
  */
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.runtime.*
 
 val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = Some(4))
 

--- a/examples/snapshot/04-pointer.sc
+++ b/examples/snapshot/04-pointer.sc
@@ -12,9 +12,9 @@
  * We'll need this to handle our inputs, such as keyboard and mouse.
  */
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.input._
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.input.*
+import eu.joaocosta.minart.runtime.*
 
 /** Note the adition of clearColor here.
   * This is the color of the canvas when nothing is drawn.

--- a/examples/snapshot/05-snake-game.sc
+++ b/examples/snapshot/05-snake-game.sc
@@ -23,9 +23,8 @@ import eu.joaocosta.minart.runtime._
  */
 val canvasSettings = Canvas.Settings(width = 32, height = 32, scale = Some(16), clearColor = Color(0, 0, 0))
 
-/**
- * Then we define our game logic, this is an implementation of the classic snake game.
- */
+/** Then we define our game logic, this is an implementation of the classic snake game.
+  */
 def mod(x: Int, y: Int): Int =
   if (x >= 0) x % y
   else mod(x + y, y)
@@ -33,9 +32,9 @@ def mod(x: Int, y: Int): Int =
 final case class Position(x: Int, y: Int)
 
 enum Direction(val x: Int, val y: Int) {
-  case Up extends Direction(0, -1)
-  case Down extends Direction(0, 1)
-  case Left extends Direction(-1, 0)
+  case Up    extends Direction(0, -1)
+  case Down  extends Direction(0, 1)
+  case Left  extends Direction(-1, 0)
   case Right extends Direction(1, 0)
 }
 
@@ -51,15 +50,15 @@ final case class GameState(
   lazy val boardHeight = board.size
 
   lazy val nextState: GameState = {
-    val newApplePos = 
+    val newApplePos =
       if (applePos == snakeHead) Position(Random.nextInt(boardWidth - 1), Random.nextInt(boardHeight - 1))
       else applePos
     val newSnakeSize =
       if (applePos == snakeHead) snakeSize + 1
       else snakeSize
     val newBoard = board
-        .updated(snakeHead.y, board(snakeHead.y).updated(snakeHead.x, snakeSize))
-        .map(_.map(life => Math.max(0, life - 1)))
+      .updated(snakeHead.y, board(snakeHead.y).updated(snakeHead.x, snakeSize))
+      .map(_.map(life => Math.max(0, life - 1)))
     copy(
       board = newBoard,
       snakeHead = Position(mod(snakeHead.x + snakeDir.x, boardWidth), mod(snakeHead.y + snakeDir.y, boardHeight)),
@@ -92,8 +91,8 @@ val initialState = GameState(Vector.fill(canvasSettings.height)(Vector.fill(canv
  * and it returns the next state.
  */
 AppLoop
-  .statefulRenderLoop(
-    (state: GameState) => (canvas: Canvas) => {
+  .statefulRenderLoop((state: GameState) =>
+    (canvas: Canvas) => {
       canvas.clear()
 
       // We draw the snake body
@@ -108,7 +107,7 @@ AppLoop
 
       // Then a nice red apple
       canvas.putPixel(state.applePos.x, state.applePos.y, Color(255, 0, 0))
-      
+
       // Then redraw the canvas
       canvas.redraw()
 
@@ -117,11 +116,11 @@ AppLoop
        */
       if (state.gameOver) initialState
       else state.updateSnakeDir(canvas.getKeyboardInput()).nextState
-    },
+    }
   )
   .configure(
     canvasSettings,
     LoopFrequency.fromHz(15), // 15 FPS
-    initialState // Notice that the configure function now needs an initialState
+    initialState              // Notice that the configure function now needs an initialState
   )
   .run()

--- a/examples/snapshot/05-snake-game.sc
+++ b/examples/snapshot/05-snake-game.sc
@@ -13,9 +13,9 @@
 import scala.util.Random
 
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.input._
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.input.*
+import eu.joaocosta.minart.runtime.*
 
 /*
  * Again, let's define our canvas settings.

--- a/examples/snapshot/06-surface-blit.sc
+++ b/examples/snapshot/06-surface-blit.sc
@@ -8,8 +8,8 @@
  */
 
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.runtime.*
 
 val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = Some(4))
 

--- a/examples/snapshot/07-canvas-settings.sc
+++ b/examples/snapshot/07-canvas-settings.sc
@@ -5,9 +5,9 @@
   * Here's how to do it.
   */
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.graphics.*
 import eu.joaocosta.minart.input.KeyboardInput.Key
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.runtime.*
 
 /** Let's define some settings.
   * Note that one of those will actually go fullScreen.

--- a/examples/snapshot/09-image.sc
+++ b/examples/snapshot/09-image.sc
@@ -6,9 +6,9 @@
  * The minart-image library and graphics.image package allows one to do just that.
  */
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.graphics.image._
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.graphics.image.*
+import eu.joaocosta.minart.runtime.*
 
 val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = Some(4))
 

--- a/examples/snapshot/10-surface-view.sc
+++ b/examples/snapshot/10-surface-view.sc
@@ -10,9 +10,9 @@
  * This tutorial will show how to use those
  */
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.graphics.image._
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.graphics.image.*
+import eu.joaocosta.minart.runtime.*
 
 // First, let's load our example scala logo image
 val canvasSettings = Canvas.Settings(width = 128, height = 128, scale = Some(4), clearColor = Color(0, 0, 0))

--- a/examples/snapshot/11-audio.sc
+++ b/examples/snapshot/11-audio.sc
@@ -5,12 +5,12 @@
   *
   * Note: This is an experimental API, it might break in a future version
   */
-import eu.joaocosta.minart.audio._
+import eu.joaocosta.minart.audio.*
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.backend.subsystem._
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.input._
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.backend.subsystem.*
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.input.*
+import eu.joaocosta.minart.runtime.*
 
 /** First, let's define a simple song
   */

--- a/examples/snapshot/12-audio-clip.sc
+++ b/examples/snapshot/12-audio-clip.sc
@@ -6,13 +6,13 @@
   *
   * Note: This is an experimental API, it might break in a future version
   */
-import eu.joaocosta.minart.audio._
-import eu.joaocosta.minart.audio.sound._
+import eu.joaocosta.minart.audio.*
+import eu.joaocosta.minart.audio.sound.*
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.backend.subsystem._
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.input._
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.backend.subsystem.*
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.input.*
+import eu.joaocosta.minart.runtime.*
 
 /** Just like loading an image, we can load sound resources
   */

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/Image.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/Image.scala
@@ -2,7 +2,7 @@ package eu.joaocosta.minart.graphics.image
 
 import scala.util.{Failure, Success, Try}
 
-import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.graphics.*
 import eu.joaocosta.minart.runtime.Resource
 
 /** Object containing user-friendly functions to images. */

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ImageReader.scala
@@ -4,7 +4,7 @@ import java.io.{ByteArrayInputStream, InputStream}
 
 import scala.util.Try
 
-import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.graphics.*
 import eu.joaocosta.minart.runtime.Resource
 
 /** Image reader with a low-level implementation on how to load an image.

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ImageWriter.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ImageWriter.scala
@@ -4,7 +4,7 @@ import java.io.{ByteArrayOutputStream, OutputStream}
 
 import scala.util.Try
 
-import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.graphics.*
 import eu.joaocosta.minart.runtime.Resource
 
 /** Image writer with a low-level implementation on how to store an image.

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/SpriteSheet.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/SpriteSheet.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.graphics.image
 
-import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.graphics.*
 
 /** A sprite sheet containing multiple sprites in a single image.
   *

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageReader.scala
@@ -4,16 +4,16 @@ import java.io.InputStream
 
 import scala.annotation.tailrec
 
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.graphics.image._
-import eu.joaocosta.minart.internal._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.graphics.image.*
+import eu.joaocosta.minart.internal.*
 
 /** Image reader for BMP files.
   *
   * Supports uncompressed 24/32bit Windows BMPs.
   */
 trait BmpImageReader extends ImageReader {
-  import ByteReader._
+  import ByteReader.*
 
   private val loadRgbPixel: ParseState[String, Color] =
     readRawBytes(3)

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageWriter.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageWriter.scala
@@ -4,16 +4,16 @@ import java.io.OutputStream
 
 import scala.annotation.tailrec
 
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.graphics.image._
-import eu.joaocosta.minart.internal._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.graphics.image.*
+import eu.joaocosta.minart.internal.*
 
 /** Image writer for BMP files.
   *
   * Stores data as uncompressed 24bit Windows BMPs.
   */
 trait BmpImageWriter extends ImageWriter {
-  import ByteWriter._
+  import ByteWriter.*
 
   private def storeBgrPixel(color: Color): ByteStreamState[String] =
     writeBytes(List(color.b, color.g, color.r))

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
@@ -4,18 +4,18 @@ import java.io.InputStream
 
 import scala.annotation.tailrec
 
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.graphics.image._
-import eu.joaocosta.minart.internal._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.graphics.image.*
+import eu.joaocosta.minart.internal.*
 
 /** Image reader for PGM/PPM files.
   *
   * Supports P2, P3, P5 and P6 PGM/PPM files with a 8 bit color range.
   */
 trait PpmImageReader extends ImageReader {
-  import PpmImageReader._
-  import ByteReader._
-  import ByteStringOps._
+  import PpmImageReader.*
+  import ByteReader.*
+  import ByteStringOps.*
 
   // P2
   private val loadStringGrayscalePixel: ParseState[String, Color] =
@@ -127,7 +127,7 @@ trait PpmImageReader extends ImageReader {
 
 object PpmImageReader {
   private object ByteStringOps {
-    import ByteReader._
+    import ByteReader.*
     private val space   = ' '.toInt
     private val newLine = '\n'.toInt
     private val comment = '#'.toInt

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageWriter.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageWriter.scala
@@ -4,16 +4,16 @@ import java.io.OutputStream
 
 import scala.annotation.tailrec
 
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.graphics.image._
-import eu.joaocosta.minart.internal._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.graphics.image.*
+import eu.joaocosta.minart.internal.*
 
 /** Image writer for PPM files.
   *
   * Stores data as P6 PPM files with a 8 bit color range.
   */
 trait PpmImageWriter extends ImageWriter {
-  import ByteWriter._
+  import ByteWriter.*
 
   private def storeBinaryRgbPixel(color: Color): ByteStreamState[String] =
     writeBytes(List(color.r, color.g, color.b))

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageReader.scala
@@ -2,16 +2,16 @@ package eu.joaocosta.minart.graphics.image.qoi
 
 import java.io.InputStream
 
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.graphics.image._
-import eu.joaocosta.minart.internal._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.graphics.image.*
+import eu.joaocosta.minart.internal.*
 
 /** Image reader for QOI files.
   */
 trait QoiImageReader extends ImageReader {
-  import QoiImageFormat._
-  import QoiImageReader._
-  import ByteReader._
+  import QoiImageFormat.*
+  import QoiImageReader.*
+  import ByteReader.*
 
   // Binary helpers
   private def wrapAround(b: Int): Int                = b & 0x0ff
@@ -21,7 +21,7 @@ trait QoiImageReader extends ImageReader {
 
   // Op loading
   private val opFromBytes: ParseState[String, Op] = {
-    import Op._
+    import Op.*
     readByte
       .collect(
         { case Some(tag) =>
@@ -54,7 +54,7 @@ trait QoiImageReader extends ImageReader {
 
   // State iteration
   private def nextState(state: QoiState, chunk: Op): QoiState = {
-    import Op._
+    import Op.*
     chunk match {
       case OpRgb(red, green, blue) =>
         val color = QoiColor(red, green, blue, state.previousColor.a)

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageWriter.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageWriter.scala
@@ -4,14 +4,14 @@ import java.io.OutputStream
 
 import scala.annotation.tailrec
 
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.graphics.image._
-import eu.joaocosta.minart.internal._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.graphics.image.*
+import eu.joaocosta.minart.internal.*
 
 /** Image writer for QOI files.
   */
 trait QoiImageWriter extends ImageWriter {
-  import ByteWriter._
+  import ByteWriter.*
 
   private def storeHeader(surface: Surface): ByteStreamState[String] = {
     (for {

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageReaderSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageReaderSpec.scala
@@ -3,8 +3,8 @@ package eu.joaocosta.minart.graphics.image
 import scala.util.Try
 
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.graphics._
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.graphics.*
+import eu.joaocosta.minart.runtime.*
 
 class ImageReaderSpec extends munit.FunSuite {
 

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageWriterSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ImageWriterSpec.scala
@@ -1,7 +1,7 @@
 package eu.joaocosta.minart.graphics.image
 
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.runtime.*
 
 class ImageWriterSpec extends munit.FunSuite {
 

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/SpriteSheetSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/SpriteSheetSpec.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.graphics.image
 
-import eu.joaocosta.minart.graphics._
+import eu.joaocosta.minart.graphics.*
 
 class SpriteSheetSpec extends munit.FunSuite {
   val surface = new RamSurface(

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/AudioClipReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/AudioClipReader.scala
@@ -4,7 +4,7 @@ import java.io.{ByteArrayInputStream, InputStream}
 
 import scala.util.Try
 
-import eu.joaocosta.minart.audio._
+import eu.joaocosta.minart.audio.*
 import eu.joaocosta.minart.runtime.Resource
 
 /** Audio Clip reader with a low-level implementation on how to load an audio clip.

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/AudioClipWriter.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/AudioClipWriter.scala
@@ -4,7 +4,7 @@ import java.io.{ByteArrayOutputStream, OutputStream}
 
 import scala.util.Try
 
-import eu.joaocosta.minart.audio._
+import eu.joaocosta.minart.audio.*
 import eu.joaocosta.minart.runtime.Resource
 
 /** Audio Clip writer with a low-level implementation on how to load an audio clip.

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/Sound.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/Sound.scala
@@ -2,7 +2,7 @@ package eu.joaocosta.minart.audio.sound
 
 import scala.util.{Failure, Success, Try}
 
-import eu.joaocosta.minart.audio._
+import eu.joaocosta.minart.audio.*
 import eu.joaocosta.minart.runtime.Resource
 
 /** Object containing user-friendly functions to audio clips. */

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioReader.scala
@@ -2,9 +2,9 @@ package eu.joaocosta.minart.audio.sound.aiff
 
 import java.io.InputStream
 
-import eu.joaocosta.minart.audio._
-import eu.joaocosta.minart.audio.sound._
-import eu.joaocosta.minart.internal._
+import eu.joaocosta.minart.audio.*
+import eu.joaocosta.minart.audio.sound.*
+import eu.joaocosta.minart.internal.*
 
 /** Audio reader for AIFF files.
   *
@@ -12,9 +12,9 @@ import eu.joaocosta.minart.internal._
   */
 trait AiffAudioReader extends AudioClipReader {
 
-  import AiffAudioReader._
-  import ByteReader._
-  import ByteFloatOps._
+  import AiffAudioReader.*
+  import ByteReader.*
+  import ByteFloatOps.*
 
   private val readId = readString(4)
 
@@ -125,7 +125,7 @@ object AiffAudioReader {
   }
 
   private object ByteFloatOps {
-    import ByteReader._
+    import ByteReader.*
     // Ported from https://github.com/python/cpython/blob/dcb342b5f9d931b030ca310bf3e175bbc54df5aa/Lib/aifc.py#L184-L199
     val readExtended: ParseState[String, Double] = for {
       head <- readBENumber(2)

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioWriter.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/aiff/AiffAudioWriter.scala
@@ -4,9 +4,9 @@ import java.io.OutputStream
 
 import scala.annotation.tailrec
 
-import eu.joaocosta.minart.audio._
-import eu.joaocosta.minart.audio.sound._
-import eu.joaocosta.minart.internal._
+import eu.joaocosta.minart.audio.*
+import eu.joaocosta.minart.audio.sound.*
+import eu.joaocosta.minart.internal.*
 
 /** Audio writer for AIFF files.
   *
@@ -16,9 +16,9 @@ trait AiffAudioWriter(sampleRate: Int, bitRate: Int) extends AudioClipWriter {
   private val chunkSize = 128
   require(Set(8, 16, 32).contains(bitRate))
 
-  import AiffAudioWriter._
-  import ByteWriter._
-  import ByteFloatOps._
+  import AiffAudioWriter.*
+  import ByteWriter.*
+  import ByteFloatOps.*
 
   private def convertSample(x: Double): List[Int] = bitRate match {
     case 8 =>
@@ -91,7 +91,7 @@ trait AiffAudioWriter(sampleRate: Int, bitRate: Int) extends AudioClipWriter {
 
 object AiffAudioWriter {
   private object ByteFloatOps {
-    import ByteWriter._
+    import ByteWriter.*
 
     def writeExtended(x: Double): ByteStreamState[String] = {
       val (sign, absX) = if (x < 0) (0x8000, -x) else (0, x)

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/qoa/QoaAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/qoa/QoaAudioReader.scala
@@ -4,9 +4,9 @@ import java.io.InputStream
 
 import scala.annotation.tailrec
 
-import eu.joaocosta.minart.audio._
-import eu.joaocosta.minart.audio.sound._
-import eu.joaocosta.minart.internal._
+import eu.joaocosta.minart.audio.*
+import eu.joaocosta.minart.audio.sound.*
+import eu.joaocosta.minart.internal.*
 
 /** Audio reader for QOA files.
   *
@@ -14,7 +14,7 @@ import eu.joaocosta.minart.internal._
   */
 trait QoaAudioReader extends AudioClipReader {
 
-  import ByteReader._
+  import ByteReader.*
 
   @tailrec
   private def extractResiduals(res: Long, acc: List[Int] = Nil): List[Int] =

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioFormat.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioFormat.scala
@@ -1,6 +1,6 @@
 package eu.joaocosta.minart.audio.sound.rtttl
 
-import eu.joaocosta.minart.audio._
+import eu.joaocosta.minart.audio.*
 
 /** Audio format RTTTL files.
   */

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/rtttl/RtttlAudioReader.scala
@@ -2,18 +2,18 @@ package eu.joaocosta.minart.audio.sound.rtttl
 
 import java.io.InputStream
 
-import eu.joaocosta.minart.audio._
-import eu.joaocosta.minart.audio.sound._
-import eu.joaocosta.minart.internal._
+import eu.joaocosta.minart.audio.*
+import eu.joaocosta.minart.audio.sound.*
+import eu.joaocosta.minart.internal.*
 
 /** Audio reader for RTTTL files.
   */
 trait RtttlAudioReader extends AudioClipReader {
 
   val oscilator: Oscillator
-  import RtttlAudioReader._
-  import ByteReader._
-  import ByteStringOps._
+  import RtttlAudioReader.*
+  import ByteReader.*
+  import ByteStringOps.*
 
   private def parseHeader(jintu: String, defaultValue: String): Either[String, Header] = {
     val defaultSection = defaultValue.split(",").map(_.split("="))
@@ -91,7 +91,7 @@ trait RtttlAudioReader extends AudioClipReader {
       defaults <- readNextSection
       header   <- State.fromEither(parseHeader(jintu, defaults))
       data     <- readNextSection
-      notes = data.split(",").map(parseData(header) _)
+      notes = data.split(",").map(parseData(header))
       clip <- State.fromEither(sequenceNotes(notes))
     } yield clip).run(bytes).map(_._2)
   }
@@ -108,7 +108,7 @@ object RtttlAudioReader {
   }
 
   private object ByteStringOps {
-    import ByteReader._
+    import ByteReader.*
     private val separator = ':'.toInt
 
     val readNextSection: ParseState[String, String] =

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioReader.scala
@@ -2,9 +2,9 @@ package eu.joaocosta.minart.audio.sound.wav
 
 import java.io.InputStream
 
-import eu.joaocosta.minart.audio._
-import eu.joaocosta.minart.audio.sound._
-import eu.joaocosta.minart.internal._
+import eu.joaocosta.minart.audio.*
+import eu.joaocosta.minart.audio.sound.*
+import eu.joaocosta.minart.internal.*
 
 /** Audio reader for WAV files.
   *
@@ -12,7 +12,7 @@ import eu.joaocosta.minart.internal._
   */
 trait WavAudioReader extends AudioClipReader {
 
-  import ByteReader._
+  import ByteReader.*
 
   private val readId = readString(4)
 

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioWriter.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/wav/WavAudioWriter.scala
@@ -4,9 +4,9 @@ import java.io.OutputStream
 
 import scala.annotation.tailrec
 
-import eu.joaocosta.minart.audio._
-import eu.joaocosta.minart.audio.sound._
-import eu.joaocosta.minart.internal._
+import eu.joaocosta.minart.audio.*
+import eu.joaocosta.minart.audio.sound.*
+import eu.joaocosta.minart.internal.*
 
 /** Audio writer for WAV files.
   *
@@ -16,7 +16,7 @@ trait WavAudioWriter(sampleRate: Int, bitRate: Int) extends AudioClipWriter {
   final val chunkSize = 128
   require(Set(8, 16, 32).contains(bitRate))
 
-  import ByteWriter._
+  import ByteWriter.*
 
   private def convertSample(x: Double): List[Int] = bitRate match {
     case 8 =>

--- a/sound/shared/src/test/scala/eu/joaocosta/minart/audio/sound/AudioClipReaderSpec.scala
+++ b/sound/shared/src/test/scala/eu/joaocosta/minart/audio/sound/AudioClipReaderSpec.scala
@@ -1,8 +1,8 @@
 package eu.joaocosta.minart.audio.sound
 
-import eu.joaocosta.minart.audio._
+import eu.joaocosta.minart.audio.*
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.runtime.*
 
 class AudioClipReaderSpec extends munit.FunSuite {
 

--- a/sound/shared/src/test/scala/eu/joaocosta/minart/audio/sound/AudioClipWriterSpec.scala
+++ b/sound/shared/src/test/scala/eu/joaocosta/minart/audio/sound/AudioClipWriterSpec.scala
@@ -2,7 +2,7 @@ package eu.joaocosta.minart.audio.sound
 
 import eu.joaocosta.minart.audio.Sampler
 import eu.joaocosta.minart.backend.defaults.given
-import eu.joaocosta.minart.runtime._
+import eu.joaocosta.minart.runtime.*
 
 class AudioClipWriterSpec extends munit.FunSuite {
 


### PR DESCRIPTION
Applies some Scala 3 automatic rewrites.

I also tried the braceless syntax (I actually enjoyed it in InterIm), but I don't think it works well here. I have too many nested classes, and those look quite confusing without braces.

Maybe I'll try that again after more rewrites.