### PR TITLE
Update examples and g8 template to 0.6.0

### DIFF
--- a/examples/release/01-introduction.md
+++ b/examples/release/01-introduction.md
@@ -23,8 +23,8 @@ scala-cli 01-introduction.md
 The simplest way to use Minart is to simply include the `minart` library, which packages all modules.
 
 ```scala
-//> using scala "3.3.1"
-//> using dep "eu.joaocosta::minart::0.6.0-M3"
+//> using scala "3.3.3"
+//> using dep "eu.joaocosta::minart::0.6.0"
 ```
 
 As for the imports, the `eu.joaocosta.minart.backend.defaults` package contains the givens with the backend-specific (JVM/JS/Native) logic.

--- a/examples/release/02-portable-applications.md
+++ b/examples/release/02-portable-applications.md
@@ -37,8 +37,8 @@ We start with the similar imports to the previous example.
 Note, however, that we now also import `eu.joaocosta.minart.runtime.*`, which provides a platform agnostic runtime that we can use.
 
 ```scala
-//> using scala "3.3.1"
-//> using dep "eu.joaocosta::minart::0.6.0-M3"
+//> using scala "3.3.3"
+//> using dep "eu.joaocosta::minart::0.6.0"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/release/03-animation.md
+++ b/examples/release/03-animation.md
@@ -11,8 +11,8 @@ This time, we'll write an animated fire, updating at 60 frames per second!
 As before, let's import the backend, graphics and runtime.
 
 ```scala
-//> using scala "3.3.1"
-//> using dep "eu.joaocosta::minart::0.6.0-M3"
+//> using scala "3.3.3"
+//> using dep "eu.joaocosta::minart::0.6.0"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/release/04-pointer-input.md
+++ b/examples/release/04-pointer-input.md
@@ -13,8 +13,8 @@ As before, let's import the backend, graphics and runtime.
 We also need to import the input package. We need this to read data from input devices, such as keyboard and mouse.
 
 ```scala
-//> using scala "3.3.1"
-//> using dep "eu.joaocosta::minart::0.6.0-M3"
+//> using scala "3.3.3"
+//> using dep "eu.joaocosta::minart::0.6.0"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/release/05-stateful-applications.md
+++ b/examples/release/05-stateful-applications.md
@@ -13,8 +13,8 @@ In this example, we will show how to write applications that manipulate a state 
 The dependencies will be the same as before. We also include Scala's `Random` here just to make the game more interesting.
 
 ```scala
-//> using scala "3.3.1"
-//> using dep "eu.joaocosta::minart::0.6.0-M3"
+//> using scala "3.3.3"
+//> using dep "eu.joaocosta::minart::0.6.0"
 
 import scala.util.Random
 

--- a/examples/release/06-surfaces.md
+++ b/examples/release/06-surfaces.md
@@ -16,8 +16,8 @@ A `Surface` is something with a `getPixel` operation (`MutableSurface`s also pro
 For this example, we just need to use the graphics and runtime
 
 ```scala
-//> using scala "3.3.1"
-//> using dep "eu.joaocosta::minart::0.6.0-M3"
+//> using scala "3.3.3"
+//> using dep "eu.joaocosta::minart::0.6.0"
 
 
 import eu.joaocosta.minart.backend.defaults.given

--- a/examples/release/07-canvas-settings.md
+++ b/examples/release/07-canvas-settings.md
@@ -11,8 +11,8 @@ Here's a quick example on how to do that. In this example application, we will c
 ### Dependencies and imports
 
 ```scala
-//> using scala "3.3.1"
-//> using dep "eu.joaocosta::minart::0.6.0-M3"
+//> using scala "3.3.3"
+//> using dep "eu.joaocosta::minart::0.6.0"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/release/08-loading-images.md
+++ b/examples/release/08-loading-images.md
@@ -14,8 +14,8 @@ This package also has an `Image` object with helpers to call the loaders.
 
 
 ```scala
-//> using scala "3.3.1"
-//> using dep "eu.joaocosta::minart::0.6.0-M3"
+//> using scala "3.3.3"
+//> using dep "eu.joaocosta::minart::0.6.0"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/release/09-surface-views.md
+++ b/examples/release/09-surface-views.md
@@ -12,8 +12,8 @@ This tutorial will show how to use those
 ### Dependencies and imports
 
 ```scala
-//> using scala "3.3.1"
-//> using dep "eu.joaocosta::minart::0.6.0-M3"
+//> using scala "3.3.3"
+//> using dep "eu.joaocosta::minart::0.6.0"
 
 import eu.joaocosta.minart.backend.defaults.given
 import eu.joaocosta.minart.graphics.*

--- a/examples/release/10-audio-playback.md
+++ b/examples/release/10-audio-playback.md
@@ -9,8 +9,8 @@ Here we will see how to generate audio waves and play a simple audio clip.
 ### Dependencies and imports
 
 ```scala
-//> using scala "3.3.1"
-//> using dep "eu.joaocosta::minart::0.6.0-M3"
+//> using scala "3.3.3"
+//> using dep "eu.joaocosta::minart::0.6.0"
 
 import eu.joaocosta.minart.audio.*
 import eu.joaocosta.minart.backend.defaults.given

--- a/examples/release/11-loading-sounds.md
+++ b/examples/release/11-loading-sounds.md
@@ -16,8 +16,8 @@ This package also has an `Sound` object with helpers to call the loaders.
 
 
 ```scala
-//> using scala "3.3.1"
-//> using dep "eu.joaocosta::minart::0.6.0-M3"
+//> using scala "3.3.3"
+//> using dep "eu.joaocosta::minart::0.6.0"
 
 import eu.joaocosta.minart.audio.*
 import eu.joaocosta.minart.audio.sound.*

--- a/src/main/g8/$if(!sbt_project.truthy)$project.scala$endif$
+++ b/src/main/g8/$if(!sbt_project.truthy)$project.scala$endif$
@@ -1,3 +1,3 @@
 //> using scala $scala_version$
 
-//> using dep eu.joaocosta::minart::0.6.0-M3
+//> using dep eu.joaocosta::minart::0.6.0

--- a/src/main/g8/$if(sbt_project.truthy)$build.sbt$endif$
+++ b/src/main/g8/$if(sbt_project.truthy)$build.sbt$endif$
@@ -13,7 +13,7 @@ lazy val root =
     .settings(
       Seq(
         libraryDependencies ++= List(
-          "eu.joaocosta" %%% "minart" % "0.6.0-M3"
+          "eu.joaocosta" %%% "minart" % "0.6.0"
         )
       )
     )

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -2,5 +2,5 @@ name = Minart Project
 organization = com.github.myself
 package = $organization$.project
 version = 1.0
-scala_version = 3.3.1
+scala_version = 3.3.3
 sbt_project = no


### PR DESCRIPTION
Updates the examples and g8 templates to 0.6.0.

Since the version is not yet released, the build will fail, but this needs to be done first in order for the release to have the updated documentation (I should find a way to automate this in the future...).