### PR TITLE
Fix MutableSurface#fillRegion implementation for out of bounds areas

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataOpaqueSurface.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataOpaqueSurface.scala
@@ -25,15 +25,18 @@ final class ImageDataOpaqueSurface(val data: ImageData) extends MutableSurface {
   }
 
   def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
-    val _x = Math.max(x, 0)
-    val _y = Math.max(y, 0)
-    val _w = Math.min(w, width - _x)
-    val _h = Math.min(h, height - _y)
-    var yy = 0
-    while (yy < _h) {
-      val start = (yy + _y) * width + _x
-      dataBuffer.fill(color.abgr | 0xff000000, start, start + _w)
-      yy += 1
+    val x1 = Math.max(x, 0)
+    val y1 = Math.max(y, 0)
+    val x2 = Math.min(x + w, width)
+    val y2 = Math.min(y + h, height)
+    if (x1 != x2 && y1 != y2) {
+      val _w = x2 - x1
+      var _y = y1
+      while (_y < y2) {
+        val start = _y * width + x1
+        dataBuffer.fill(color.abgr | 0xff000000, start, start + _w)
+        _y += 1
+      }
     }
   }
 }

--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
@@ -25,15 +25,18 @@ final class ImageDataSurface(val data: ImageData) extends MutableSurface {
   }
 
   def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
-    val _x = Math.max(x, 0)
-    val _y = Math.max(y, 0)
-    val _w = Math.min(w, width - _x)
-    val _h = Math.min(h, height - _y)
-    var yy = 0
-    while (yy < _h) {
-      val start = (yy + _y) * width + _x
-      dataBuffer.fill(color.abgr, start, start + _w)
-      yy += 1
+    val x1 = Math.max(x, 0)
+    val y1 = Math.max(y, 0)
+    val x2 = Math.min(x + w, width)
+    val y2 = Math.min(y + h, height)
+    if (x1 != x2 && y1 != y2) {
+      val _w = x2 - x1
+      var _y = y1
+      while (_y < y2) {
+        val start = _y * width + x1
+        dataBuffer.fill(color.abgr, start, start + _w)
+        _y += 1
+      }
     }
   }
 }

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
@@ -25,19 +25,21 @@ final class BufferedImageSurface(val bufferedImage: BufferedImage) extends Mutab
   }
 
   def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
-    val _x = Math.max(x, 0)
-    val _y = Math.max(y, 0)
-    val _w = Math.min(w, width - _x)
-    val _h = Math.min(h, height - _y)
-    var yy = 0
-    while (yy < _h) {
-      val lineBase = (yy + _y) * width
-      var xx       = 0
-      while (xx < _w) {
-        dataBuffer.setElem(lineBase + xx + _x, color.argb)
-        xx += 1
+    val x1 = Math.max(x, 0)
+    val y1 = Math.max(y, 0)
+    val x2 = Math.min(x + w, width)
+    val y2 = Math.min(y + h, height)
+    if (x1 != x2 && y1 != y2) {
+      var _y = y1
+      while (_y < y2) {
+        val lineBase = _y * width
+        var _x       = x1
+        while (_x < x2) {
+          dataBuffer.setElem(lineBase + _x, color.argb)
+          _x += 1
+        }
+        _y += 1
       }
-      yy += 1
     }
   }
 

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlSurface.scala
@@ -32,17 +32,21 @@ final class SdlSurface(val data: Ptr[SDL_Surface]) extends MutableSurface with A
   }
 
   def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
