### PR TITLE
Add MutableSurface#modify

### DIFF
--- a/backend/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/backend/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -111,4 +111,9 @@ trait MutableSurfaceTests extends munit.FunSuite {
     assert(source.getPixel(0, 0) == Some(Color(255, 0, 0)))
     assert(surface.getPixel(1, 1) == Some(Color(255, 0, 0)))
   }
+
+  test("Modify a surface in place") {
+    surface.modify(_.map(_ => Color(1, 2, 3)))
+    assert(surface.getPixels().flatten.forall(_ == Color(1, 2, 3)))
+  }
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/MutableSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/MutableSurface.scala
@@ -81,4 +81,12 @@ trait MutableSurface extends Surface {
   )(x: Int, y: Int, cx: Int = 0, cy: Int = 0, cw: Int = that.width, ch: Int = that.height): Unit = {
     Blitter.fullBlit(this, that, blendMode, x, y, cx, cy, cw, ch)
   }
+
+  /** Modifies this surface using surface view transformations
+    *
+    * @param f operations to apply
+    */
+  def modify(f: SurfaceView => Surface): Unit = {
+    blit(f(this.view).toRamSurface())(0, 0)
+  }
 }

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -111,4 +111,9 @@ trait MutableSurfaceTests extends munit.FunSuite {
     assert(source.getPixel(0, 0) == Some(Color(255, 0, 0)))
     assert(surface.getPixel(1, 1) == Some(Color(255, 0, 0)))
   }
+
+  test("Modify a surface in place") {
+    surface.modify(_.map(_ => Color(1, 2, 3)))
+    assert(surface.getPixels().flatten.forall(_ == Color(1, 2, 3)))
+  }
 }


### PR DESCRIPTION
Adds a `MutableSurface#modify` method to manipulate a mutable surface as a surface view.

While this might not be particularly interesting for pure Minart apps (that can rely on `RamSurface`), it's pretty helpful for interop with other libraries. For example, if a JS library uses `ImageData`, that could be modified with `ImageDataSurface(imageData).modify(doStuffHere)`.