### PR TITLE
Fix resource loading

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsResource.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/JsResource.scala
@@ -11,7 +11,8 @@ import org.scalajs.dom.{ProgressEvent, XMLHttpRequest}
 
 import eu.joaocosta.minart.runtime.Resource
 
-/** Resource loader that fetches resources using a XML HTTP Request.
+/** Resource loader that fetches resources from the local storage.
+  * If it fails, it uses a XML HTTP Request.
   */
 final case class JsResource(resourcePath: String) extends Resource {
   def path = "./" + resourcePath

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaResource.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/JavaResource.scala
@@ -17,8 +17,7 @@ final case class JavaResource(resourcePath: String) extends Resource {
   def path = "./" + resourcePath
 
   override def exists(): Boolean =
-    this.getClass().getResource("/" + resourcePath) != null ||
-      new File(path).exists()
+    new File(path).exists() || this.getClass().getResource("/" + resourcePath) != null
 
   def unsafeInputStream(): InputStream =
     Try(new BufferedInputStream(new FileInputStream(path)))

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/NativeResource.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/NativeResource.scala
@@ -8,15 +8,14 @@ import scala.util.{Failure, Success, Try}
 
 import eu.joaocosta.minart.runtime.Resource
 
-/** Resource loader that fetches the data from the executable resources.
-  * If that fails, it tries to fetch the data from a file.
+/** Resource loader that fetches the data from a file.
+  *  If that fails, it tries to fetch the data from the executable resources.
   *
-  *  Due to scala-native limitations, the async methods are actually synchronous.
+  * Currently in scala-native limitations, the async methods are actually synchronous.
   */
 final case class NativeResource(resourcePath: String) extends Resource {
   override def exists(): Boolean =
-    this.getClass().getResource("/" + resourcePath) != null ||
-      new File(path).exists()
+    new File(path).exists() || this.getClass().getResource("/" + resourcePath) != null
 
   def path = "./" + resourcePath
 

--- a/core/shared/src/main/scala/eu/joaocosta/minart/internal/ByteReader.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/internal/ByteReader.scala
@@ -32,8 +32,12 @@ private[minart] object ByteReader {
     val byteArr = Array.ofDim[Byte](n)
     var read    = bytes.read(byteArr)
     while (read >= 0 && read < n) {
-      byteArr(read) = bytes.read().toByte
-      read += 1
+      val byte = bytes.read()
+      if (byte == -1) read = -1
+      else {
+        byteArr(read) = byte.toByte
+        read += 1
+      }
     }
     bytes -> byteArr.map(b => java.lang.Byte.toUnsignedInt(b))
   }
@@ -43,8 +47,12 @@ private[minart] object ByteReader {
     val byteArr = Array.ofDim[Byte](n)
     var read    = bytes.read(byteArr)
     while (read >= 0 && read < n) {
-      byteArr(read) = bytes.read().toByte
-      read += 1
+      val byte = bytes.read()
+      if (byte == -1) read = -1
+      else {
+        byteArr(read) = byte.toByte
+        read += 1
+      }
     }
     bytes -> byteArr
   }
@@ -107,7 +115,7 @@ private[minart] object ByteReader {
       else {
         hasBuffer = false
         b(0) = buffer.toByte
-        inner.read(b, 1, b.size - 1)
+        inner.read(b, 1, b.size - 1) + 1
       }
     }
     override def reset(): Unit = ()

--- a/core/shared/src/main/scala/eu/joaocosta/minart/internal/ByteReader.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/internal/ByteReader.scala
@@ -30,14 +30,22 @@ private[minart] object ByteReader {
   /** Read N Bytes */
   def readBytes(n: Int): ParseState[Nothing, Array[Int]] = State { bytes =>
     val byteArr = Array.ofDim[Byte](n)
-    bytes.read(byteArr)
+    var read    = bytes.read(byteArr)
+    while (read >= 0 && read < n) {
+      byteArr(read) = bytes.read().toByte
+      read += 1
+    }
     bytes -> byteArr.map(b => java.lang.Byte.toUnsignedInt(b))
   }
 
   /** Read N Bytes */
   def readRawBytes(n: Int): ParseState[Nothing, Array[Byte]] = State { bytes =>
     val byteArr = Array.ofDim[Byte](n)
-    bytes.read(byteArr)
+    var read    = bytes.read(byteArr)
+    while (read >= 0 && read < n) {
+      byteArr(read) = bytes.read().toByte
+      read += 1
+    }
     bytes -> byteArr
   }
 

--- a/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/qoa/QoaAudioReader.scala
+++ b/sound/shared/src/main/scala/eu/joaocosta/minart/audio/sound/qoa/QoaAudioReader.scala
@@ -87,7 +87,7 @@ trait QoaAudioReader extends AudioClipReader {
       State.pure(AudioClip.fromIndexedSeq(acc, sampleRate))
     else {
       val frameData = for {
-        numChannels <- readBENumber(1).validate(_ == 1, c => s"Expected a Mono QOA file, got $c channels")
+        numChannels <- readByte.map(_.getOrElse(0)).validate(_ == 1, c => s"Expected a Mono QOA file, got $c channels")
         newSampleRate <- readBENumber(3).validate(
           s => sampleRate == 0 || s == sampleRate,
           s => s"Sample rate changed mid file. Expected $sampleRate, got $s"


### PR DESCRIPTION
In some instances, reading a byte array from an `InputStream` might not return all the requested bytes, even if the file has not reached it's end. In this situation, Minart was loading corrupted data (it was inserting zeros).

Now, when this happens, the byte reader falls back to a slower strategy for the rest of the batch.

This PR also fixes the resource loading order documentation, along with the `exists()` check, and avoids loading so many batches in the QOA reader.