### PR TITLE
Add lineScroll and columnScroll helpers

### DIFF
--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/WrapAround.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/WrapAround.scala
@@ -20,10 +20,31 @@ final class WrapAround(surface: Surface) {
     *  @param y vertical position on the reference surface
     *  @return surface view with the scrolled surface
     */
-  def getSurface(x: Int, y: Int): SurfaceView =
+  def getSurface(x: Int, y: Int): SurfaceView = {
     val startX = WrapAround.floorMod(x, surface.width)
     val startY = WrapAround.floorMod(y, surface.height)
     precomputed.clip(startX, startY, surface.width, surface.height)
+  }
+
+  /** Gets a surface with every line offset by dx.
+    *
+    *  @param dx horizontal offset of each line, based on the y position
+    *  @return surface view with the scrolled surface
+    */
+  def lineScroll(dx: Int => Int): SurfaceView = {
+    val precomputedOffsets = Array.tabulate(surface.height)(y => dx(y)).map(x => WrapAround.floorMod(x, surface.width))
+    precomputed.contramap((x, y) => (x + precomputedOffsets(y), y)).toSurfaceView(surface.width, surface.height)
+  }
+
+  /** Gets a surface with every column offset by dy.
+    *
+    *  @param dy horizontal offset of each line, based on the x position
+    *  @return surface view with the scrolled surface
+    */
+  def columnScroll(dy: Int => Int): SurfaceView = {
+    val precomputedOffsets = Array.tabulate(surface.width)(x => dy(x)).map(y => WrapAround.floorMod(y, surface.height))
+    precomputed.contramap((x, y) => (x, y + precomputedOffsets(x))).toSurfaceView(surface.width, surface.height)
+  }
 }
 
 object WrapAround {

--- a/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/WrapAroundSpec.scala
+++ b/image/shared/src/test/scala/eu/joaocosta/minart/graphics/image/WrapAroundSpec.scala
@@ -10,20 +10,46 @@ class WrapAroundSpec extends munit.FunSuite {
     )
   )
 
