### PR TITLE
Add a Kernel object to help with convolutions

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Kernel.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Kernel.scala
@@ -1,0 +1,195 @@
+package eu.joaocosta.minart.graphics
+
+/** A kernel used for convolution.
+  * It simplifies the usage of Plane#coflatMap in a performant way.
+  */
+sealed trait Kernel {
+
+  def width: Int
+
+  def height: Int
+
+  /** Convolution function to use.
+    *
+    * Use as `plane.coflatMap(kernel)`
+    */
+  def apply(getPixel: (Int, Int) => Color): Color
+}
+
+object Kernel {
+
+  def apply(matrix: Seq[Seq[Int]] = Seq(Seq(1)), normalization: Int = 1): SingleKernel =
+    new SingleKernel(IArray.from(matrix.iterator.map(IArray.from)), normalization)
+
+  /** Identity kernel, does nothing.
+    */
+  val identity: SingleKernel = SingleKernel()
+
+  /** Average blur kernel. Averages the pixels in a window.
+    *
+    *  Both the width and height must be odd.
+    */
+  def averageBlur(width: Int, height: Int): SingleKernel = {
+    val line = IArray.fill(width)(1)
+    SingleKernel(IArray.fill(height)(line), width * height)
+  }
+
+  /** Convolution kernel using a single matrix., where all color chanels are handled the same way.
+    * The alpha channel is discarded (forced to 255).
+    *
+    * The center of the matrix maps to the target position. As such, all dimensions must be odd.
+    *
+    * For performance reasons, all entries are integers, but are then divided by normalization
+    * constant.
+    */
+  final case class SingleKernel(matrix: IArray[IArray[Int]] = IArray(IArray(1)), normalization: Int = 1)
+      extends Kernel {
+    val width: Int  = matrix.headOption.map(_.size).getOrElse(0)
+    val height: Int = matrix.size
+    require(matrix.forall(_.size == width), "Invalid kernel, not all rows have the same size")
+    require(width % 2 == 1 && height % 2 == 1, s"Invalid kernel, width ($width) and height ($height) must be odd")
+    require(normalization != 0, "Invalid kernel normalization constant")
+
+    private val minX = -width / 2
+    private val minY = -height / 2
+
+    /** Convolution function to use.
+      *  All color channels are handled the same way, with the alpha channel being forced to 255.
+      *
+      * Use as `plane.coflatMap(kernel)`
+      */
+    def apply(getPixel: (Int, Int) => Color): Color = {
+      var accR: Int = 0
+      var accG: Int = 0
+      var accB: Int = 0
+
+      var dMY = 0
+      while (dMY < height) {
+        val dy  = minY + dMY
+        var dMX = 0
+        while (dMX < width) {
+          val weight = matrix(dMY)(dMX)
+          if (weight != 0) {
+            val dx    = minX + dMX
+            val color = getPixel(dx, dy)
+            accR += weight * color.r
+            accG += weight * color.g
+            accB += weight * color.b
+          }
+          dMX += 1
+        }
+        dMY += 1
+      }
+
+      if (normalization != 1)
+        Color((accR / normalization).toInt, (accG / normalization).toInt, (accB / normalization).toInt)
+      else
+        Color(accR, accG, accB)
+    }
+
+    /** Creates a kernel equivalent to this one, but resized (keeping the center unchanged).
+      * The new width and height must be odd.
+      *
+      * Increases in size add a padding of 0s, while decreases just crop the values.
+      * The normalization constant stays unchanged.
+      */
+    def resize(newWidth: Int, newHeight: Int): SingleKernel = {
+      val dw = newWidth - width
+      val dh = newHeight - height
+      if (dw == 0 && dh == 0) {
+        this
+      } else {
+        val lines = matrix.map(line =>
+          if (dw > 0) {
+            IArray.fill(dw / 2)(0) ++ line ++ IArray.fill(dw / 2)(0)
+          } else if (dw < 0) {
+            line.drop(dw / 2).dropRight(dw / 2)
+          } else {
+            line
+          }
+        )
+        new SingleKernel(
+          if (dh > 0) {
+            val emptyLine = IArray.fill(newWidth)(0)
+            IArray.fill(dh / 2)(emptyLine) ++ lines ++ IArray.fill(dh / 2)(emptyLine)
+          } else if (dh < 0) lines.drop(dh / 2).dropRight(dh / 2)
+          else lines,
+          normalization
+        )
+      }
+    }
+
+    override def equals(that: Any): Boolean =
+      super.equals(that) ||
+        (that.isInstanceOf[SingleKernel] &&
+          this.matrix.toVector.map(_.toVector) == that.asInstanceOf[SingleKernel].matrix.toVector.map(_.toVector) &&
+          this.normalization == that.asInstanceOf[SingleKernel].normalization)
+
+    override def toString(): String =
+      s"SingleKernel(1 / ${normalization} * ${matrix.iterator.map(_.mkString("[", ",", "]")).mkString("[", ",", "]")})"
+
+    override def hashCode(): Int =
+      (this.matrix.toVector.map(_.toVector), this.normalization).hashCode()
+  }
+
+  /** Convolution kernel using a matrix per color channel.
+    *
+    * The center of the matrix maps to the target position. As such, all dimensions must be odd.
+    *
+    * For performance reasons, all entries are integers, but are then divided by normalization
+    * constant.
+    */
+  final case class MultiKernel(
+      kernelR: SingleKernel = Kernel.identity,
+      kernelG: SingleKernel = Kernel.identity,
+      kernelB: SingleKernel = Kernel.identity,
+      kernelA: SingleKernel = Kernel.identity
+  ) extends Kernel {
+    val width: Int  = Iterator(kernelR, kernelG, kernelB, kernelA).map(_.width).max
+    val height: Int = Iterator(kernelR, kernelG, kernelB, kernelA).map(_.height).max
+
+    private val matrixR = kernelR.resize(width, height).matrix
+    private val matrixG = kernelG.resize(width, height).matrix
+    private val matrixB = kernelB.resize(width, height).matrix
+    private val matrixA = kernelA.resize(width, height).matrix
+
+    private val minX = -width / 2
+    private val minY = -height / 2
+
+    def apply(getPixel: (Int, Int) => Color): Color = {
+      var accR: Int = 0
+      var accG: Int = 0
+      var accB: Int = 0
+      var accA: Int = 0
+
+      var dMY = 0
+      while (dMY < height) {
+        val dy  = minY + dMY
+        var dMX = 0
+        while (dMX < width) {
+          val weightR = matrixR(dMY)(dMX)
+          val weightG = matrixG(dMY)(dMX)
+          val weightB = matrixB(dMY)(dMX)
+          val weightA = matrixA(dMY)(dMX)
+          if (weightR != 0 || weightG != 0 || weightB != 0 || weightA != 0) {
+            val dx    = minX + dMX
+            val color = getPixel(dx, dy)
+            accR += weightR * color.r
+            accG += weightG * color.g
+            accB += weightB * color.b
+            accA += weightA * color.a
+          }
+          dMX += 1
+        }
+        dMY += 1
+      }
+
+      Color(
+        (accR / kernelR.normalization).toInt,
+        (accG / kernelG.normalization).toInt,
+        (accB / kernelB.normalization).toInt,
+        (accA / kernelA.normalization).toInt
+      )
+    }
+  }
+}

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -63,6 +63,14 @@ trait Plane extends Function2[Int, Int, Color] { outer =>
         f((dx: Int, dy: Int) => outer.getPixel(x + dx, y + dy))
     }
 