-    val _x = Math.max(x, 0)
-    val _y = Math.max(y, 0)
-    val _w = Math.min(w, width - _x)
-    val _h = Math.min(h, height - _y)
-    SDL_SetRenderDrawColor(renderer, color.r.toUByte, color.g.toUByte, color.b.toUByte, color.a.toUByte)
-    val rect = stackalloc[SDL_Rect]()
-    (!rect).x = _x
-    (!rect).y = _y
-    (!rect).w = _w
-    (!rect).h = _h
-    SDL_RenderFillRect(renderer, rect)
+    val x1 = Math.max(x, 0)
+    val y1 = Math.max(y, 0)
+    val x2 = Math.min(x + w, width)
+    val y2 = Math.min(y + h, height)
+    if (x1 != x2 && y1 != y2) {
+      val _w = x2 - x1
+      val _h = y2 - y1
+      SDL_SetRenderDrawColor(renderer, color.r.toUByte, color.g.toUByte, color.b.toUByte, color.a.toUByte)
+      val rect = stackalloc[SDL_Rect]()
+      (!rect).x = x1
+      (!rect).y = y1
+      (!rect).w = _w
+      (!rect).h = _h
+      SDL_RenderFillRect(renderer, rect)
+    }
   }
 
   override def blit(

--- a/backend/native/src/test/scala/eu/joaocosta/minart/graphics/SdlSurfaceSpec.scala
+++ b/backend/native/src/test/scala/eu/joaocosta/minart/graphics/SdlSurfaceSpec.scala
@@ -6,7 +6,7 @@ import sdl2.all.*
 
 import eu.joaocosta.minart.backend.*
 
-class SdlImageSurfaceSpec extends MutableSurfaceTests {
+class SdlSurfaceSpec extends MutableSurfaceTests {
   lazy val surface = new SdlSurface(
     SDL_CreateRGBSurface(
       0.toUInt,

--- a/backend/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/backend/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -49,7 +49,11 @@ trait MutableSurfaceTests extends munit.FunSuite {
     assert(surface.getPixel(1, 0) == Some(Color(3, 2, 1)))
     assert(surface.getPixel(1, 1) == Some(Color(2, 2, 2)))
 
+    // offscreen, do nothing
     surface.fillRegion(-100, -100, 100, 100, Color(0, 0, 0))
+    assert(surface.getPixel(0, 0) == Some(Color(1, 1, 1)))
+
+    surface.fillRegion(-100, -100, 200, 200, Color(0, 0, 0))
     assert(surface.getPixel(0, 0) == Some(Color(0, 0, 0)))
   }
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
@@ -22,19 +22,21 @@ final class RamSurface(val dataBuffer: Vector[Array[Color]]) extends MutableSurf
   def unsafePutPixel(x: Int, y: Int, color: Color): Unit = dataBuffer(y)(x) = color
 
   def fillRegion(x: Int, y: Int, w: Int, h: Int, color: Color): Unit = {
-    val _x = Math.max(x, 0)
-    val _y = Math.max(y, 0)
-    val _w = Math.min(w, width - _x)
-    val _h = Math.min(h, height - _y)
-    var yy = 0
-    while (yy < _h) {
-      var xx   = 0
-      val line = dataBuffer(_y + yy)
-      while (xx < _w) {
-        line(_x + xx) = color
-        xx += 1
+    val x1 = Math.max(x, 0)
+    val y1 = Math.max(y, 0)
+    val x2 = Math.min(x + w, width)
+    val y2 = Math.min(y + h, height)
+    if (x1 != x2 && y1 != y2) {
+      var _y = y1
+      while (_y < y2) {
+        var _x   = x1
+        val line = dataBuffer(_y)
+        while (_x < x2) {
+          line(_x) = color
+          _x += 1
+        }
+        _y += 1
       }
-      yy += 1
     }
   }
 }

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -49,7 +49,11 @@ trait MutableSurfaceTests extends munit.FunSuite {
     assert(surface.getPixel(1, 0) == Some(Color(3, 2, 1)))
     assert(surface.getPixel(1, 1) == Some(Color(2, 2, 2)))
 
+    // offscreen, do nothing
     surface.fillRegion(-100, -100, 100, 100, Color(0, 0, 0))
+    assert(surface.getPixel(0, 0) == Some(Color(1, 1, 1)))
+
+    surface.fillRegion(-100, -100, 200, 200, Color(0, 0, 0))
     assert(surface.getPixel(0, 0) == Some(Color(0, 0, 0)))
   }
 


### PR DESCRIPTION
When a region started in a negative position, the width was not being correctly calculated.

Funnily enough, the tests were also broken.