### PR TITLE
Support stroke rasterization

### DIFF
--- a/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
+++ b/backend/native/src/main/scala/eu/joaocosta/minart/backend/SdlCanvas.scala
@@ -7,7 +7,6 @@ import sdl2.all.*
 import sdl2.enumerations.SDL_BlendMode.*
 import sdl2.enumerations.SDL_EventType.*
 import sdl2.enumerations.SDL_InitFlag.*
-import sdl2.enumerations.SDL_KeyCode.*
 import sdl2.enumerations.SDL_WindowFlags.*
 
 import eu.joaocosta.minart.graphics.*

--- a/core/shared/src/main/scala/eu/joaocosta/minart/geometry/AxisAlignedBoundingBox.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/geometry/AxisAlignedBoundingBox.scala
@@ -129,7 +129,7 @@ object AxisAlignedBoundingBox {
       this
     }
 
-    def add(point: Shape.Point): this.type = add(point.x, point.y)
+    def add(point: Point): this.type = add(point.x, point.y)
 
     def result(): AxisAlignedBoundingBox =
       if (x1 > x2 || y1 > y2) AxisAlignedBoundingBox(0, 0, 0, 0)

--- a/core/shared/src/main/scala/eu/joaocosta/minart/geometry/Circle.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/geometry/Circle.scala
@@ -9,7 +9,7 @@ package eu.joaocosta.minart.geometry
   * @param center center of the circle.
   * @param radius circle radius
   */
