### PR TITLE
Cleanup canvas code

### DIFF
--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -133,6 +133,9 @@ final class SdlCanvas() extends SurfaceBackedCanvas {
   // Cleanup
 
   protected def unsafeDestroy() = {
+    SDL_DestroyWindow(window)
+    surface.cleanup()
+    SDL_FreeSurface(surface.data)
     SDL_Quit()
   }
 


### PR DESCRIPTION
Cleans up all canvas implementations a bit:
- The AWT Canvas now avoids reallocating the key listener, and only synchronizes when it recognizes the pressed/released keys
- The HTML Canvas now cleans up the event listeners on shutdown
- The SDL Canvas now cleans up unused memory when the settings change and on shutdown