### PR TITLE
Specialize clipped Ram Surface Views

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Blitter.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Blitter.scala
@@ -209,7 +209,9 @@ private[graphics] object Blitter {
       if (maxX > 0 && maxY > 0) {
         source match {
           case ramSurf: RamSurface => unsafeBlitMatrix(dest, ramSurf.dataBuffer, blendMode, x, y, cx, cy, maxX, maxY)
-          case _                   => unsafeBlitSurface(dest, source, blendMode, x, y, cx, cy, maxX, maxY)
+          case SurfaceView.RamSurfaceView(surface, _cx, _cy, _, _) =>
+            fullBlit(dest, surface, blendMode, x, y, cx + _cx, cy + _cy, cw, ch)
+          case _ => unsafeBlitSurface(dest, source, blendMode, x, y, cx, cy, maxX, maxY)
         }
 
       }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -40,7 +40,7 @@ trait Plane extends Function2[Int, Int, Color] { outer =>
   }
 
   /** Combines this plane with a surface by combining their colors with the given function. */
-  final def zipWith(that: Surface, f: (Color, Color) => Color): SurfaceView = SurfaceView(
+  final def zipWith(that: Surface, f: (Color, Color) => Color): SurfaceView = SurfaceView.PlaneSurfaceView(
     new Plane {
       def getPixel(x: Int, y: Int): Color = {
         val c1 = outer.getPixel(x, y)
@@ -166,7 +166,7 @@ trait Plane extends Function2[Int, Int, Color] { outer =>
     * @param height surface view height
     */
   final def toSurfaceView(width: Int, height: Int): SurfaceView =
-    SurfaceView(this, width, height)
+    SurfaceView.PlaneSurfaceView(this, width, height)
 
   /** Converts this plane to a RAM surface, assuming (0, 0) as the top-left corner.
     *

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -1,48 +1,33 @@
 package eu.joaocosta.minart.graphics
 
-/** A view over a surface, stored as a plane limited by a width and height.
+/** A view over a surface.
   *  Allows lazy operations to be applied over a surface.
   *
   *  This can have a performance impact. However, a new RAM surface with the operations already applied can be constructed using `toRamSurface`
   */
-final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surface { outer =>
-
-  def unsafeGetPixel(x: Int, y: Int): Color =
-    plane.getPixel(x, y)
+sealed trait SurfaceView extends Surface {
+  def unsafeGetPixel(x: Int, y: Int): Color
 
   /** Maps the colors from this surface view. */
-  def map(f: Color => Color): SurfaceView = copy(plane.map(f))
+  def map(f: Color => Color): SurfaceView
 
   /** Flatmaps the inner plane of this surface view */
-  def flatMap(f: Color => Plane): SurfaceView =
-    copy(plane = plane.flatMap(f))
+  def flatMap(f: Color => Plane): SurfaceView
 
   /** Contramaps the positions from this surface view. */
-  def contramap(f: (Int, Int) => (Int, Int)): Plane =
-    plane.contramap(f)
+  def contramap(f: (Int, Int) => (Int, Int)): Plane
 
   /** Combines this view with a surface by combining their colors with the given function. */
-  def zipWith(that: Surface, f: (Color, Color) => Color): SurfaceView =
-    plane
-      .zipWith(that, f)
-      .copy(
-        width = Math.min(that.width, width),
-        height = Math.min(that.height, height)
-      )
+  def zipWith(that: Surface, f: (Color, Color) => Color): SurfaceView
 
   /** Combines this view with a plane by combining their colors with the given function. */
-  def zipWith(that: Plane, f: (Color, Color) => Color): SurfaceView =
-    copy(plane = plane.zipWith(that, f))
+  def zipWith(that: Plane, f: (Color, Color) => Color): SurfaceView
 
   /** Coflatmaps this plane with a SurfaceView => Color function.
     * Effectively, each pixel of the new view is computed from a translated view, which can be used to
     * implement convolutions.
     */
-  def coflatMap(f: SurfaceView => Color): SurfaceView =
-    copy(plane = new Plane {
-      def getPixel(x: Int, y: Int): Color =
-        f(outer.clip(x, y, width - x, height - y))
-    })
+  def coflatMap(f: SurfaceView => Color): SurfaceView
 
   /** Clips this view to a chosen rectangle
     *
@@ -51,12 +36,7 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
     * @param cw clip width
     * @param ch clip height
     */
-  def clip(cx: Int, cy: Int, cw: Int, ch: Int): SurfaceView = {
-    val newWidth  = Math.min(cw, this.width - cx)
-    val newHeight = Math.min(ch, this.height - cy)
-    if (cx == 0 && cy == 0 && newWidth == width && newHeight == height) this
-    else plane.clip(cx, cy, newWidth, newHeight)
-  }
+  def clip(cx: Int, cy: Int, cw: Int, ch: Int): SurfaceView
 
   /** Overlays a surface on top of this view.
     *
@@ -67,62 +47,42 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
     * @param x leftmost pixel on the destination plane
     * @param y topmost pixel on the destination plane
     */
-  def overlay(that: Surface, blendMode: BlendMode = BlendMode.Copy)(x: Int, y: Int): SurfaceView =
-    copy(plane = plane.overlay(that, blendMode)(x, y))
+  def overlay(that: Surface, blendMode: BlendMode = BlendMode.Copy)(x: Int, y: Int): SurfaceView
 
   /** Inverts a surface color. */
-  def invertColor: SurfaceView = map(_.invert)
+  final def invertColor: SurfaceView = map(_.invert)
 
   /** Premultiplies the color channels with the alpha channel.
     *
     * If this surface is going to be used multiple times, it is usually recommended
     * to store this as a temporary surface instead of using a surface view.
     */
-  def premultiplyAlpha: SurfaceView = map(_.premultiplyAlpha)
+  final def premultiplyAlpha: SurfaceView = map(_.premultiplyAlpha)
 
   /** Flips a surface horizontally. */
-  def flipH: SurfaceView =
-    copy(plane = plane.flipH.translate(width - 1, 0))
+  def flipH: SurfaceView
 
   /** Flips a surface vertically. */
-  def flipV: SurfaceView =
-    copy(plane = plane.flipV.translate(0, height - 1))
+  def flipV: SurfaceView
 
   /** Scales a surface. */
-  def scale(sx: Double, sy: Double): SurfaceView =
-    if (sx == 1.0 && sy == 1.0) this
-    else copy(plane = plane.scale(sx, sy), width = (width * sx).toInt, height = (height * sy).toInt)
+  def scale(sx: Double, sy: Double): SurfaceView
 
   /** Scales a surface. */
-  def scale(s: Double): SurfaceView = scale(s, s)
+  final def scale(s: Double): SurfaceView = scale(s, s)
 
   /** Transposes a surface. */
-  def transpose: SurfaceView =
-    plane.transpose.toSurfaceView(height, width)
+  def transpose: SurfaceView
 
   /** Returns a plane that repeats this surface forever */
-  def repeating: Plane =
-    if (width <= 0 || height <= 0) Plane.fromConstant(SurfaceView.defaultColor)
-    else
-      new Plane {
-        def getPixel(x: Int, y: Int): Color = {
-          outer.plane.getPixel(SurfaceView.floorMod(x, outer.width), SurfaceView.floorMod(y, outer.height))
-        }
-      }
+  def repeating: Plane
 
   /** Repeats this surface xTimes on the x axis and yTimes on the yAxis */
-  def repeating(xTimes: Int, yTimes: Int): SurfaceView =
+  final def repeating(xTimes: Int, yTimes: Int): SurfaceView =
     repeating.toSurfaceView(width * xTimes, height * yTimes)
 
   /** Returns a plane that clamps this surface when out of bounds */
-  def clamped: Plane =
-    if (width <= 0 || height <= 0) Plane.fromConstant(SurfaceView.defaultColor)
-    else
-      new Plane {
-        def getPixel(x: Int, y: Int): Color = {
-          outer.plane.getPixel(SurfaceView.clamp(0, x, outer.width - 1), SurfaceView.clamp(0, y, outer.height - 1))
-        }
-      }
+  def clamped: Plane
 
   /** Forces the surface to be computed and returns a new view.
     * Equivalent to `toRamSurface().view`.
@@ -131,7 +91,7 @@ final case class SurfaceView(plane: Plane, width: Int, height: Int) extends Surf
     * coflatMap (e.g. a convolution with a large kernel) to avoid recomputing
     * the same pixel multiple times.
     */
-  def precompute: SurfaceView = toRamSurface().view
+  final def precompute: SurfaceView = toRamSurface().view
 
   override def view: SurfaceView = this
 }
@@ -147,6 +107,171 @@ object SurfaceView {
     Math.max(minValue, Math.min(value, maxValue))
 
   /** Generates a surface view from a surface */
-  def apply(surface: Surface): SurfaceView =
-    SurfaceView(Plane.fromSurfaceWithFallback(surface, defaultColor), surface.width, surface.height)
+  def apply(surface: Surface): SurfaceView = surface match {
+    case sv: SurfaceView        => sv
+    case ramSurface: RamSurface => RamSurfaceView(ramSurface, 0, 0, surface.width, surface.height)
+    case _ =>
+      PlaneSurfaceView(Plane.fromSurfaceWithFallback(surface, defaultColor), surface.width, surface.height)
+  }
+
+  private[graphics] final case class PlaneSurfaceView(plane: Plane, width: Int, height: Int) extends SurfaceView {
+    outer =>
+
+    def unsafeGetPixel(x: Int, y: Int): Color =
+      plane.getPixel(x, y)
+
+    def map(f: Color => Color): SurfaceView = copy(plane.map(f))
+
+    def flatMap(f: Color => Plane): SurfaceView =
+      copy(plane = plane.flatMap(f))
+
+    def contramap(f: (Int, Int) => (Int, Int)): Plane =
+      plane.contramap(f)
+
+    def zipWith(that: Surface, f: (Color, Color) => Color): SurfaceView =
+      plane
+        .zipWith(that, f)
+        .clip(0, 0, Math.min(that.width, this.width), Math.min(that.height, this.height))
+
+    def zipWith(that: Plane, f: (Color, Color) => Color): SurfaceView =
+      copy(plane = plane.zipWith(that, f))
+
+    def coflatMap(f: SurfaceView => Color): SurfaceView =
+      copy(plane = new Plane {
+        def getPixel(x: Int, y: Int): Color =
+          f(outer.clip(x, y, width - x, height - y))
+      })
+
+    def clip(cx: Int, cy: Int, cw: Int, ch: Int): SurfaceView = {
+      val newWidth  = Math.min(cw, this.width - cx)
+      val newHeight = Math.min(ch, this.height - cy)
+      if (cx == 0 && cy == 0 && newWidth == width && newHeight == height) this
+      else plane.clip(cx, cy, newWidth, newHeight)
+    }
+
+    def overlay(that: Surface, blendMode: BlendMode = BlendMode.Copy)(x: Int, y: Int): SurfaceView =
+      copy(plane = plane.overlay(that, blendMode)(x, y))
+
+    def flipH: SurfaceView =
+      copy(plane = plane.flipH.translate(width - 1, 0))
+
+    def flipV: SurfaceView =
+      copy(plane = plane.flipV.translate(0, height - 1))
+
+    def scale(sx: Double, sy: Double): SurfaceView =
+      if (sx == 1.0 && sy == 1.0) this
+      else copy(plane = plane.scale(sx, sy), width = (width * sx).toInt, height = (height * sy).toInt)
+
+    def transpose: SurfaceView =
+      plane.transpose.toSurfaceView(height, width)
+
+    def repeating: Plane =
+      if (width <= 0 || height <= 0) Plane.fromConstant(SurfaceView.defaultColor)
+      else
+        new Plane {
+          def getPixel(x: Int, y: Int): Color = {
+            outer.plane.getPixel(SurfaceView.floorMod(x, outer.width), SurfaceView.floorMod(y, outer.height))
+          }
+        }
+
+    def clamped: Plane =
+      if (width <= 0 || height <= 0) Plane.fromConstant(SurfaceView.defaultColor)
+      else
+        new Plane {
+          def getPixel(x: Int, y: Int): Color = {
+            outer.plane.getPixel(SurfaceView.clamp(0, x, outer.width - 1), SurfaceView.clamp(0, y, outer.height - 1))
+          }
+        }
+
+    override def view: SurfaceView = this
+  }
+
+  /** Optimized view of a clipped RamSurface */
+  private[graphics] final case class RamSurfaceView(
+      ramSurface: RamSurface,
+      cx: Int,
+      cy: Int,
+      width: Int,
+      height: Int
+  ) extends SurfaceView {
+    outer =>
+
+    private inline def toPlaneSurfaceView(): SurfaceView =
+      PlaneSurfaceView(Plane.fromSurfaceWithFallback(ramSurface, defaultColor), ramSurface.width, ramSurface.height)
+        .clip(cx, cy, width, height)
+
+    def unsafeGetPixel(x: Int, y: Int): Color = ramSurface.getPixelOrElse(cx, cy, SurfaceView.defaultColor)
+
+    override def getPixels(): Vector[Array[Color]] = {
+      Vector.tabulate(height) { y =>
+        ramSurface.dataBuffer(cy + y).slice(cx, cx + width)
+      }
+    }
+
+    def map(f: Color => Color): SurfaceView = toPlaneSurfaceView().map(f)
+
+    def flatMap(f: Color => Plane): SurfaceView =
+      toPlaneSurfaceView().flatMap(f)
+
+    def contramap(f: (Int, Int) => (Int, Int)): Plane =
+      toPlaneSurfaceView().contramap(f)
+
+    def zipWith(that: Surface, f: (Color, Color) => Color): SurfaceView =
+      toPlaneSurfaceView().zipWith(that, f)
+
+    def zipWith(that: Plane, f: (Color, Color) => Color): SurfaceView =
+      toPlaneSurfaceView().zipWith(that, f)
+
+    def coflatMap(f: SurfaceView => Color): SurfaceView =
+      toPlaneSurfaceView().coflatMap(f)
+
+    def clip(cx: Int, cy: Int, cw: Int, ch: Int): SurfaceView =
+      val newCx     = this.cx + cx
+      val newCy     = this.cy + cy
+      val newWidth  = Math.min(cw, this.width - cx)
+      val newHeight = Math.min(ch, this.height - cy)
+      copy(cx = newCx, cy = newCy, newWidth, newHeight)
+
+    def overlay(that: Surface, blendMode: BlendMode = BlendMode.Copy)(x: Int, y: Int): SurfaceView =
+      toPlaneSurfaceView().overlay(that, blendMode)(x, y)
+
+    def flipH: SurfaceView =
+      toPlaneSurfaceView().flipH
+
+    def flipV: SurfaceView =
+      toPlaneSurfaceView().flipV
+
+    def scale(sx: Double, sy: Double): SurfaceView =
+      if (sx == 1.0 && sy == 1.0) this
+      else toPlaneSurfaceView().scale(sx, sy)
+
+    def transpose: SurfaceView =
+      toPlaneSurfaceView().transpose
+
+    def repeating: Plane =
+      if (width <= 0 || height <= 0) Plane.fromConstant(SurfaceView.defaultColor)
+      else
+        new Plane {
+          def getPixel(x: Int, y: Int): Color = {
+            ramSurface.unsafeGetPixel(
+              outer.cx + SurfaceView.floorMod(x, outer.width),
+              outer.cy + SurfaceView.floorMod(y, outer.height)
+            )
+          }
+        }
+
+    def clamped: Plane =
+      if (width <= 0 || height <= 0) Plane.fromConstant(SurfaceView.defaultColor)
+      else
+        new Plane {
+          def getPixel(x: Int, y: Int): Color = {
+            ramSurface.unsafeGetPixel(
+              cx + SurfaceView.clamp(0, x, outer.width - 1),
+              cy + SurfaceView.clamp(0, y, outer.height - 1)
+            )
+          }
+        }
+
+    override def view: SurfaceView = this
+  }
 }


### PR DESCRIPTION
Adds a specialized implementation of surface views that are basically a clipped `RamSurface`.

There are a few reasons to do this:
- This type of surface views can be blitted more efficiently
- This type of surface views can be converted into a `RamSurface more efficiently
- A lot of surface views are like this:
  - `RamSurface#view`
  - `SurfaceView#precompute`
  - `Spritesheet`s
  - `Scroller`s

In my tests I saw a 2x-3x speed improvement on the JVM and Native on a scene with heavy parallax scrolling, so this seems promising.

I feel like there are going to be some edge cases with a behavior mismatch (out of bound clips, maybe?), but so far it seems to work without any problems.