### PR TITLE
Rename Scroller to WrapAround

### DIFF
--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/WrapAround.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/WrapAround.scala
@@ -2,7 +2,7 @@ package eu.joaocosta.minart.graphics.image
 
 import eu.joaocosta.minart.graphics.*
 
-/** A surface that's optimzied to be used as a scrolling layer.
+/** A surface that's optimzied to be used as a scrolling layer that wraps around.
   *
   *  Unlike a repeating plane, this is limited in height and width. However, it can be quite faster, as some data is precomputed.
   *
@@ -10,23 +10,23 @@ import eu.joaocosta.minart.graphics.*
   *
   *  @param surface reference surface to use
   */
-final class Scroller(surface: Surface) {
+final class WrapAround(surface: Surface) {
 
   private val precomputed = surface.view.repeating(2, 2).precompute
 
-  /** Gets a surface scrolled to start at position (x, y).
+  /** Gets a surface offset to start at position (x, y).
     *
     *  @param x horizontal position on the reference surface
     *  @param y vertical position on the reference surface
     *  @return surface view with the scrolled surface
     */
   def getSurface(x: Int, y: Int): SurfaceView =
-    val startX = Scroller.floorMod(x, surface.width)
-    val startY = Scroller.floorMod(y, surface.height)
+    val startX = WrapAround.floorMod(x, surface.width)
+    val startY = WrapAround.floorMod(y, surface.height)
     precomputed.clip(startX, startY, surface.width, surface.height)
 }
 
-object Scroller {
+object WrapAround {
   private def floorMod(x: Int, y: Int): Int = {
     val rem = x % y
     if (rem >= 0) rem

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/WrapAroundSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/WrapAroundSpec.scala
@@ -2,7 +2,7 @@ package eu.joaocosta.minart.graphics.image
 
 import eu.joaocosta.minart.graphics.*
 
-class ScrollerSpec extends munit.FunSuite {
+class WrapAroundSpec extends munit.FunSuite {
   val surface = new RamSurface(
     List(
       List(Color(255, 0, 0), Color(0, 255, 0), Color(0, 0, 255)),
@@ -11,21 +11,21 @@ class ScrollerSpec extends munit.FunSuite {
   )
 
   test("Generate a surface with the correct size") {
-    val scroller   = new Scroller(surface)
-    val newSurface = scroller.getSurface(0, 0)
+    val wrapAround = new WrapAround(surface)
+    val newSurface = wrapAround.getSurface(0, 0)
     assert(newSurface.width == surface.width)
     assert(newSurface.height == surface.height)
   }
 
   test("handle no scroll") {
-    val scroller   = new Scroller(surface)
-    val newSurface = scroller.getSurface(0, 0)
+    val wrapAround = new WrapAround(surface)
+    val newSurface = wrapAround.getSurface(0, 0)
     assert(newSurface.getPixels().flatten.toList == surface.getPixels().flatten.toList)
   }
 
   test("handle positive scroll") {
-    val scroller   = new Scroller(surface)
-    val newSurface = scroller.getSurface(2, 1)
+    val wrapAround = new WrapAround(surface)
+    val newSurface = wrapAround.getSurface(2, 1)
     assert(
       newSurface.getPixels().toList.map(_.toList) ==
         List(
@@ -36,8 +36,8 @@ class ScrollerSpec extends munit.FunSuite {
   }
 
   test("handle negative scroll") {
-    val scroller   = new Scroller(surface)
-    val newSurface = scroller.getSurface(-1, -1)
+    val wrapAround = new WrapAround(surface)
+    val newSurface = wrapAround.getSurface(-1, -1)
     assert(
       newSurface.getPixels().toList.map(_.toList) ==
         List(
@@ -48,8 +48,8 @@ class ScrollerSpec extends munit.FunSuite {
   }
 
   test("handle overflow scroll") {
-    val scroller   = new Scroller(surface)
-    val newSurface = scroller.getSurface(6, -4)
+    val wrapAround = new WrapAround(surface)
+    val newSurface = wrapAround.getSurface(6, -4)
     assert(newSurface.getPixels().flatten.toList == surface.getPixels().flatten.toList)
   }
 }


### PR DESCRIPTION
Renames `Scroller` to `WrapAround`.

`Scroller` makes it sound that it's what should be used on something like a scrolling map, and you really don't want to use this if you don't need the wrap around behavior.