### PR TITLE
Avoid boxing on AABB foreach

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/geometry/AxisAlignedBoundingBox.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/geometry/AxisAlignedBoundingBox.scala
@@ -92,11 +92,17 @@ final case class AxisAlignedBoundingBox(
     *
     * @param f side effect, receiving (x, y) points
     */
-  def foreach(f: (Int, Int) => Unit): Unit =
-    for {
-      y <- (y1 until y2).iterator
-      x <- (x1 until x2).iterator
-    } f(x, y)
+  def foreach(f: (Int, Int) => Unit): Unit = {
+    var y = y1
+    while (y < y2) {
+      var x = x1
+      while (x < x2) {
+        f(x, y)
+        x = x + 1
+      }
+      y = y + 1
+    }
+  }
 }
 
 object AxisAlignedBoundingBox {


### PR DESCRIPTION
Avoid some boxing/allocations on AABB foreach

From my tests, this doesn't really bring much of a performance improvement, but I guess it won't hurt.