### PR TITLE
Add Scroller helper

### DIFF
--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/Scroller.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/Scroller.scala
@@ -1,0 +1,35 @@
+package eu.joaocosta.minart.graphics.image
+
+import eu.joaocosta.minart.graphics.*
+
+/** A surface that's optimzied to be used as a scrolling layer.
+  *
+  *  Unlike a repeating plane, this is limited in height and width. However, it can be quite faster, as some data is precomputed.
+  *
+  *  This also means that changes to the original surface after the scroller creation won't be reflected.
+  *
+  *  @param surface reference surface to use
+  */
+final class Scroller(surface: Surface) {
+
+  private val precomputed = surface.view.repeating(2, 2).precompute
+
+  /** Gets a surface scrolled to start at position (x, y).
+    *
+    *  @param x horizontal position on the reference surface
+    *  @param y vertical position on the reference surface
+    *  @return surface view with the scrolled surface
+    */
+  def getSurface(x: Int, y: Int): SurfaceView =
+    val startX = Scroller.floorMod(x, surface.width)
+    val startY = Scroller.floorMod(y, surface.height)
+    precomputed.clip(startX, startY, surface.width, surface.height)
+}
+
+object Scroller {
+  private def floorMod(x: Int, y: Int): Int = {
+    val rem = x % y
+    if (rem >= 0) rem
+    else rem + y
+  }
+}

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/SpriteSheet.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/SpriteSheet.scala
@@ -8,7 +8,7 @@ import eu.joaocosta.minart.graphics.*
   *  @param spriteWidth width of each sprite
   *  @param spriteHeight height of each sprite
   */
-class SpriteSheet(surface: Surface, val spriteWidth: Int, val spriteHeight: Int) {
+final class SpriteSheet(surface: Surface, val spriteWidth: Int, val spriteHeight: Int) {
 
   /** How many sprites are stored on each line */
   val spritesPerLine = surface.width / spriteWidth

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ScrollerSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/ScrollerSpec.scala
@@ -1,0 +1,55 @@
+package eu.joaocosta.minart.graphics.image
+
+import eu.joaocosta.minart.graphics.*
+
+class ScrollerSpec extends munit.FunSuite {
+  val surface = new RamSurface(
+    List(
+      List(Color(255, 0, 0), Color(0, 255, 0), Color(0, 0, 255)),
+      List(Color(0, 255, 255), Color(255, 0, 255), Color(255, 255, 0))
+    )
+  )
+
+  test("Generate a surface with the correct size") {
+    val scroller   = new Scroller(surface)
+    val newSurface = scroller.getSurface(0, 0)
+    assert(newSurface.width == surface.width)
+    assert(newSurface.height == surface.height)
+  }
+
+  test("handle no scroll") {
+    val scroller   = new Scroller(surface)
+    val newSurface = scroller.getSurface(0, 0)
+    assert(newSurface.getPixels().flatten.toList == surface.getPixels().flatten.toList)
+  }
+
+  test("handle positive scroll") {
+    val scroller   = new Scroller(surface)
+    val newSurface = scroller.getSurface(2, 1)
+    assert(
+      newSurface.getPixels().toList.map(_.toList) ==
+        List(
+          List(Color(255, 255, 0), Color(0, 255, 255), Color(255, 0, 255)),
+          List(Color(0, 0, 255), Color(255, 0, 0), Color(0, 255, 0))
+        )
+    )
+  }
+
+  test("handle negative scroll") {
+    val scroller   = new Scroller(surface)
+    val newSurface = scroller.getSurface(-1, -1)
+    assert(
+      newSurface.getPixels().toList.map(_.toList) ==
+        List(
+          List(Color(255, 255, 0), Color(0, 255, 255), Color(255, 0, 255)),
+          List(Color(0, 0, 255), Color(255, 0, 0), Color(0, 255, 0))
+        )
+    )
+  }
+
+  test("handle overflow scroll") {
+    val scroller   = new Scroller(surface)
+    val newSurface = scroller.getSurface(6, -4)
+    assert(newSurface.getPixels().flatten.toList == surface.getPixels().flatten.toList)
+  }
+}


### PR DESCRIPTION
Adds a `Scroller` helper to Minart image to handle scrolling background/foreground layers.

While `SurfaceView#repeating` also worked for this, it was not optimized for this use case (where a surface larger than a screen is scrolled) and ended up calling `%` too often