+  /** Coflatmaps this plane with a convolution kernel.
+    */
+  final def coflatMap(kernel: Kernel): Plane =
+    new Plane {
+      def getPixel(x: Int, y: Int): Color =
+        kernel.apply((dx: Int, dy: Int) => outer.getPixel(x + dx, y + dy))
+    }
+
   /** Clips this plane to a chosen rectangle
     *
     * @param cx leftmost pixel on the surface

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/KernelSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/KernelSpec.scala
@@ -9,7 +9,8 @@ class KernelSpec extends munit.FunSuite {
         Seq(3, 2, 1, 0, 0),
         Seq(1, 1, 1, 1, 1)
       ),
-      1
+      1,
+      0
     )
     assert(kernel.width == 5)
     assert(kernel.height == 3)
@@ -22,7 +23,8 @@ class KernelSpec extends munit.FunSuite {
           Seq(1, 2, 3, 0, 0),
           Seq(3, 2, 1, 0, 0)
         ),
-        1
+        1,
+        0
       )
     }
   }
@@ -35,7 +37,8 @@ class KernelSpec extends munit.FunSuite {
           Seq(3),
           Seq(1, 1, 1, 1, 1)
         ),
-        1
+        1,
+        0
       )
     }
   }
@@ -48,6 +51,7 @@ class KernelSpec extends munit.FunSuite {
           Seq(3, 2, 1, 0, 0),
           Seq(1, 1, 1, 1, 1)
         ),
+        0,
         0
       )
     }
@@ -60,7 +64,8 @@ class KernelSpec extends munit.FunSuite {
         Seq(0, 1, 0),
         Seq(1, 0, 1)
       ),
-      1
+      1,
+      0
     )
     val kernelB = Kernel(
       Seq(
@@ -68,28 +73,40 @@ class KernelSpec extends munit.FunSuite {
         Seq(0, 1, 0),
         Seq(1, 0, 1)
       ),
-      1
+      1,
+      0
     )
     val kernelC = Kernel(
-      Seq(
-        Seq(1, 0, 1),
-        Seq(0, 1, 0),
-        Seq(1, 0, 1)
-      ),
-      2
-    )
-    val kernelD = Kernel(
       Seq(
         Seq(1, 0, 1),
         Seq(0, 2, 0),
         Seq(1, 0, 1)
       ),
-      1
+      1,
+      0
+    )
+    val kernelD = Kernel(
+      Seq(
+        Seq(1, 0, 1),
+        Seq(0, 1, 0),
+        Seq(1, 0, 1)
+      ),
+      2,
+      0
+    )
+    val kernelE = Kernel(
+      Seq(
+        Seq(1, 0, 1),
+        Seq(0, 1, 0),
+        Seq(1, 0, 1)
+      ),
+      1,
+      127
     )
     assert(kernelA == kernelB)
     assert(kernelA != kernelC)
     assert(kernelA != kernelD)
-
+    assert(kernelA != kernelE)
   }
 
 }

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/KernelSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/KernelSpec.scala
@@ -1,0 +1,95 @@
+package eu.joaocosta.minart.graphics
+
+class KernelSpec extends munit.FunSuite {
+
+  test("Can be created from a odd-sized matrix") {
+    val kernel = Kernel(
+      Seq(
+        Seq(1, 2, 3, 0, 0),
+        Seq(3, 2, 1, 0, 0),
+        Seq(1, 1, 1, 1, 1)
+      ),
+      1
+    )
+    assert(kernel.width == 5)
+    assert(kernel.height == 3)
+  }
+
+  test("Cannot be created from a even-sized matrix") {
+    intercept[IllegalArgumentException] {
+      Kernel(
+        Seq(
+          Seq(1, 2, 3, 0, 0),
+          Seq(3, 2, 1, 0, 0)
+        ),
+        1
+      )
+    }
+  }
+
+  test("Cannot be created from an unbalanced matrix") {
+    intercept[IllegalArgumentException] {
+      Kernel(
+        Seq(
+          Seq(1, 2, 3, 0, 0),
+          Seq(3),
+          Seq(1, 1, 1, 1, 1)
+        ),
+        1
+      )
+    }
+  }
+
+  test("Cannot be created with a normalization constant of 0") {
+    intercept[IllegalArgumentException] {
+      Kernel(
+        Seq(
+          Seq(1, 2, 3, 0, 0),
+          Seq(3, 2, 1, 0, 0),
+          Seq(1, 1, 1, 1, 1)
+        ),
+        0
+      )
+    }
+  }
+
+  test("Can be compared for equality") {
+    val kernelA = Kernel(
+      Seq(
+        Seq(1, 0, 1),
+        Seq(0, 1, 0),
+        Seq(1, 0, 1)
+      ),
+      1
+    )
+    val kernelB = Kernel(
+      Seq(
+        Seq(1, 0, 1),
+        Seq(0, 1, 0),
+        Seq(1, 0, 1)
+      ),
+      1
+    )
+    val kernelC = Kernel(
+      Seq(
+        Seq(1, 0, 1),
+        Seq(0, 1, 0),
+        Seq(1, 0, 1)
+      ),
+      2
+    )
+    val kernelD = Kernel(
+      Seq(
+        Seq(1, 0, 1),
+        Seq(0, 2, 0),
+        Seq(1, 0, 1)
+      ),
+      1
+    )
+    assert(kernelA == kernelB)
+    assert(kernelA != kernelC)
+    assert(kernelA != kernelD)
+
+  }
+
+}

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
@@ -103,10 +103,35 @@ class PlaneSpec extends munit.FunSuite {
     assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
   }
 
-  test("Coflatmapping it updates the colors based on the kernel") {
+  test("Coflatmapping it updates the colors based on the kernel function") {
     val newSurface =
       surface.view.repeating
         .coflatMap(img => img(1, 2))
+        .toRamSurface(surface.width, surface.height)
+    val newPixels = newSurface.getPixels()
+    val expectedPixels =
+      surface.view.repeating
+        .translate(-1, -2)
+        .toRamSurface(surface.width, surface.height)
+        .getPixels()
+
+    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+  }
+
+  test("Coflatmapping it updates the colors based on the kernel") {
+    val kernel = Kernel(
+      Seq(
+        Seq(0, 0, 0),
+        Seq(0, 0, 0),
+        Seq(0, 0, 0),
+        Seq(0, 0, 0),
+        Seq(0, 0, 1)
+      ),
+      1
+    )
+    val newSurface =
+      surface.view.repeating
+        .coflatMap(kernel)
         .toRamSurface(surface.width, surface.height)
     val newPixels = newSurface.getPixels()
     val expectedPixels =

--- a/examples/snapshot/09-surface-views.md
+++ b/examples/snapshot/09-surface-views.md
@@ -59,13 +59,12 @@ Let's see an example with multiple effects, such as:
  - Wobble
  - Checkerboard invert
 
-Before we start, let's precompute the convolution window that we will use for the blur
+Before we start, let's precompute the convolution kernel that we will use for the blur.
+We could use a simple function, but Minart already provides some optimized kernels
+out of the box.
 
 ```scala
-val convolutionWindow = for {
-  x <- (-1 to 1)
-  y <- (-1 to 1)
-} yield (x, y)
+val blurKernel = Kernel.averageBlur(3, 3)
 
 ```
 
@@ -79,14 +78,8 @@ def application(t: Double, canvas: Canvas): Unit = {
 
   val image = updatedBitmap.view.repeating // Create an infinite Plane from our surface
     .scale(zoom, zoom)  // Scale
-    .coflatMap { img => // Average blur
-      convolutionWindow.iterator
-        .map { case (x, y) => img(x, y) }
-        .foldLeft(Color(0, 0, 0)) { case (Color(r, g, b), Color(rr, gg, bb)) =>
-          Color(r + rr / 9, g + gg / 9, b + bb / 9)
-        }
-    }
-    .rotate(t)                                                        // Rotate
+    .coflatMap(blurKernel) // Average blur
+    .rotate(t) // Rotate
     .contramap((x, y) => (x + (5 * Math.sin(t + y / 10.0)).toInt, y)) // Wobbly effect
     .flatMap(color =>
       (x, y) => // Checkerboard effect


### PR DESCRIPTION
Adds a new [`Kernel`](https://en.wikipedia.org/wiki/Kernel_(image_processing)) object to help with convolutions using `coflatMap`.

It was quite hard to use `coflatMap` in a performant way. This seems to help some common operations to be much faster.

On that note, I did notice that some operations (like color bleed `.coflatMap(plane => Color(plane(-1, 0).r, plane(0, 0).g, plane(1, 0).b)`) are slightly faster without a kernel, but I think that's an edge case where the implementation is just trivial.

I'm still not entirely sure about the API and kernels provided out of the box, but I'll play around with it a bit before releasing 0.6.2.