### PR TITLE
Fix canvas clear when changing settings

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/HtmlCanvas.scala
@@ -128,7 +128,7 @@ final class HtmlCanvas(parentNode: => dom.Node = dom.document.body) extends Surf
     }
     ctx.fillStyle = clearColorStr
     ctx.fillRect(0, 0, newSettings.width, newSettings.height)
-    clear(Set(Canvas.Buffer.Backbuffer))
+    surface.fill(newSettings.clearColor)
     extendedSettings
   }
 

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/AwtCanvas.scala
@@ -82,7 +82,7 @@ final class AwtCanvas() extends SurfaceBackedCanvas {
     javaCanvas.frame.addKeyListener(keyListener)
     javaCanvas.addMouseListener(mouseListener)
     javaCanvas.frame.addMouseListener(mouseListener)
-    clear(Set(Canvas.Buffer.Backbuffer))
+    surface.fill(newSettings.clearColor)
     fullExtendedSettings
   }
 

--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -19,9 +19,6 @@ final class SdlCanvas() extends SurfaceBackedCanvas {
 
   // Rendering resources
 
-  private[this] var ubyteClearR: UByte              = _
-  private[this] var ubyteClearG: UByte              = _
-  private[this] var ubyteClearB: UByte              = _
   private[this] var window: Ptr[SDL_Window]         = _
   private[this] var windowSurface: Ptr[SDL_Surface] = _
   protected var surface: SdlSurface                 = _
@@ -82,9 +79,6 @@ final class SdlCanvas() extends SurfaceBackedCanvas {
   protected def unsafeApplySettings(newSettings: Canvas.Settings): LowLevelCanvas.ExtendedSettings = {
     val extendedSettings = LowLevelCanvas.ExtendedSettings(newSettings)
     SDL_DestroyWindow(window)
-    ubyteClearR = newSettings.clearColor.r.toUByte
-    ubyteClearG = newSettings.clearColor.g.toUByte
-    ubyteClearB = newSettings.clearColor.b.toUByte
     Zone { implicit z =>
       window = SDL_CreateWindow(
         toCString(newSettings.title),
@@ -115,6 +109,9 @@ final class SdlCanvas() extends SurfaceBackedCanvas {
       windowWidth = (!windowSurface).w,
       windowHeight = (!windowSurface).h
     )
+    val ubyteClearR = newSettings.clearColor.r.toUByte
+    val ubyteClearG = newSettings.clearColor.g.toUByte
+    val ubyteClearB = newSettings.clearColor.b.toUByte
     (0 until fullExtendedSettings.windowHeight * fullExtendedSettings.windowWidth).foreach { i =>
       val baseAddr = i * 4
       (!windowSurface).pixels(baseAddr + 0) = ubyteClearB.toByte
@@ -122,7 +119,7 @@ final class SdlCanvas() extends SurfaceBackedCanvas {
       (!windowSurface).pixels(baseAddr + 2) = ubyteClearR.toByte
       (!windowSurface).pixels(baseAddr + 3) = 255.toByte
     }
-    clear(Set(Canvas.Buffer.Backbuffer))
+    surface.fill(newSettings.clearColor)
     fullExtendedSettings
   }
 


### PR DESCRIPTION
The `unsafeApplySettings` implementations were calling `clear(Set(Canvas.Buffer.Backbuffer))`, which was wrong, as it was obviously clearing the screen with the wrong settings.

This PR changes it to simply fill the new surface based on the new settings.