### PR TITLE
Add tutorials to the microsite

### DIFF
--- a/docs/_docs/advanced-usage.md
+++ b/docs/_docs/advanced-usage.md
@@ -2,7 +2,7 @@
 title: Advanced Usage
 ---
 
-# Advanced Usage
+# Advanced usage
 
 If for some reason you want to make your binary as small as possible, you can include individual packages instead of
 the full `minart` bundle.

--- a/docs/_docs/getting-started.md
+++ b/docs/_docs/getting-started.md
@@ -2,7 +2,7 @@
 title: Getting Started
 ---
 
-# Getting Started
+# Getting started
 
 To include Minart, simply add the `minart` library to your project:
 

--- a/docs/_docs/overview.md
+++ b/docs/_docs/overview.md
@@ -2,7 +2,7 @@
 title: Feature Overview
 ---
 
-# Feature Overview
+# Feature overview
 
 ## Cross-compilation
 

--- a/docs/_docs/structure.md
+++ b/docs/_docs/structure.md
@@ -1,5 +1,5 @@
 ---
-title: Project structure
+title: Project Structure
 ---
 
 # Project structure

--- a/docs/_docs/tutorial.md
+++ b/docs/_docs/tutorial.md
@@ -1,0 +1,10 @@
+---
+title: Tutorial
+---
+
+# Tutorial
+
+Here you'll find multiple examples that also work as a tutorial to get started with Minart. It is recommended to follow them in order.
+
+If you would like to run some of them, all the examples are available in [the examples directory](https://github.com/JD557/minart/tree/master/examples).
+Just follow the instructions to run them with [Scala CLI](https://scala-cli.virtuslab.org/).

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -10,7 +10,7 @@ subsection:
     page: advanced-usage.md
   - title: Tutorial
     directory: tutorial
-    index: ../../examples/README.md
+    index: tutorial.md
     subsection:
       - title: "1. Introduction"
         page: ../../examples/release/01-introduction.md

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -8,3 +8,29 @@ subsection:
     page: structure.md
   - title: Advanced Usage
     page: advanced-usage.md
+  - title: Tutorial
+    directory: tutorial
+    index: ../../examples/README.md
+    subsection:
+      - title: "1. Introduction"
+        page: ../../examples/release/01-introduction.md
+      - title: "2. Portable Applications"
+        page: ../../examples/release/02-portable-applications.md
+      - title: "3. Animation"
+        page: ../../examples/release/03-animation.md
+      - title: "4. Pointer Input"
+        page: ../../examples/release/04-pointer-input.md
+      - title: "5. Stateful Applications"
+        page: ../../examples/release/05-stateful-applications.md
+      - title: "6. Surfaces"
+        page: ../../examples/release/06-surfaces.md
+      - title: "7. Canvas Settings"
+        page: ../../examples/release/07-canvas-settings.md
+      - title: "8. Loading Images"
+        page: ../../examples/release/08-loading-images.md
+      - title: "9. Surface Views"
+        page: ../../examples/release/09-surface-views.md
+      - title: "10. Audio Playback"
+        page: ../../examples/release/10-audio-playback.md
+      - title: "11. Loading Sounds"
+        page: ../../examples/release/11-loading-sounds.md

--- a/examples/release/02-portable-applications.md
+++ b/examples/release/02-portable-applications.md
@@ -1,4 +1,4 @@
-# 2. Writing portable applications
+# 2. Portable applications
 
 The first example only ran on the JVM, but Minart provides some abstractions to easily cross compile to JS and Native backends.
 

--- a/examples/release/04-pointer-input.md
+++ b/examples/release/04-pointer-input.md
@@ -1,4 +1,4 @@
-# 4. Pointer Input
+# 4. Pointer input
 
 Now that we learned the basics of animation, we can start to look at more dynamic applications.
 

--- a/examples/release/05-stateful-applications.md
+++ b/examples/release/05-stateful-applications.md
@@ -1,4 +1,4 @@
-# 5. Stateful Applications
+# 5. Stateful applications
 
 Now that we learned the basics of animation and input handling, we are almost ready to make interactive applications, such as a game.
 

--- a/examples/release/10-audio-playback.md
+++ b/examples/release/10-audio-playback.md
@@ -1,4 +1,4 @@
-# 10. Audio Playback
+# 10. Audio playback
 
 Besides graphics and input, Minart also supports loading and playing back audio.
 

--- a/examples/snapshot/02-portable-applications.md
+++ b/examples/snapshot/02-portable-applications.md
@@ -1,4 +1,4 @@
-# 2. Writing portable applications
+# 2. Portable applications
 
 The first example only ran on the JVM, but Minart provides some abstractions to easily cross compile to JS and Native backends.
 

--- a/examples/snapshot/04-pointer-input.md
+++ b/examples/snapshot/04-pointer-input.md
@@ -1,4 +1,4 @@
-# 4. Pointer Input
+# 4. Pointer input
 
 Now that we learned the basics of animation, we can start to look at more dynamic applications.
 

--- a/examples/snapshot/05-stateful-applications.md
+++ b/examples/snapshot/05-stateful-applications.md
@@ -1,4 +1,4 @@
-# 5. Stateful Applications
+# 5. Stateful applications
 
 Now that we learned the basics of animation and input handling, we are almost ready to make interactive applications, such as a game.
 

--- a/examples/snapshot/10-audio-playback.md
+++ b/examples/snapshot/10-audio-playback.md
@@ -1,4 +1,4 @@
-# 10. Audio Playback
+# 10. Audio playback
 
 Besides graphics and input, Minart also supports loading and playing back audio.
 


### PR DESCRIPTION
Now that the examples are all converted to Markdown, it's easy to add them to the microsite (I just need to be careful to update the examples *before* releasing a new version).

![imagem](https://github.com/JD557/minart/assets/1187242/dec2bd90-96ca-4eb8-be24-fea5f93d8da1)

Unfortunately, this is blocked by https://github.com/lampepfl/dotty/issues/18996 (See the "README" section in the image above... should be called "Tutorial")

