### PR TITLE
Replace `using lib` with `using dep`

### DIFF
--- a/examples/release/01-introduction.md
+++ b/examples/release/01-introduction.md
@@ -24,7 +24,7 @@ The simplest way to use Minart is to simply include the `minart` library, which 
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-M2"
+//> using dep "eu.joaocosta::minart::0.6.0-M2"
 ```
 
 As for the imports, the `eu.joaocosta.minart.backend.defaults` package contains the givens with the backend-specific (JVM/JS/Native) logic.

--- a/examples/release/02-portable-applications.md
+++ b/examples/release/02-portable-applications.md
@@ -38,7 +38,7 @@ Note, however, that we now also import `eu.joaocosta.minart.runtime.*`, which pr
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-M2"
+//> using dep "eu.joaocosta::minart::0.6.0-M2"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/release/03-animation.md
+++ b/examples/release/03-animation.md
@@ -12,7 +12,7 @@ As before, let's import the backend, graphics and runtime.
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-M2"
+//> using dep "eu.joaocosta::minart::0.6.0-M2"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/release/04-pointer-input.md
+++ b/examples/release/04-pointer-input.md
@@ -14,7 +14,7 @@ We also need to import the input package. We need this to read data from input d
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-M2"
+//> using dep "eu.joaocosta::minart::0.6.0-M2"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/release/05-stateful-applications.md
+++ b/examples/release/05-stateful-applications.md
@@ -14,7 +14,7 @@ The dependencies will be the same as before. We also include Scala's `Random` he
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-M2"
+//> using dep "eu.joaocosta::minart::0.6.0-M2"
 
 import scala.util.Random
 

--- a/examples/release/06-surfaces.md
+++ b/examples/release/06-surfaces.md
@@ -17,7 +17,7 @@ For this example, we just need to use the graphics and runtime
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-M2"
+//> using dep "eu.joaocosta::minart::0.6.0-M2"
 
 
 import eu.joaocosta.minart.backend.defaults.given

--- a/examples/release/07-canvas-settings.md
+++ b/examples/release/07-canvas-settings.md
@@ -12,7 +12,7 @@ Here's a quick example on how to do that. In this example application, we will c
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-M2"
+//> using dep "eu.joaocosta::minart::0.6.0-M2"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/release/08-loading-images.md
+++ b/examples/release/08-loading-images.md
@@ -15,7 +15,7 @@ This package also has an `Image` object with helpers to call the loaders.
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-M2"
+//> using dep "eu.joaocosta::minart::0.6.0-M2"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/release/09-surface-views.md
+++ b/examples/release/09-surface-views.md
@@ -13,7 +13,7 @@ This tutorial will show how to use those
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-M2"
+//> using dep "eu.joaocosta::minart::0.6.0-M2"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/release/10-audio-playback.md
+++ b/examples/release/10-audio-playback.md
@@ -10,7 +10,7 @@ Here we will see how to generate audio waves and play a simple audio clip.
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-M2"
+//> using dep "eu.joaocosta::minart::0.6.0-M2"
 
 import eu.joaocosta.minart.audio.*
 import eu.joaocosta.minart.backend.defaults.given

--- a/examples/release/11-loading-sounds.md
+++ b/examples/release/11-loading-sounds.md
@@ -17,7 +17,7 @@ This package also has an `Sound` object with helpers to call the loaders.
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-M2"
+//> using dep "eu.joaocosta::minart::0.6.0-M2"
 
 import eu.joaocosta.minart.audio.*
 import eu.joaocosta.minart.audio.sound.*

--- a/examples/snapshot/01-introduction.md
+++ b/examples/snapshot/01-introduction.md
@@ -24,7 +24,7 @@ The simplest way to use Minart is to simply include the `minart` library, which 
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-SNAPSHOT"
+//> using dep "eu.joaocosta::minart::0.6.0-SNAPSHOT"
 ```
 
 As for the imports, the `eu.joaocosta.minart.backend.defaults` package contains the givens with the backend-specific (JVM/JS/Native) logic.

--- a/examples/snapshot/02-portable-applications.md
+++ b/examples/snapshot/02-portable-applications.md
@@ -38,7 +38,7 @@ Note, however, that we now also import `eu.joaocosta.minart.runtime.*`, which pr
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-SNAPSHOT"
+//> using dep "eu.joaocosta::minart::0.6.0-SNAPSHOT"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/snapshot/03-animation.md
+++ b/examples/snapshot/03-animation.md
@@ -12,7 +12,7 @@ As before, let's import the backend, graphics and runtime.
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-SNAPSHOT"
+//> using dep "eu.joaocosta::minart::0.6.0-SNAPSHOT"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/snapshot/04-pointer-input.md
+++ b/examples/snapshot/04-pointer-input.md
@@ -14,7 +14,7 @@ We also need to import the input package. We need this to read data from input d
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-SNAPSHOT"
+//> using dep "eu.joaocosta::minart::0.6.0-SNAPSHOT"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/snapshot/05-stateful-applications.md
+++ b/examples/snapshot/05-stateful-applications.md
@@ -14,7 +14,7 @@ The dependencies will be the same as before. We also include Scala's `Random` he
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-SNAPSHOT"
+//> using dep "eu.joaocosta::minart::0.6.0-SNAPSHOT"
 
 import scala.util.Random
 

--- a/examples/snapshot/06-surfaces.md
+++ b/examples/snapshot/06-surfaces.md
@@ -17,7 +17,7 @@ For this example, we just need to use the graphics and runtime
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-SNAPSHOT"
+//> using dep "eu.joaocosta::minart::0.6.0-SNAPSHOT"
 
 
 import eu.joaocosta.minart.backend.defaults.given

--- a/examples/snapshot/07-canvas-settings.md
+++ b/examples/snapshot/07-canvas-settings.md
@@ -12,7 +12,7 @@ Here's a quick example on how to do that. In this example application, we will c
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-SNAPSHOT"
+//> using dep "eu.joaocosta::minart::0.6.0-SNAPSHOT"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/snapshot/08-loading-images.md
+++ b/examples/snapshot/08-loading-images.md
@@ -15,7 +15,7 @@ This package also has an `Image` object with helpers to call the loaders.
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-SNAPSHOT"
+//> using dep "eu.joaocosta::minart::0.6.0-SNAPSHOT"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/snapshot/09-surface-views.md
+++ b/examples/snapshot/09-surface-views.md
@@ -13,7 +13,7 @@ This tutorial will show how to use those
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-SNAPSHOT"
+//> using dep "eu.joaocosta::minart::0.6.0-SNAPSHOT"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/snapshot/10-audio-playback.md
+++ b/examples/snapshot/10-audio-playback.md
@@ -10,7 +10,7 @@ Here we will see how to generate audio waves and play a simple audio clip.
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-SNAPSHOT"
+//> using dep "eu.joaocosta::minart::0.6.0-SNAPSHOT"
 
 import eu.joaocosta.minart.audio.*
 import eu.joaocosta.minart.backend.defaults.given

--- a/examples/snapshot/11-loading-sounds.md
+++ b/examples/snapshot/11-loading-sounds.md
@@ -17,7 +17,7 @@ This package also has an `Sound` object with helpers to call the loaders.
 
 ```scala
 //> using scala "3.3.1"
-//> using lib "eu.joaocosta::minart::0.6.0-SNAPSHOT"
+//> using dep "eu.joaocosta::minart::0.6.0-SNAPSHOT"
 
 import eu.joaocosta.minart.audio.*
 import eu.joaocosta.minart.audio.sound.*


### PR DESCRIPTION
Scala CLI deprecated `using lib` in favor of `using dep`