### PR TITLE
Optimize polygon rasterization

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/geometry/AxisAlignedBoundingBox.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/geometry/AxisAlignedBoundingBox.scala
@@ -98,3 +98,29 @@ final case class AxisAlignedBoundingBox(
       x <- (x1 until x2).iterator
     } f(x, y)
 }
+
+object AxisAlignedBoundingBox {
+
+  /** Mutable Builder for AABBs.
+    */
+  final class Builder() {
+    private var x1: Int = Int.MaxValue
+    private var y1: Int = Int.MaxValue
+    private var x2: Int = Int.MinValue
+    private var y2: Int = Int.MinValue
+
+    def add(x: Int, y: Int): this.type = {
+      if (x < x1) x1 = x
+      if (y < y1) y1 = y
+      if (x > x2) x2 = x
+      if (y > y2) y2 = y
+      this
+    }
+
+    def add(point: Shape.Point): this.type = add(point.x, point.y)
+
+    def result(): AxisAlignedBoundingBox =
+      if (x1 > x2 || y1 > y2) AxisAlignedBoundingBox(0, 0, 0, 0)
+      else AxisAlignedBoundingBox(x1, y1, x2 - x1, y2 - y1)
+  }
+}


### PR DESCRIPTION
Adds some optimizations to the polygon rasterization.

- Marks some stuff as `lazy val` (e.g. using the known face, one can do some preculling before computing the aabb, and vice versa), - Avoids the use of `distinct` (which allocates a `HashSet`)
- Short-circuits `faceAt` and `contains`
- Picks a better point for the `knownFace` test (the center sometimes was outside of the polygon... I ntoiced the same issue with the centroid, which is probably due to integer math)
- Adds an AABB builder, to avoid iterating over the points multiple times.

This optimizations led to a ~2x performance improvement when rendering the Stanford bunny. After this, I mostly just see `Iterator.next()` on the hot spot list.