### PR TITLE
Add `MutableSurface#blitPlane` operation

### DIFF
--- a/backend/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/backend/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -85,6 +85,14 @@ trait MutableSurfaceTests extends munit.FunSuite {
     surface.blit(source)(0, 0, 0, 0, 2 * source.width, 2 * source.height)
   }
 
+  test("Combine a surface with a plane without blowing up") {
+    val source = surface.view.repeating
+
+    surface.blitPlane(source)(0, 0)
+    surface.blitPlane(source)(-1, -1)
+    surface.blitPlane(source)(1, 1)
+  }
+
   test("Correctly combine two surfaces") {
     surface.fill(Color(255, 0, 0))
     val source = surface.toRamSurface()

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/MutableSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/MutableSurface.scala
@@ -82,6 +82,23 @@ trait MutableSurface extends Surface {
     Blitter.fullBlit(this, that, blendMode, x, y, cx, cy, cw, ch)
   }
 
+  /** Draws a plane on top of this surface.
+    *
+    * The plane will always fill the full surface, and the x, y parameters only define where the plane origin should be.
+    *
+    * @param that plane to draw
+    * @param blendMode blend strategy to use
+    * @param x position of the plane origin on the destination surface
+    * @param y position of the plane origin on the destination surface
+    */
+  def blitPlane(
+      that: Plane,
+      blendMode: BlendMode = BlendMode.Copy
+  )(x: Int, y: Int): Unit = {
+    val surface = that.clip(-x, -y, this.width, this.height)
+    blit(surface, blendMode)(0, 0)
+  }
+
   /** Modifies this surface using surface view transformations
     *
     * @param f operations to apply

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -85,6 +85,14 @@ trait MutableSurfaceTests extends munit.FunSuite {
     surface.blit(source)(0, 0, 0, 0, 2 * source.width, 2 * source.height)
   }
 
+  test("Combine a surface with a plane without blowing up") {
+    val source = surface.view.repeating
+
+    surface.blitPlane(source)(0, 0)
+    surface.blitPlane(source)(-1, -1)
+    surface.blitPlane(source)(1, 1)
+  }
+
   test("Correctly combine two surfaces") {
     surface.fill(Color(255, 0, 0))
     val source = surface.toRamSurface()

--- a/examples/snapshot/09-surface-views.md
+++ b/examples/snapshot/09-surface-views.md
@@ -93,9 +93,8 @@ def application(t: Double, canvas: Canvas): Unit = {
         if (x % 32 < 16 != y % 32 < 16) color.invert
         else color
     )
-    .clip(0, 0, 128, 128) // Clip into a SurfaceView
 
-  canvas.blit(image)(0, 0)
+  canvas.blitPlane(image)(0, 0)
 }
 ```
 


### PR DESCRIPTION
Adds `MutableSurface#blitPlane` operation that fills the surface with a plane (according to the `BlendMode`).

Turns out that this is quite useful, especially to blit planes onto the canvas.