### PR TITLE
Revamp ConvexPolygon and expose determinantsForEach

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/geometry/ConvexPolygon.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/geometry/ConvexPolygon.scala
@@ -8,47 +8,67 @@ package eu.joaocosta.minart.geometry
   * If this is not the case, the methods may return wrong results.
   *
   * This API is *experimental* and might change in the near future.
-  *
-  * @param vertices ordered sequence of vertices.
   */
-final case class ConvexPolygon(vertices: Vector[Point]) extends Shape.ShapeWithContour {
-  val size = vertices.size
-  require(size >= 3, "A polygon needs at least 3 vertices")
+sealed trait ConvexPolygon extends Shape.ShapeWithContour {
 
-  lazy val aabb: AxisAlignedBoundingBox =
+  /** Ordered sequence of vertices.
+    */
+  def vertices: Vector[Point]
+
+  final lazy val size = vertices.size
+
+  final lazy val aabb: AxisAlignedBoundingBox =
     AxisAlignedBoundingBox.fromPoints(vertices)
 
-  lazy val knownFace: Option[Shape.Face] =
-    faceAt(vertices.head)
-
-  lazy val contour: Vector[Stroke] =
+  final lazy val contour: Vector[Stroke] =
     (vertices :+ vertices.head)
       .sliding(2)
       .collect { case Vector(a, b) => Stroke.Line(a, b) }
       .toVector
 
-  // See https://jtsorlinis.github.io/rendering-tutorial/ and
-  // https://lisyarus.github.io/blog/posts/implementing-a-tiny-cpu-rasterizer-part-2.html
-  private inline def determinant(x1: Double, y1: Double, x2: Double, y2: Double, x3: Double, y3: Double): Double =
-    (x2 - x1) * (y3 - y1) - (y2 - y1) * (x3 - x1)
+  final lazy val knownFace: Option[Shape.Face] =
+    faceAt(vertices.head)
 
-  // Helpful loop to avoid boxing and allocations
-  private inline def determinantsForEach(x: Double, y: Double)(inline f: Double => Unit): Unit = {
+  /** Iterates over all edges and applies a function f: (i, det(V_i - V_i+1, P - Vi)) => Unit.
+    *
+    * Useful for low level rasterization operations.
+    *
+    * @param x Px
+    * @param y Py
+    * @param f (i, det(V_i - V_i+1, P - Vi)) => Unit
+    */
+  inline final def determinantsForEach(x: Double, y: Double)(inline f: (Int, Double) => Unit): Unit = {
     var idx = 0
     while (idx < size) {
       val current = vertices(idx)
       val next    = if (idx + 1 >= size) vertices(0) else vertices(idx + 1)
-      val det     = determinant(current.x, current.y, next.x, next.y, x, y)
-      f(det)
+      val det     = ConvexPolygon.determinant(current.x, current.y, next.x, next.y, x, y)
+      f(idx, det)
       idx += 1
     }
   }
 
-  def faceAt(x: Int, y: Int): Option[Shape.Face] = {
+  /** Checks if this polygon contains another polygon.
+    *
+    * @param that polygon to check
+    * @return true if that polygon is contained in this polygon
+    */
+  final def contains(that: ConvexPolygon): Boolean =
+    that.vertices.forall(p => this.contains(p))
+
+  /** Checks if this polygon collides with another polygon.
+    *
+    * @param that polygon to check
+    * @return true if the polygons collide
+    */
+  final def collides(that: ConvexPolygon): Boolean =
+    this.vertices.exists(v => that.contains(v)) || that.vertices.exists(v => this.contains(v))
+
+  final def faceAt(x: Int, y: Int): Option[Shape.Face] = {
     var inside: Boolean         = true
     var firstIteration: Boolean = true
     var last: Boolean           = true
-    determinantsForEach(x, y) { det =>
+    determinantsForEach(x, y) { (_, det) =>
       if (det != 0 && inside) {
         val sign = det >= 0
         if (!firstIteration && last != sign) inside = false
@@ -61,11 +81,11 @@ final case class ConvexPolygon(vertices: Vector[Point]) extends Shape.ShapeWithC
     else Shape.someBack
   }
 
-  override def contains(x: Int, y: Int): Boolean = {
+  override final def contains(x: Int, y: Int): Boolean = {
     var inside: Boolean         = true
     var firstIteration: Boolean = true
     var last: Boolean           = true
-    determinantsForEach(x, y) { det =>
+    determinantsForEach(x, y) { (_, det) =>
       if (det != 0 && inside) {
         val sign = det >= 0
         if (!firstIteration && last != sign) inside = false
@@ -76,66 +96,64 @@ final case class ConvexPolygon(vertices: Vector[Point]) extends Shape.ShapeWithC
     inside
   }
 
-  /** Checks if this polygon contains another polygon.
-    *
-    * @param that polygon to check
-    * @return true if that polygon is contained in this polygon
-    */
-  def contains(that: ConvexPolygon): Boolean =
-    that.vertices.forall(p => this.contains(p))
-
-  /** Checks if this polygon collides with another polygon.
-    *
-    * @param that polygon to check
-    * @return true if the polygons collide
-    */
-  def collides(that: ConvexPolygon): Boolean =
-    this.vertices.exists(v => that.contains(v)) || that.vertices.exists(v => this.contains(v))
-
-  override def mapMatrix(matrix: Matrix): Shape.ShapeWithContour =
+  override def mapMatrix(matrix: Matrix): ConvexPolygon =
     if (matrix == Matrix.identity) this
-    else ConvexPolygon.MatrixPolygon(matrix, this)
+    else ConvexPolygon.MatrixConvexPolygon(matrix, this)
 
   // Overrides to refine the type signature
-  override def contramapMatrix(matrix: Matrix): Shape.ShapeWithContour =
-    mapMatrix(matrix.inverse)
-  override def translate(dx: Double, dy: Double): Shape.ShapeWithContour =
-    mapMatrix(Matrix.translation(dx, dy))
-  override def flipH: Shape.ShapeWithContour                         = mapMatrix(Matrix.flipH)
-  override def flipV: Shape.ShapeWithContour                         = mapMatrix(Matrix.flipV)
-  override def scale(sx: Double, sy: Double): Shape.ShapeWithContour =
-    mapMatrix(Matrix.scaling(sx, sy))
-  override def scale(s: Double): Shape.ShapeWithContour      = scale(s, s)
-  override def rotate(theta: Double): Shape.ShapeWithContour =
-    mapMatrix(Matrix.rotation(theta))
-  override def shear(sx: Double, sy: Double): Shape.ShapeWithContour =
-    mapMatrix(Matrix.shear(sx, sy))
-  override def transpose: Shape.ShapeWithContour = mapMatrix(Matrix.transpose)
+  override final def contramapMatrix(matrix: Matrix): ConvexPolygon   = mapMatrix(matrix.inverse)
+  override final def translate(dx: Double, dy: Double): ConvexPolygon = mapMatrix(Matrix.translation(dx, dy))
+  override final def flipH: ConvexPolygon                             = mapMatrix(Matrix.flipH)
+  override final def flipV: ConvexPolygon                             = mapMatrix(Matrix.flipV)
+  override final def scale(sx: Double, sy: Double): ConvexPolygon     = mapMatrix(Matrix.scaling(sx, sy))
+  override final def scale(s: Double): ConvexPolygon                  = scale(s, s)
+  override final def rotate(theta: Double): ConvexPolygon             = mapMatrix(Matrix.rotation(theta))
+  override final def shear(sx: Double, sy: Double): ConvexPolygon     = mapMatrix(Matrix.shear(sx, sy))
+  override final def transpose: ConvexPolygon                         = mapMatrix(Matrix.transpose)
 }
 
 object ConvexPolygon {
-  private[ConvexPolygon] final case class MatrixPolygon(matrix: Matrix, polygon: ConvexPolygon)
-      extends Shape.ShapeWithContour {
-    lazy val toConvexPolygon = ConvexPolygon(
-      vertices = polygon.vertices.map { point =>
-        Point(
-          matrix.applyX(point.x, point.y),
-          matrix.applyY(point.x, point.y)
-        )
-      }
-    )
 
-    def knownFace: Option[Shape.Face]              = toConvexPolygon.knownFace
-    def aabb: AxisAlignedBoundingBox               = toConvexPolygon.aabb
-    def contour                                    = toConvexPolygon.contour
-    def faceAt(x: Int, y: Int): Option[Shape.Face] =
-      toConvexPolygon.faceAt(x, y)
-    override def contains(x: Int, y: Int): Boolean =
-      toConvexPolygon.contains(x, y)
-    override def mapMatrix(matrix: Matrix): MatrixPolygon =
+  /** Convex polygon constructed from a series of vertices.
+    *
+    * It's considered to be facing the viewer if the vertices are clockwise.
+    *
+    * There is no check in place to guarantee that the generated polygon is actually convex.
+    * If this is not the case, the methods may return wrong results.
+    *
+    * @param vertices ordered sequence of vertices.
+    */
+  def apply(vertices: Vector[Point]): StrictConvexPolygon = {
+    require(vertices.size >= 3, "A convex polygon needs at least 3 vertices")
+    StrictConvexPolygon(vertices)
+  }
+
+  // See https://jtsorlinis.github.io/rendering-tutorial/ and
+  // https://lisyarus.github.io/blog/posts/implementing-a-tiny-cpu-rasterizer-part-2.html
+  private inline def determinant(x1: Double, y1: Double, x2: Double, y2: Double, x3: Double, y3: Double): Double =
+    (x2 - x1) * (y3 - y1) - (y2 - y1) * (x3 - x1)
+
+  /** Convex Polygon with vertices computed ahead of time
+    *
+    * @param vertices ordered sequence of vertices
+    */
+  final case class StrictConvexPolygon private[ConvexPolygon] (vertices: Vector[Point]) extends ConvexPolygon
+
+  /** Convex Polygon with a matrix transformation applied
+    *
+    * @param matrix Matrix transformation
+    * @param polygon inner polygon
+    */
+  final case class MatrixConvexPolygon private[ConvexPolygon] (matrix: Matrix, polygon: ConvexPolygon)
+      extends ConvexPolygon {
+    lazy val vertices = polygon.vertices.map { point =>
+      Point(
+        matrix.applyX(point.x, point.y),
+        matrix.applyY(point.x, point.y)
+      )
+    }
+    override def mapMatrix(matrix: Matrix): MatrixConvexPolygon =
       if (matrix == Matrix.identity) this
-      else MatrixPolygon(matrix.multiply(this.matrix), polygon)
-    override def translate(dx: Double, dy: Double): MatrixPolygon =
-      mapMatrix(Matrix.translation(dx, dy))
+      else MatrixConvexPolygon(matrix.multiply(this.matrix), polygon)
   }
 }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/geometry/Shape.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/geometry/Shape.scala
@@ -205,7 +205,7 @@ object Shape {
   private[geometry] val someFront = Some(Face.Front)
   private[geometry] val someBack  = Some(Face.Back)
 
-  private[Shape] final case class MatrixShape(matrix: Matrix, shape: Shape) extends Shape {
+  final case class MatrixShape private[Shape] (matrix: Matrix, shape: Shape) extends Shape {
     def knownFace: Option[Shape.Face] = if (matrix.a * matrix.e < 0)
       shape.knownFace.map {
         case Face.Front => Face.Back
@@ -235,7 +235,7 @@ object Shape {
       shape.faceAt(math.round(matrix.inverse.applyX(x, y)).toInt, math.round(matrix.inverse.applyY(x, y)).toInt)
     override def contains(x: Int, y: Int): Boolean =
       shape.contains(math.round(matrix.inverse.applyX(x, y)).toInt, math.round(matrix.inverse.applyY(x, y)).toInt)
-    override def mapMatrix(matrix: Matrix) =
+    override def mapMatrix(matrix: Matrix): MatrixShape =
       MatrixShape(matrix.multiply(this.matrix), shape)
   }
 }


### PR DESCRIPTION
Exposes `ConvexPolygon#determinantsForEach` and refactors the hierarchy so that repeated transformations still yield a `ConvexPolygon` (which allows one to use `determinantsForEach`).

This should allow some more advanced effects, such as per-vertex color with interpolation.
Right now this is not exposed in the rasterizer and must be used manually, as I'm neither sure how a high-level API for this would look like, nor how non-triangles should be treated.