-final case class Circle(center: Shape.Point, radius: Double) extends Shape {
+final case class Circle(center: Point, radius: Double) extends Shape.ShapeWithContour {
 
   /** The absolute radius */
   val absRadius = math.abs(radius)
@@ -28,6 +28,8 @@ final case class Circle(center: Shape.Point, radius: Double) extends Shape {
     if (radius > 0) Shape.someFront
     else if (radius < 0) Shape.someBack
     else None
+
+  def contour: Vector[Stroke] = Vector(Stroke.Circle(center, radius))
 
   def faceAt(x: Int, y: Int): Option[Shape.Face] = {
     if ((x - center.x) * (x - center.x) + (y - center.y) * (y - center.y) <= squareRadius)
@@ -57,26 +59,26 @@ final case class Circle(center: Shape.Point, radius: Double) extends Shape {
     (this.center.x - that.center.x) * (this.center.x - that.center.x) +
       (this.center.y - that.center.y) * (this.center.y - that.center.y) <= sumRadius * sumRadius
 
-  override def translate(dx: Double, dy: Double): Shape =
+  override def translate(dx: Double, dy: Double): Circle =
     if (dx == 0 && dy == 0) this
-    else Circle(Shape.Point(center.x + dx, center.y + dy), radius)
+    else Circle(Point(center.x + dx, center.y + dy), radius)
 
   override def flipH: Circle =
-    Circle(Shape.Point(-center.x, center.y), -radius)
+    Circle(Point(-center.x, center.y), -radius)
 
   override def flipV: Circle =
-    Circle(Shape.Point(center.x, -center.y), -radius)
+    Circle(Point(center.x, -center.y), -radius)
 
-  override def scale(s: Double): Shape =
+  override def scale(s: Double): Circle =
     if (s == 1.0) this
-    else Circle(Shape.Point(center.x * s, center.y * s), radius * s)
+    else Circle(Point(center.x * s, center.y * s), radius * s)
 
   override def rotate(theta: Double): Shape = {
     val matrix = Matrix.rotation(theta)
     if (matrix == Matrix.identity) this
     else {
       Circle(
-        Shape.Point(
+        Point(
           matrix.applyX(center.x.toDouble, center.y.toDouble),
           matrix.applyY(center.x.toDouble, center.y.toDouble)
         ),
@@ -86,5 +88,5 @@ final case class Circle(center: Shape.Point, radius: Double) extends Shape {
   }
 
   override def transpose: Circle =
-    Circle(center = Shape.Point(center.y, center.x), -radius)
+    Circle(center = Point(center.y, center.x), -radius)
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/geometry/Point.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/geometry/Point.scala
@@ -1,0 +1,5 @@
+package eu.joaocosta.minart.geometry
+
+/** Coordinates of a point in the shape or stroke.
+  */
+final case class Point(x: Double, y: Double)

--- a/core/shared/src/main/scala/eu/joaocosta/minart/geometry/Shape.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/geometry/Shape.scala
@@ -2,7 +2,7 @@ package eu.joaocosta.minart.geometry
 
 /** Abstract shape.
   *
-  *  Can be combined with other shapes and can check if a point is inside of it.
+  * Can be combined with other shapes and can check if a point is inside of it.
   *
   * This API is *experimental* and might change in the near future.
   */
@@ -40,7 +40,7 @@ trait Shape {
     * @param y y coordinates of the point
     * @return None if the point is not contained, Some(face) if the point is contained.
     */
-  final def faceAt(point: Shape.Point): Option[Shape.Face] = faceAt(point.x.toInt, point.y.toInt)
+  final def faceAt(point: Point): Option[Shape.Face] = faceAt(point.x.toInt, point.y.toInt)
 
   /** Checks if this shape contains a point.
     *
@@ -60,7 +60,7 @@ trait Shape {
     * @param y y coordinates of the point
     * @return None if the point is not contained, Some(face) if the point is contained.
     */
-  final def contains(point: Shape.Point): Boolean = contains(point.x.toInt, point.y.toInt)
+  final def contains(point: Point): Boolean = contains(point.x.toInt, point.y.toInt)
 
   /** Contramaps the points in this shape using a matrix.
     *
@@ -89,14 +89,14 @@ trait Shape {
     * Internally, this method will invert the matrix, so for performance sensitive operations it is recommended to use
     * mapMatrix with the direct matrix instead.
     */
-  def contramapMatrix(matrix: Matrix) =
+  def contramapMatrix(matrix: Matrix): Shape =
     mapMatrix(matrix.inverse)
 
   /** Maps this the points in this shape using a matrix.
     *
     * This method can be chained multiple times efficiently.
     */
-  def mapMatrix(matrix: Matrix) =
+  def mapMatrix(matrix: Matrix): Shape =
     if (matrix == Matrix.identity) this
     else Shape.MatrixShape(matrix, this)
 
@@ -131,10 +131,6 @@ trait Shape {
 }
 
 object Shape {
-
-  /** Coordinates of a point in the shape.
-    */
-  final case class Point(x: Double, y: Double)
 
   /** The shape of a circle.
     *
@@ -192,6 +188,17 @@ object Shape {
   enum Face {
     case Front
     case Back
+  }
+
+  /** Shape with a contour that can be rendered.
+    *
+    * It's OK for some shapes to not provide a contour.
+    */
+  trait ShapeWithContour extends Shape {
+
+    /** Contour of this shape as a list of strokes.
+      */
+    def contour: Vector[Stroke]
   }
 
   // Preallocated values to avoid repeated allocations

--- a/core/shared/src/main/scala/eu/joaocosta/minart/geometry/Stroke.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/geometry/Stroke.scala
@@ -1,0 +1,8 @@
+package eu.joaocosta.minart.geometry
+
+/** Represents lines, curves or countours that can be stroked.
+  */
+enum Stroke {
+  case Line(p1: Point, p2: Point)
+  case Circle(center: Point, radius: Double)
+}

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/MutableSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/MutableSurface.scala
@@ -109,6 +109,22 @@ trait MutableSurface extends Surface {
     blit(surface, blendMode)(0, 0)
   }
 
+  /** Draws a stroke on top of this surface.
+    *
+    * This API is *experimental* and might change in the near future.
+    *
+    * @param stroke shape to draw
+    * @param color color of the line
+    * @param x position of the shape origin on the destination surface
+    * @param y position of the shape origin on the destination surface
+    */
+  def rasterizeStroke(
+      stroke: Stroke,
+      color: Color
+  )(x: Int, y: Int): Unit = {
+    Rasterizer.rasterizeStroke(this, stroke, color, x, y)
+  }
+
   /** Draws a shape on top of this surface.
     *
     * This API is *experimental* and might change in the near future.
@@ -120,13 +136,29 @@ trait MutableSurface extends Surface {
     * @param x position of the shape origin on the destination surface
     * @param y position of the shape origin on the destination surface
     */
-  def rasterize(
+  def rasterizeShape(
       shape: Shape,
       frontfaceColor: Option[Color],
       backfaceColor: Option[Color] = None,
       blendMode: BlendMode = BlendMode.Copy
   )(x: Int, y: Int): Unit = {
     Rasterizer.rasterizeShape(this, shape.translate(x, y), frontfaceColor, backfaceColor, blendMode)
+  }
+
+  /** Draws the contour of a shape on top of this surface.
+    *
+    * This API is *experimental* and might change in the near future.
+    *
+    * @param shape shape whose countour to draw
+    * @param color color of the line
+    * @param x position of the shape origin on the destination surface
+    * @param y position of the shape origin on the destination surface
+    */
+  def rasterizeContour(
+      shape: Shape.ShapeWithContour,
+      color: Color
+  )(x: Int, y: Int): Unit = {
+    shape.contour.foreach(stroke => rasterizeStroke(stroke, color)(x, y))
   }
 
   /** Modifies this surface using surface view transformations

--- a/core/shared/src/main/scala/eu/joaocosta/minart/runtime/AppLoop.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/runtime/AppLoop.scala
@@ -4,7 +4,6 @@ import eu.joaocosta.minart.audio.*
 import eu.joaocosta.minart.backend.defaults.*
 import eu.joaocosta.minart.backend.subsystem.*
 import eu.joaocosta.minart.graphics.*
-import eu.joaocosta.minart.runtime.*
 
 /** App loop that keeps an internal state that is passed to every iteration.
   */

--- a/core/shared/src/test/scala/eu/joaocosta/minart/geometry/CircleSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/geometry/CircleSpec.scala
@@ -1,7 +1,5 @@
 package eu.joaocosta.minart.geometry
 
-import eu.joaocosta.minart.geometry.Shape.Point
-
 class CircleSpec extends munit.FunSuite {
   test("Computes the bounding box of a circle") {
     val circle = Circle(

--- a/core/shared/src/test/scala/eu/joaocosta/minart/geometry/ConvexPolygonSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/geometry/ConvexPolygonSpec.scala
@@ -1,7 +1,5 @@
 package eu.joaocosta.minart.geometry
 
-import eu.joaocosta.minart.geometry.Shape.Point
-
 class ConvexPolygonSpec extends munit.FunSuite {
   test("Computes the bounding box of a polygon") {
     val polygon = ConvexPolygon(

--- a/examples/snapshot/10-vector-shapes.md
+++ b/examples/snapshot/10-vector-shapes.md
@@ -27,7 +27,7 @@ Minart already comes with some basic shapes, such as circle and convex polygons,
 First, let's create a few shapes with those methods.
 
 ```scala
-import eu.joaocosta.minart.geometry.Shape.Point
+import eu.joaocosta.minart.geometry.Point
 
 val triangle = Shape.triangle(Point(-16, 16), Point(0, -16), Point(16, 16))
 val square = Shape.rectangle(Point(-16, -16), Point(16, 16))
@@ -57,20 +57,30 @@ This is helpful if, for some reason, you know you don't want to draw back faces.
 
 ### Rasterizing
 
-Now we just need to use the `rasterize` operation, just like we did with `blit`.
+Now we just need to use the `rasterizeShape` operation, just like we did with `blit`.
 
 In this example we will also scale our images with time, to show how the color changes when the face flips.
+
+There's also a `rasterizeStroke` operation to draw lines and a `rasterizeContour` operation to draw only the shape
+contours (note that not all shapes support this, some transformations can make the contour computation impossible).
 
 ```scala
 val frontfaceColor = Color(255, 0, 0)
 val backfaceColor = Color(0, 255, 0)
+val contourColor = Color(255, 255, 255)
 
 def application(t: Double, canvas: Canvas): Unit = {
   val scale = math.sin(t)
-  canvas.rasterize(triangle.scale(scale, 1.0), Some(frontfaceColor), Some(backfaceColor))(32, 32)
-  canvas.rasterize(square.scale(scale, 1.0), Some(frontfaceColor), Some(backfaceColor))(64, 32)
-  canvas.rasterize(octagon.scale(scale, 1.0), Some(frontfaceColor), Some(backfaceColor))(32, 64)
-  canvas.rasterize(circle.scale(scale, 1.0), Some(frontfaceColor), Some(backfaceColor))(64, 64)
+  canvas.rasterizeShape(triangle.scale(scale, 1.0), Some(frontfaceColor), Some(backfaceColor))(32, 32)
+  canvas.rasterizeShape(square.scale(scale, 1.0), Some(frontfaceColor), Some(backfaceColor))(64, 32)
+  canvas.rasterizeShape(octagon.scale(scale, 1.0), Some(frontfaceColor), Some(backfaceColor))(32, 64)
+  canvas.rasterizeShape(circle.scale(scale, 1.0), Some(frontfaceColor), Some(backfaceColor))(64, 64)
+
+  canvas.rasterizeContour(triangle.scale(scale, 1.0), contourColor)(32, 32)
+  canvas.rasterizeContour(square.scale(scale, 1.0), contourColor)(64, 32)
+  canvas.rasterizeContour(octagon.scale(scale, 1.0), contourColor)(32, 64)
+  // Can't compute the contour of a circle scaled on only one dimension
+  //canvas.rasterizeContour(circle.scale(scale, 1.0), contourColor)(64, 64)
 }
 ```
 


### PR DESCRIPTION
Adds some limited support for stroke rasterization.

Currently:
- This only works for `MutableSurface`s (not `Plane`s or `SurfaceView`s) as that implementation is not that simple...
- No `BlendMode` (kind of like `fillRegion`... I think this makes sense, as most `BlendMode`s don't really make sense with a flat color)
- Only circles and lines (I'll think about curves later)
- No stroke width

Related to #514 