### PR TITLE
Flatten RamSurface data buffer

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Surface.scala
@@ -1,5 +1,7 @@
 package eu.joaocosta.minart.graphics
 
+import scala.collection.immutable.ArraySeq
+
 /** A Surface is an object that contains a set of pixels.
   */
 trait Surface {
@@ -80,7 +82,7 @@ trait Surface {
   }
 
   /** Copies this surface into a new surface stored in RAM. */
-  final def toRamSurface(): RamSurface = new RamSurface(getPixels())
+  final def toRamSurface(): RamSurface = new RamSurface(getPixels().map(ArraySeq.unsafeWrapArray))
 }
 
 object Surface {

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -244,7 +244,8 @@ object SurfaceView {
         if (width <= 0) {
           b += Array.empty[Color]
         } else {
-          b += ramSurface.dataBuffer(cy + y).slice(cx, cx + width)
+          val base = (cy + y) * ramSurface.width + cx
+          b += ramSurface.dataBuffer.slice(base, base + width)
         }
         y += 1
       }

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/MutableSurfaceTests.scala
@@ -6,7 +6,7 @@ trait MutableSurfaceTests extends munit.FunSuite {
 
   test("Return the correct number of pixels") {
     val pixels = surface.getPixels()
-    assert(pixels.size == surface.height)
+    assertEquals(pixels.size, surface.height)
     assert(pixels.forall(_.size == surface.width))
   }
 
@@ -14,12 +14,12 @@ trait MutableSurfaceTests extends munit.FunSuite {
     surface.putPixel(0, 0, Color(1, 2, 3))
     surface.putPixel(0, 1, Color(3, 2, 1))
     surface.putPixel(1, 0, Color(2, 1, 3))
-    assert(surface.getPixel(0, 0) == Some(Color(1, 2, 3)))
-    assert(surface.getPixel(0, 1) == Some(Color(3, 2, 1)))
-    assert(surface.getPixel(1, 0) == Some(Color(2, 1, 3)))
-    assert(surface.getPixels()(0)(0) == Color(1, 2, 3))
-    assert(surface.getPixels()(1)(0) == Color(3, 2, 1))
-    assert(surface.getPixels()(0)(1) == Color(2, 1, 3))
+    assertEquals(surface.getPixel(0, 0), Some(Color(1, 2, 3)))
+    assertEquals(surface.getPixel(0, 1), Some(Color(3, 2, 1)))
+    assertEquals(surface.getPixel(1, 0), Some(Color(2, 1, 3)))
+    assertEquals(surface.getPixels()(0)(0), Color(1, 2, 3))
+    assertEquals(surface.getPixels()(1)(0), Color(3, 2, 1))
+    assertEquals(surface.getPixels()(0)(1), Color(2, 1, 3))
   }
 
   test("Don't blow up when invalid positions are provided") {
@@ -27,34 +27,35 @@ trait MutableSurfaceTests extends munit.FunSuite {
     surface.putPixel(surface.width, 0, Color(1, 2, 3))
     surface.putPixel(0, surface.height, Color(1, 2, 3))
 
-    assert(surface.getPixel(-1, -1) == None)
-    assert(surface.getPixel(surface.width, 0) == None)
-    assert(surface.getPixel(0, surface.height) == None)
+    assertEquals(surface.getPixel(-1, -1), None)
+    assertEquals(surface.getPixel(surface.width, 0), None)
+    assertEquals(surface.getPixel(0, surface.height), None)
   }
 
   test("Fill the surface with a single color") {
     surface.fill(Color(1, 2, 3))
+
     assert(surface.getPixels().flatten.forall(_ == Color(1, 2, 3)))
     surface.fill(Color(3, 2, 1))
     assert(surface.getPixels().flatten.forall(_ == Color(3, 2, 1)))
 
     surface.fillRegion(0, 0, 1, 2, Color(1, 1, 1))
-    assert(surface.getPixel(0, 0) == Some(Color(1, 1, 1)))
-    assert(surface.getPixel(0, 1) == Some(Color(1, 1, 1)))
-    assert(surface.getPixel(1, 0) == Some(Color(3, 2, 1)))
+    assertEquals(surface.getPixel(0, 0), Some(Color(1, 1, 1)))
+    assertEquals(surface.getPixel(0, 1), Some(Color(1, 1, 1)))
+    assertEquals(surface.getPixel(1, 0), Some(Color(3, 2, 1)))
 
     surface.fillRegion(1, 1, 1, 1, Color(2, 2, 2))
-    assert(surface.getPixel(0, 0) == Some(Color(1, 1, 1)))
-    assert(surface.getPixel(0, 1) == Some(Color(1, 1, 1)))
-    assert(surface.getPixel(1, 0) == Some(Color(3, 2, 1)))
-    assert(surface.getPixel(1, 1) == Some(Color(2, 2, 2)))
+    assertEquals(surface.getPixel(0, 0), Some(Color(1, 1, 1)))
+    assertEquals(surface.getPixel(0, 1), Some(Color(1, 1, 1)))
+    assertEquals(surface.getPixel(1, 0), Some(Color(3, 2, 1)))
+    assertEquals(surface.getPixel(1, 1), Some(Color(2, 2, 2)))
 
     // offscreen, do nothing
     surface.fillRegion(-100, -100, 100, 100, Color(0, 0, 0))
-    assert(surface.getPixel(0, 0) == Some(Color(1, 1, 1)))
+    assertEquals(surface.getPixel(0, 0), Some(Color(1, 1, 1)))
 
     surface.fillRegion(-100, -100, 200, 200, Color(0, 0, 0))
-    assert(surface.getPixel(0, 0) == Some(Color(0, 0, 0)))
+    assertEquals(surface.getPixel(0, 0), Some(Color(0, 0, 0)))
   }
 
   test("Combine two surfaces without blowing up") {
@@ -98,26 +99,26 @@ trait MutableSurfaceTests extends munit.FunSuite {
     val source = surface.toRamSurface()
     surface.fill(Color(0, 0, 0))
 
-    assert(surface.getPixel(0, 0) == Some(Color(0, 0, 0)))
-    assert(surface.getPixel(1, 1) == Some(Color(0, 0, 0)))
+    assertEquals(surface.getPixel(0, 0), Some(Color(0, 0, 0)))
+    assertEquals(surface.getPixel(1, 1), Some(Color(0, 0, 0)))
 
     surface.blit(source)(1, 1)
 
-    assert(surface.getPixel(0, 0) == Some(Color(0, 0, 0)))
-    assert(source.getPixel(0, 0) == Some(Color(255, 0, 0)))
-    assert(surface.getPixel(1, 1) == Some(Color(255, 0, 0)))
+    assertEquals(surface.getPixel(0, 0), Some(Color(0, 0, 0)))
+    assertEquals(source.getPixel(0, 0), Some(Color(255, 0, 0)))
+    assertEquals(surface.getPixel(1, 1), Some(Color(255, 0, 0)))
 
     surface.blit(source, BlendMode.ColorMask(Color(255, 0, 0)))(0, 0)
 
-    assert(surface.getPixel(0, 0) == Some(Color(0, 0, 0)))
-    assert(source.getPixel(0, 0) == Some(Color(255, 0, 0)))
-    assert(surface.getPixel(1, 1) == Some(Color(255, 0, 0)))
+    assertEquals(surface.getPixel(0, 0), Some(Color(0, 0, 0)))
+    assertEquals(source.getPixel(0, 0), Some(Color(255, 0, 0)))
+    assertEquals(surface.getPixel(1, 1), Some(Color(255, 0, 0)))
 
     surface.blit(source, BlendMode.ColorMask(Color(0, 0, 0)))(0, 0)
 
-    assert(surface.getPixel(0, 0) == Some(Color(255, 0, 0)))
-    assert(source.getPixel(0, 0) == Some(Color(255, 0, 0)))
-    assert(surface.getPixel(1, 1) == Some(Color(255, 0, 0)))
+    assertEquals(surface.getPixel(0, 0), Some(Color(255, 0, 0)))
+    assertEquals(source.getPixel(0, 0), Some(Color(255, 0, 0)))
+    assertEquals(surface.getPixel(1, 1), Some(Color(255, 0, 0)))
   }
 
   test("Modify a surface in place") {

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
@@ -5,32 +5,32 @@ import scala.util.Random
 class PlaneSpec extends munit.FunSuite {
 
   lazy val surface = new RamSurface(
-    Vector.fill(16)(Array.fill(8)(Color(Random.nextInt(255), Random.nextInt(255), Random.nextInt(255))))
+    Vector.fill(16)(Vector.fill(8)(Color(Random.nextInt(255), Random.nextInt(255), Random.nextInt(255))))
   )
   lazy val originalPixels = surface.getPixels()
 
   test("Can be created from a constant color") {
     val plane = Plane.fromConstant(Color(10, 20, 30))
-    assert(plane.getPixel(Random.nextInt(), Random.nextInt()) == Color(10, 20, 30))
+    assertEquals(plane.getPixel(Random.nextInt(), Random.nextInt()), Color(10, 20, 30))
   }
 
   test("Can be created from a function") {
     val plane = Plane.fromFunction((x, y) => Color(x, y, x + y))
-    assert(plane.getPixel(10, 20) == Color(10, 20, 30))
+    assertEquals(plane.getPixel(10, 20), Color(10, 20, 30))
   }
 
   test("Can be created from a surface with a fallback color") {
     val plane = Plane.fromSurfaceWithFallback(surface, Color(1, 2, 3))
-    assert(plane.getPixel(1, 2) == surface.getPixel(1, 2).get)
-    assert(plane.getPixel(-1, -2) == Color(1, 2, 3))
-    assert(plane.getPixel(1000, 1000) == Color(1, 2, 3))
+    assertEquals(plane.getPixel(1, 2), surface.getPixel(1, 2).get)
+    assertEquals(plane.getPixel(-1, -2), Color(1, 2, 3))
+    assertEquals(plane.getPixel(1000, 1000), Color(1, 2, 3))
   }
 
   test("Can be created from a surface with repetition") {
     val plane = surface.view.repeating
-    assert(plane.getPixel(1, 2) == surface.getPixel(1, 2).get)
-    assert(plane.getPixel(1 + 8, 2 + 16) == surface.getPixel(1, 2).get)
-    assert(plane.getPixel(1 - 8, 2 - 16) == surface.getPixel(1, 2).get)
+    assertEquals(plane.getPixel(1, 2), surface.getPixel(1, 2).get)
+    assertEquals(plane.getPixel(1 + 8, 2 + 16), surface.getPixel(1, 2).get)
+    assertEquals(plane.getPixel(1 - 8, 2 - 16), surface.getPixel(1, 2).get)
   }
 
   test("Mapping it updates the colors") {
@@ -41,9 +41,9 @@ class PlaneSpec extends munit.FunSuite {
     val newPixels      = newSurface.getPixels()
     val expectedPixels = originalPixels.map(_.map(_.invert))
 
-    assert(newSurface.width == surface.width)
-    assert(newSurface.height == surface.height)
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newSurface.width, surface.width)
+    assertEquals(newSurface.height, surface.height)
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("Flatmapping it updates the colors based on the position") {
@@ -55,9 +55,9 @@ class PlaneSpec extends munit.FunSuite {
     val expectedPixels =
       originalPixels.take(8) ++ originalPixels.drop(8).map(_.map(_.invert))
 
-    assert(newSurface.width == surface.width)
-    assert(newSurface.height == surface.height)
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newSurface.width, surface.width)
+    assertEquals(newSurface.height, surface.height)
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("Contramapping updates the positions") {
@@ -68,9 +68,9 @@ class PlaneSpec extends munit.FunSuite {
     val newPixels      = newSurface.getPixels()
     val expectedPixels = originalPixels.transpose
 
-    assert(newSurface.width == surface.height)
-    assert(newSurface.height == surface.width)
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newSurface.width, surface.height)
+    assertEquals(newSurface.height, surface.width)
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("Zipping combines two planes") {
@@ -83,9 +83,9 @@ class PlaneSpec extends munit.FunSuite {
     val newPixels      = newSurface.getPixels()
     val expectedPixels = originalPixels.map(_.map(_ => Color(0, 0, 0)))
 
-    assert(newSurface.width == surface.width)
-    assert(newSurface.height == surface.height)
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newSurface.width, surface.width)
+    assertEquals(newSurface.height, surface.height)
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("Zipping combines a plane and a surface") {
@@ -98,9 +98,9 @@ class PlaneSpec extends munit.FunSuite {
     val newPixels      = newSurface.getPixels()
     val expectedPixels = originalPixels.map(_.map(_ => Color(0, 0, 0)))
 
-    assert(newSurface.width == surface.width)
-    assert(newSurface.height == surface.height)
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newSurface.width, surface.width)
+    assertEquals(newSurface.height, surface.height)
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("Coflatmapping it updates the colors based on the kernel function") {
@@ -115,7 +115,7 @@ class PlaneSpec extends munit.FunSuite {
         .toRamSurface(surface.width, surface.height)
         .getPixels()
 
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("Coflatmapping it updates the colors based on the kernel") {
@@ -140,7 +140,7 @@ class PlaneSpec extends munit.FunSuite {
         .toRamSurface(surface.width, surface.height)
         .getPixels()
 
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("Clipping clips the view") {
@@ -151,9 +151,9 @@ class PlaneSpec extends munit.FunSuite {
     val newPixels      = newSurface.getPixels()
     val expectedPixels = originalPixels.slice(5, 7).map(_.slice(5, 7))
 
-    assert(newSurface.width == 2)
-    assert(newSurface.height == 2)
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newSurface.width, 2)
+    assertEquals(newSurface.height, 2)
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("Overlay combines a plane and a surface") {
@@ -162,75 +162,75 @@ class PlaneSpec extends munit.FunSuite {
     val newPlane =
       plane.overlay(surface)(2, 2)
 
-    assert(newPlane(0, 0) == surface.unsafeGetPixel(0, 0))
-    assert(newPlane(1, 1) == surface.unsafeGetPixel(1, 1))
-    assert(newPlane(2, 2) == surface.unsafeGetPixel(0, 0))
-    assert(newPlane(3, 3) == surface.unsafeGetPixel(1, 1))
+    assertEquals(newPlane(0, 0), surface.unsafeGetPixel(0, 0))
+    assertEquals(newPlane(1, 1), surface.unsafeGetPixel(1, 1))
+    assertEquals(newPlane(2, 2), surface.unsafeGetPixel(0, 0))
+    assertEquals(newPlane(3, 3), surface.unsafeGetPixel(1, 1))
   }
 
   test("Inverting the color updates all colors with the inverse") {
-    assert(Plane.fromConstant(Color(110, 120, 130)).invertColor(100, 100) == Color(110, 120, 130).invert)
+    assertEquals(Plane.fromConstant(Color(110, 120, 130)).invertColor(100, 100), Color(110, 120, 130).invert)
   }
 
   test("Translation moves all pixels") {
     val original =
       surface.view.repeating
     val transformed = original.translate(5, 10)
-    assert(original(0, 0) == transformed(5, 10))
+    assertEquals(original(0, 0), transformed(5, 10))
   }
 
   test("FlipH mirrors the pixels with the Y axis") {
     val original =
       surface.view.repeating
     val transformed = original.flipH
-    assert(original(5, 10) == transformed(-5, 10))
+    assertEquals(original(5, 10), transformed(-5, 10))
   }
 
   test("FlipV mirrors the pixels with the X axis") {
     val original =
       surface.view.repeating
     val transformed = original.flipV
-    assert(original(5, 10) == transformed(5, -10))
+    assertEquals(original(5, 10), transformed(5, -10))
   }
 
   test("Scale upscales the plane") {
     val original =
       surface.view.repeating
     val transformed = original.scale(2)
-    assert(original(0, 0) == transformed(0, 0))
-    assert(original(0, 0) == transformed(1, 0))
-    assert(original(0, 0) == transformed(0, 1))
-    assert(original(0, 0) == transformed(1, 1))
+    assertEquals(original(0, 0), transformed(0, 0))
+    assertEquals(original(0, 0), transformed(1, 0))
+    assertEquals(original(0, 0), transformed(0, 1))
+    assertEquals(original(0, 0), transformed(1, 1))
 
-    assert(original(1, 1) == transformed(2, 2))
-    assert(original(1, 1) == transformed(3, 2))
-    assert(original(1, 1) == transformed(2, 3))
-    assert(original(1, 1) == transformed(3, 3))
+    assertEquals(original(1, 1), transformed(2, 2))
+    assertEquals(original(1, 1), transformed(3, 2))
+    assertEquals(original(1, 1), transformed(2, 3))
+    assertEquals(original(1, 1), transformed(3, 3))
   }
 
   test("Scale downscales the plane") {
     val original =
       surface.view.repeating
     val transformed = original.scale(0.5)
-    assert(original(0, 0) == transformed(0, 0))
-    assert(original(2, 2) == transformed(1, 1))
+    assertEquals(original(0, 0), transformed(0, 0))
+    assertEquals(original(2, 2), transformed(1, 1))
   }
 
   test("Rotate moves all pixels clockwise") {
     val original =
       surface.view.repeating
     val transformed = original.rotate(Math.PI / 2)
-    assert(original(0, 0) == transformed(0, 0))
-    assert(original(5, 3) == transformed(-3, 5))
+    assertEquals(original(0, 0), transformed(0, 0))
+    assertEquals(original(5, 3), transformed(-3, 5))
   }
 
   test("Shear moves all pixels") {
     val original =
       surface.view.repeating
     val transformed = original.shear(1, 0)
-    assert(original(0, 0) == transformed(0, 0))
-    assert(original(0, 1) == transformed(1, 1))
-    assert(original(0, 2) == transformed(2, 2))
+    assertEquals(original(0, 0), transformed(0, 0))
+    assertEquals(original(0, 1), transformed(1, 1))
+    assertEquals(original(0, 2), transformed(2, 2))
   }
 
   test("Transpose moves all pixels") {
@@ -238,8 +238,8 @@ class PlaneSpec extends munit.FunSuite {
       surface.view.repeating
     val transformed = original.transpose
 
-    assert(original(0, 0) == transformed(0, 0))
-    assert(original(0, 1) == transformed(1, 0))
-    assert(original(0, 2) == transformed(2, 0))
+    assertEquals(original(0, 0), transformed(0, 0))
+    assertEquals(original(0, 1), transformed(1, 0))
+    assertEquals(original(0, 2), transformed(2, 0))
   }
 }

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/SurfaceViewSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/SurfaceViewSpec.scala
@@ -5,7 +5,7 @@ import scala.util.Random
 class SurfaceViewSpec extends munit.FunSuite {
 
   lazy val surface = new RamSurface(
-    Vector.fill(16)(Array.fill(8)(Color(Random.nextInt(255), Random.nextInt(255), Random.nextInt(255))))
+    Vector.fill(16)(Vector.fill(8)(Color(Random.nextInt(255), Random.nextInt(255), Random.nextInt(255))))
   )
   lazy val originalPixels = surface.getPixels()
 
@@ -13,9 +13,9 @@ class SurfaceViewSpec extends munit.FunSuite {
     val newSurface = surface.view.toRamSurface()
     val newPixels  = newSurface.getPixels()
 
-    assert(newSurface.width == surface.width)
-    assert(newSurface.height == surface.height)
-    assert(newPixels.map(_.toVector) == originalPixels.map(_.toVector))
+    assertEquals(newSurface.width, surface.width)
+    assertEquals(newSurface.height, surface.height)
+    assertEquals(newPixels.map(_.toVector), originalPixels.map(_.toVector))
   }
 
   test("The map view updates the colors") {
@@ -23,9 +23,9 @@ class SurfaceViewSpec extends munit.FunSuite {
     val newPixels      = newSurface.getPixels()
     val expectedPixels = originalPixels.map(_.map(_.invert))
 
-    assert(newSurface.width == surface.width)
-    assert(newSurface.height == surface.height)
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newSurface.width, surface.width)
+    assertEquals(newSurface.height, surface.height)
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("The flatMap view updates the colors based on the position") {
@@ -36,9 +36,9 @@ class SurfaceViewSpec extends munit.FunSuite {
     val expectedPixels =
       originalPixels.take(8) ++ originalPixels.drop(8).map(_.map(_.invert))
 
-    assert(newSurface.width == surface.width)
-    assert(newSurface.height == surface.height)
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newSurface.width, surface.width)
+    assertEquals(newSurface.height, surface.height)
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("The contramap view updates the positions") {
@@ -46,9 +46,9 @@ class SurfaceViewSpec extends munit.FunSuite {
     val newPixels  = newSurface.getPixels()
     val expectedPixels = originalPixels.transpose
 
-    assert(newSurface.width == surface.height)
-    assert(newSurface.height == surface.width)
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newSurface.width, surface.height)
+    assertEquals(newSurface.height, surface.width)
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("The zip view combines two surfaces") {
@@ -59,9 +59,9 @@ class SurfaceViewSpec extends munit.FunSuite {
     val newPixels      = newSurface.getPixels()
     val expectedPixels = originalPixels.map(_.map(_ => Color(0, 0, 0)))
 
-    assert(newSurface.width == surface.width)
-    assert(newSurface.height == surface.height)
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newSurface.width, surface.width)
+    assertEquals(newSurface.height, surface.height)
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("Coflatmapping it updates the colors based on the kernel") {
@@ -77,7 +77,7 @@ class SurfaceViewSpec extends munit.FunSuite {
         .toRamSurface(surface.width, surface.height)
         .getPixels()
 
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("The clip view clips a surface") {
@@ -86,9 +86,9 @@ class SurfaceViewSpec extends munit.FunSuite {
     val newPixels      = newSurface.getPixels()
     val expectedPixels = originalPixels.slice(5, 7).map(_.slice(5, 7))
 
-    assert(newSurface.width == 2)
-    assert(newSurface.height == 2)
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newSurface.width, 2)
+    assertEquals(newSurface.height, 2)
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("Overlay combines two surfaces") {
@@ -102,9 +102,9 @@ class SurfaceViewSpec extends munit.FunSuite {
           oldLine.take(2) ++ newLine.dropRight(2)
         }
 
-    assert(newSurface.width == surface.width)
-    assert(newSurface.height == surface.height)
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newSurface.width, surface.width)
+    assertEquals(newSurface.height, surface.height)
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("FlipH mirrors the surface horizontally") {
@@ -112,7 +112,7 @@ class SurfaceViewSpec extends munit.FunSuite {
       surface.view.flipH.toRamSurface()
     val newPixels      = newSurface.getPixels()
     val expectedPixels = originalPixels.map(_.reverse)
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("FlipV mirrors the surface vertically") {
@@ -120,31 +120,31 @@ class SurfaceViewSpec extends munit.FunSuite {
       surface.view.flipV.toRamSurface()
     val newPixels      = newSurface.getPixels()
     val expectedPixels = originalPixels.reverse
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
   test("Scale upscales the surface") {
     val newSurface =
       surface.view.scale(2.0).toRamSurface()
 
-    assert(newSurface.width == 2 * surface.width)
-    assert(newSurface.height == 2 * surface.height)
+    assertEquals(newSurface.width, 2 * surface.width)
+    assertEquals(newSurface.height, 2 * surface.height)
   }
 
   test("Scale downscales the plane") {
     val newSurface =
       surface.view.scale(0.5).toRamSurface()
 
-    assert(newSurface.width == surface.width / 2)
-    assert(newSurface.height == surface.height / 2)
+    assertEquals(newSurface.width, surface.width / 2)
+    assertEquals(newSurface.height, surface.height / 2)
   }
 
   test("Scale upscale/downscales the plane across independent axis") {
     val newSurface =
       surface.view.scale(0.5, 2.0).toRamSurface()
 
-    assert(newSurface.width == surface.width / 2)
-    assert(newSurface.height == surface.height * 2)
+    assertEquals(newSurface.width, surface.width / 2)
+    assertEquals(newSurface.height, surface.height * 2)
   }
 
   test("Transpose transposes the image") {
@@ -153,8 +153,8 @@ class SurfaceViewSpec extends munit.FunSuite {
     val newPixels      = newSurface.getPixels()
     val expectedPixels = originalPixels.transpose
 
-    assert(newSurface.width == surface.height)
-    assert(newSurface.height == surface.width)
-    assert(newPixels.map(_.toVector) == expectedPixels.map(_.toVector))
+    assertEquals(newSurface.width, surface.height)
+    assertEquals(newSurface.height, surface.width)
+    assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 }

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/bmp/BmpImageReader.scala
@@ -3,6 +3,7 @@ package eu.joaocosta.minart.graphics.image.bmp
 import java.io.InputStream
 
 import scala.annotation.tailrec
+import scala.collection.immutable.ArraySeq
 
 import eu.joaocosta.minart.graphics.*
 import eu.joaocosta.minart.graphics.image.*
@@ -136,7 +137,7 @@ trait BmpImageReader extends ImageReader {
           Left(s"Invalid number of lines: Got ${pixelMatrix.size}, expected ${header.height}")
         else if (pixelMatrix.nonEmpty && pixelMatrix.last.size != header.width)
           Left(s"Invalid number of pixels in the last line: Got ${pixelMatrix.last.size}, expected ${header.width}")
-        else Right(new RamSurface(pixelMatrix))
+        else Right(new RamSurface(pixelMatrix.map(ArraySeq.unsafeWrapArray)))
       }
     }
   }

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/pdi/PdiImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/pdi/PdiImageReader.scala
@@ -3,6 +3,7 @@ package eu.joaocosta.minart.graphics.image.pdi
 import java.io.InputStream
 
 import scala.annotation.tailrec
+import scala.collection.immutable.ArraySeq
 
 import eu.joaocosta.minart.graphics.*
 import eu.joaocosta.minart.graphics.image.*
@@ -81,7 +82,7 @@ trait PdiImageReader extends ImageReader {
           Vector.fill(cellHeader.clipTop)(Array.fill(width)(emptyColor)) ++
             centerPixels.map(center => leftPad ++ center ++ rightPad) ++
             Vector.fill(cellHeader.clipBottom)(Array.fill(width)(emptyColor))
-      } yield (new RamSurface(pixels))
+      } yield (new RamSurface(pixels.map(ArraySeq.unsafeWrapArray)))
     }
   }
 }

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/ppm/PpmImageReader.scala
@@ -3,6 +3,7 @@ package eu.joaocosta.minart.graphics.image.ppm
 import java.io.InputStream
 
 import scala.annotation.tailrec
+import scala.collection.immutable.ArraySeq
 
 import eu.joaocosta.minart.graphics.*
 import eu.joaocosta.minart.graphics.image.*
@@ -160,7 +161,7 @@ trait PpmImageReader extends ImageReader {
           Left(s"Invalid number of lines: Got ${pixelMatrix.size}, expected ${header.height}")
         else if (pixelMatrix.nonEmpty && pixelMatrix.last.size != header.width)
           Left(s"Invalid number of pixels in the last line: Got ${pixelMatrix.last.size}, expected ${header.width}")
-        else Right(new RamSurface(pixelMatrix))
+        else Right(new RamSurface(pixelMatrix.map(ArraySeq.unsafeWrapArray)))
       }
     }
   }

--- a/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageReader.scala
+++ b/image/shared/src/main/scala/eu/joaocosta/minart/graphics/image/qoi/QoiImageReader.scala
@@ -117,9 +117,8 @@ trait QoiImageReader extends ImageReader {
             finalState.imageAcc.reverseIterator
               .take(expectedPixels)
               .map(_.minartColor)
-              .grouped(header.width.toInt)
-              .map(_.toArray)
-              .toVector
+              .toArray,
+            header.height.toInt
           ),
           s"Invalid number of pixels! Got ${finalState.imageAcc.size}, expected ${expectedPixels}"
         )


### PR DESCRIPTION
Uses a flat array to store the RamSurface data.

This seems to have a significant `getPixel` speedup, as the `Vector` access is removed.

![image](https://github.com/user-attachments/assets/d3681481-d1e9-42de-942a-bdbdb79e1202)

I might still do some extra benchmarks to ensure that this does not affect normal blit performance, but I doubt it, as it also removes some indirection there.