-  test("Generate a surface with the correct size") {
+  test("getSurface generate a surface with the correct size") {
     val wrapAround = new WrapAround(surface)
     val newSurface = wrapAround.getSurface(0, 0)
     assert(newSurface.width == surface.width)
     assert(newSurface.height == surface.height)
   }
 
-  test("handle no scroll") {
+  test("lineScroll generate a surface with the correct size") {
+    val wrapAround = new WrapAround(surface)
+    val newSurface = wrapAround.lineScroll(_ => 0)
+    assert(newSurface.width == surface.width)
+    assert(newSurface.height == surface.height)
+  }
+
+  test("columnScroll generate a surface with the correct size") {
+    val wrapAround = new WrapAround(surface)
+    val newSurface = wrapAround.columnScroll(_ => 0)
+    assert(newSurface.width == surface.width)
+    assert(newSurface.height == surface.height)
+  }
+
+  test("getSurface handles no scroll") {
     val wrapAround = new WrapAround(surface)
     val newSurface = wrapAround.getSurface(0, 0)
     assert(newSurface.getPixels().flatten.toList == surface.getPixels().flatten.toList)
   }
 
-  test("handle positive scroll") {
+  test("lineScroll handles no scroll") {
+    val wrapAround = new WrapAround(surface)
+    val newSurface = wrapAround.lineScroll(_ => 0)
+    assert(newSurface.getPixels().flatten.toList == surface.getPixels().flatten.toList)
+  }
+
+  test("columnScroll handles no scroll") {
+    val wrapAround = new WrapAround(surface)
+    val newSurface = wrapAround.columnScroll(_ => 0)
+    assert(newSurface.getPixels().flatten.toList == surface.getPixels().flatten.toList)
+  }
+
+  test("getSurface handles positive scroll") {
     val wrapAround = new WrapAround(surface)
     val newSurface = wrapAround.getSurface(2, 1)
     assert(
@@ -35,7 +61,21 @@ class WrapAroundSpec extends munit.FunSuite {
     )
   }
 
-  test("handle negative scroll") {
+  test("lineScroll handles positive scroll") {
+    val wrapAround      = new WrapAround(surface)
+    val expectedSurface = wrapAround.getSurface(2, 0)
+    val newSurface      = wrapAround.lineScroll(_ => 2)
+    assert(newSurface.getPixels().flatten.toList == expectedSurface.getPixels().flatten.toList)
+  }
+
+  test("columnScroll handles positive scroll") {
+    val wrapAround      = new WrapAround(surface)
+    val expectedSurface = wrapAround.getSurface(0, 1)
+    val newSurface      = wrapAround.columnScroll(_ => 1)
+    assert(newSurface.getPixels().flatten.toList == expectedSurface.getPixels().flatten.toList)
+  }
+
+  test("getSurface handles negative scroll") {
     val wrapAround = new WrapAround(surface)
     val newSurface = wrapAround.getSurface(-1, -1)
     assert(
@@ -47,9 +87,61 @@ class WrapAroundSpec extends munit.FunSuite {
     )
   }
 
-  test("handle overflow scroll") {
+  test("lineScroll handles negative scroll") {
+    val wrapAround      = new WrapAround(surface)
+    val expectedSurface = wrapAround.getSurface(-1, 0)
+    val newSurface      = wrapAround.lineScroll(_ => -1)
+    assert(newSurface.getPixels().flatten.toList == expectedSurface.getPixels().flatten.toList)
+  }
+
+  test("columnScroll handles negative scroll") {
+    val wrapAround      = new WrapAround(surface)
+    val expectedSurface = wrapAround.getSurface(0, -1)
+    val newSurface      = wrapAround.columnScroll(_ => -1)
+    assert(newSurface.getPixels().flatten.toList == expectedSurface.getPixels().flatten.toList)
+  }
+
+  test("getSurface handles overflow scroll") {
     val wrapAround = new WrapAround(surface)
     val newSurface = wrapAround.getSurface(6, -4)
     assert(newSurface.getPixels().flatten.toList == surface.getPixels().flatten.toList)
+  }
+
+  test("lineScroll handles overflow scroll") {
+    val wrapAround      = new WrapAround(surface)
+    val expectedSurface = wrapAround.getSurface(6, 0)
+    val newSurface      = wrapAround.lineScroll(_ => 6)
+    assert(newSurface.getPixels().flatten.toList == expectedSurface.getPixels().flatten.toList)
+  }
+
+  test("columnScroll handles overflow scroll") {
+    val wrapAround      = new WrapAround(surface)
+    val expectedSurface = wrapAround.getSurface(0, -4)
+    val newSurface      = wrapAround.columnScroll(_ => -4)
+    assert(newSurface.getPixels().flatten.toList == expectedSurface.getPixels().flatten.toList)
+  }
+
+  test("lineScroll handles variable scroll") {
+    val wrapAround = new WrapAround(surface)
+    val newSurface = wrapAround.lineScroll(y => y)
+    assert(
+      newSurface.getPixels().toList.map(_.toList) ==
+        List(
+          List(Color(255, 0, 0), Color(0, 255, 0), Color(0, 0, 255)),
+          List(Color(255, 0, 255), Color(255, 255, 0), Color(0, 255, 255))
+        )
+    )
+  }
+
+  test("columnScroll handles variable scroll") {
+    val wrapAround = new WrapAround(surface)
+    val newSurface = wrapAround.columnScroll(x => x)
+    assert(
+      newSurface.getPixels().toList.map(_.toList) ==
+        List(
+          List(Color(255, 0, 0), Color(255, 0, 255), Color(0, 0, 255)),
+          List(Color(0, 255, 255), Color(0, 255, 0), Color(255, 255, 0))
+        )
+    )
   }
 }


### PR DESCRIPTION
Adds `WrapAround#lineScroll` and `WrapAround#columnScroll` methods.

While those are easily done with `SurfaceView#contramap`, they can be quite costly, since the same value gets computed for each line/column.

Using the `WrapAround` precomputed surface along with a lookup table is way more efficient.