### PR TITLE
Add tabulate/copyFrom to concrete surfaces

### DIFF
--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataOpaqueSurface.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataOpaqueSurface.scala
@@ -80,6 +80,28 @@ final class ImageDataOpaqueSurface(val data: ImageData) extends MutableSurface {
 
 object ImageDataOpaqueSurface {
 
+  /** Produces an opaque ImageData backed surface containing values of a given function
+    *  over ranges of integer values starting from 0.
+    *
+    *  @param width the surface width
+    *  @param height the surface height
+    *  @param f the function computing the element values
+    */
+  def tabulate(width: Int, height: Int)(f: (Int, Int) => Color): ImageDataOpaqueSurface = {
+    val surface =
+      ImageDataOpaqueSurface.fromImage(new Image(width, height))
+    var y = 0
+    while (y < height) {
+      var x = 0
+      while (x < width) {
+        surface.unsafePutPixel(x, y, f(x, y))
+        x += 1
+      }
+      y += 1
+    }
+    surface
+  }
+
   /** Loads an ImageDataOpaqueSurface from an offscreen canvas
     *
     * @param canvas offscreen canvas

--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataOpaqueSurface.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataOpaqueSurface.scala
@@ -16,7 +16,7 @@ import org.scalajs.dom.{
   window
 }
 
-import eu.joaocosta.minart.graphics.{Color, MutableSurface}
+import eu.joaocosta.minart.graphics.{Color, MutableSurface, Surface}
 
 /** A mutable surface backed by an ImageData that drops the alpha channel when puting pixels.
   *
@@ -79,6 +79,13 @@ final class ImageDataOpaqueSurface(val data: ImageData) extends MutableSurface {
 }
 
 object ImageDataOpaqueSurface {
+
+  /** Copies a surface into an opaque ImageData backed surface.
+    *
+    *  @param surface surface to copy from
+    */
+  def copyFrom(surface: Surface): ImageDataOpaqueSurface =
+    ImageDataOpaqueSurface.tabulate(surface.width, surface.height)(surface.unsafeGetPixel)
 
   /** Produces an opaque ImageData backed surface containing values of a given function
     *  over ranges of integer values starting from 0.

--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
@@ -15,7 +15,7 @@ import org.scalajs.dom.{
   window
 }
 
-import eu.joaocosta.minart.graphics.{Color, MutableSurface}
+import eu.joaocosta.minart.graphics.{Color, MutableSurface, Surface}
 
 /** A mutable surface backed by an ImageData.
   *
@@ -77,6 +77,13 @@ final class ImageDataSurface(val data: ImageData) extends MutableSurface {
 }
 
 object ImageDataSurface {
+
+  /** Copies a surface into an ImageData backed surface.
+    *
+    *  @param surface surface to copy from
+    */
+  def copyFrom(surface: Surface): ImageDataSurface =
+    ImageDataSurface.tabulate(surface.width, surface.height)(surface.unsafeGetPixel)
 
   /** Produces an ImageData backed surface containing values of a given function
     *  over ranges of integer values starting from 0.

--- a/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
+++ b/backend/js/src/main/scala/eu/joaocosta/minart/backend/ImageDataSurface.scala
@@ -78,6 +78,28 @@ final class ImageDataSurface(val data: ImageData) extends MutableSurface {
 
 object ImageDataSurface {
 
+  /** Produces an ImageData backed surface containing values of a given function
+    *  over ranges of integer values starting from 0.
+    *
+    *  @param width the surface width
+    *  @param height the surface height
+    *  @param f the function computing the element values
+    */
+  def tabulate(width: Int, height: Int)(f: (Int, Int) => Color): ImageDataSurface = {
+    val surface =
+      ImageDataSurface.fromImage(new Image(width, height))
+    var y = 0
+    while (y < height) {
+      var x = 0
+      while (x < width) {
+        surface.unsafePutPixel(x, y, f(x, y))
+        x += 1
+      }
+      y += 1
+    }
+    surface
+  }
+
   /** Loads an ImageDataOpaqueSurface from an offscreen canvas
     *
     * @param canvas offscreen canvas

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
@@ -67,3 +67,29 @@ final class BufferedImageSurface(val bufferedImage: BufferedImage) extends Mutab
         super.blit(that, blendMode)(x, y, cx, cy, cw, ch)
     }
 }
+
+object BufferedImageSurface {
+
+  /** Produces a BufferedImage backed surface containing values of a given function
+    *  over ranges of integer values starting from 0.
+    *
+    *  @param width the surface width
+    *  @param height the surface height
+    *  @param f the function computing the element values
+    */
+  def tabulate(width: Int, height: Int)(f: (Int, Int) => Color): BufferedImageSurface = {
+    val surface =
+      new BufferedImageSurface(new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB))
+    var y = 0
+    while (y < height) {
+      var x = 0
+      while (x < width) {
+        surface.unsafePutPixel(x, y, f(x, y))
+        x += 1
+      }
+      y += 1
+    }
+    surface
+  }
+
+}

--- a/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
+++ b/backend/jvm/src/main/scala/eu/joaocosta/minart/backend/BufferedImageSurface.scala
@@ -70,6 +70,13 @@ final class BufferedImageSurface(val bufferedImage: BufferedImage) extends Mutab
 
 object BufferedImageSurface {
 
+  /** Copies a surface into an BufferedImage backed surface.
+    *
+    *  @param surface surface to copy from
+    */
+  def copyFrom(surface: Surface): BufferedImageSurface =
+    BufferedImageSurface.tabulate(surface.width, surface.height)(surface.unsafeGetPixel)
+
   /** Produces a BufferedImage backed surface containing values of a given function
     *  over ranges of integer values starting from 0.
     *

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
@@ -43,12 +43,21 @@ final class RamSurface(val dataBuffer: Vector[Array[Color]]) extends MutableSurf
 
 object RamSurface {
 
-  /** Produces a RAM surface containing values of a given function
-    *  over ranges of integer values starting from 0.
+  /** Copies a surface into a RAM Surface surface.
     *
-    *  @param width the surface width
-    *  @param height the surface height
-    *  @param f the function computing the element values
+    * This is just an alias to Suface#toRamSurface.
+    *
+    * @param surface surface to copy from
+    */
+  def copyFrom(surface: Surface): RamSurface =
+    surface.toRamSurface()
+
+  /** Produces a RAM surface containing values of a given function
+    * over ranges of integer values starting from 0.
+    *
+    * @param width the surface width
+    * @param height the surface height
+    * @param f the function computing the element values
     */
   def tabulate(width: Int, height: Int)(f: (Int, Int) => Color): RamSurface = {
     val b = Vector.newBuilder[Array[Color]]


### PR DESCRIPTION
Adds a `tabulate` helper to the JS and JVM concrete surfaces, along with a `copyFrom` helper to make it easier to convert between RAM surfaces and backend specific surfaces.

Those helpers were not added to SDL surfaces, due to the manual memory management requirements.