### PR TITLE
Add Surface#tabulate helpers

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/MutableSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/MutableSurface.scala
@@ -169,3 +169,16 @@ trait MutableSurface extends Surface {
     blit(f(this.view).toRamSurface())(0, 0)
   }
 }
+
+object MutableSurface {
+
+  /** Produces a mutable surface containing values of a given function
+    *  over ranges of integer values starting from 0.
+    *
+    *  @param width the surface width
+    *  @param height the surface height
+    *  @param f the function computing the element values
+    */
+  def tabulate(width: Int, height: Int)(f: (Int, Int) => Color): MutableSurface =
+    RamSurface.tabulate(width, height)(f)
+}

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -226,7 +226,7 @@ trait Plane extends Function2[Int, Int, Color] { outer =>
     * @param height surface height
     */
   final def toRamSurface(width: Int, height: Int): RamSurface =
-    toSurfaceView(width, height).toRamSurface()
+    RamSurface.tabulate(width, height)(getPixel)
 }
 
 object Plane {

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
@@ -40,3 +40,34 @@ final class RamSurface(val dataBuffer: Vector[Array[Color]]) extends MutableSurf
     }
   }
 }
+
+object RamSurface {
+
+  /** Produces a RAM surface containing values of a given function
+    *  over ranges of integer values starting from 0.
+    *
+    *  @param width the surface width
+    *  @param height the surface height
+    *  @param f the function computing the element values
+    */
+  def tabulate(width: Int, height: Int)(f: (Int, Int) => Color): RamSurface = {
+    val b = Vector.newBuilder[Array[Color]]
+    b.sizeHint(height)
+    var y = 0
+    while (y < height) {
+      if (width <= 0) {
+        b += Array.empty[Color]
+      } else {
+        val array = new Array[Color](width)
+        var x     = 0
+        while (x < width) {
+          array(x) = f(x, y)
+          x += 1
+        }
+        b += array
+      }
+      y += 1
+    }
+    new RamSurface(b.result())
+  }
+}

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
@@ -82,3 +82,16 @@ trait Surface {
   /** Copies this surface into a new surface stored in RAM. */
   final def toRamSurface(): RamSurface = new RamSurface(getPixels())
 }
+
+object Surface {
+
+  /** Produces a surface containing values of a given function
+    *  over ranges of integer values starting from 0.
+    *
+    *  @param width the surface width
+    *  @param height the surface height
+    *  @param f the function computing the element values
+    */
+  def tabulate(width: Int, height: Int)(f: (Int, Int) => Color): Surface =
+    MutableSurface.tabulate(width, height)(f)
+}


### PR DESCRIPTION
Adds `tabulate` methods to `Surface`, `MutableSurface` and `RamSurface`.

This is a common operation, and the previous alternatives (creating a surface from a `Plane` or creating a surface and filling it with `putPixel`) were not great,