### PR TITLE
Make AudioClip intervals consistent

### DIFF
--- a/core/shared/src/test/scala/eu/joaocosta/minart/audio/AudioClipSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/audio/AudioClipSpec.scala
@@ -3,63 +3,106 @@ package eu.joaocosta.minart.audio
 class AudioClipSpec extends munit.FunSuite {
 
   test("An audio clip is correctly sampled") {
-    val clip = AudioClip(x => x / 2.0, 2.0)
-    assert(Sampler.numSamples(clip, 1) == 2)
-    assert(Sampler.sampleClip(clip, 1).toList == List(0.0, 0.5))
+    val clip = AudioClip.fromFunction(x => x / 2.0, 2.0)
+    assertEquals(Sampler.numSamples(clip, 1), 2)
+    assertEquals(Sampler.sampleClip(clip, 1).toList, List(0.0, 0.5))
 
-    assert(Sampler.numSamples(clip, 2) == 4)
-    assert(Sampler.sampleClip(clip, 2).toList == List(0.0, 0.25, 0.5, 0.75))
+    assertEquals(Sampler.numSamples(clip, 2), 4)
+    assertEquals(Sampler.sampleClip(clip, 2).toList, List(0.0, 0.25, 0.5, 0.75))
   }
 
-  test("take and drop correctly update the durations") {
-    val clip = AudioClip(x => x / 2.0, 2.0)
-    assert(clip.take(0.5).duration == 0.5)
-    assert(clip.take(5).duration == 2.0)
+  test("The take and drop operations correctly update the durations") {
+    val clip = AudioClip.fromFunction(x => x / 2.0, 2.0)
+    assertEquals(clip.take(0.5).duration, 0.5)
+    assertEquals(clip.take(5).duration, 2.0)
 
-    assert(clip.drop(0.5).duration == 1.5)
-    assert(clip.drop(5).duration == 0.0)
+    assertEquals(clip.drop(0.5).duration, 1.5)
+    assertEquals(clip.drop(5).duration, 0.0)
+  }
+
+  test("The take and drop operations correctly split the clip") {
+    val clip = AudioClip.fromFunction(x => x / 2.0, 2.0)
+
+    val clipA = clip.take(0.5)
+    val clipB = clip.drop(0.5)
+
+    assertEquals(clipA.getAmplitude(0.0), Some(0.0))
+    assertEquals(clipA.getAmplitude(0.1), Some(0.1 / 2.0))
+    assertEquals(clipA.getAmplitude(0.5), None)
+
+    assertEquals(clipB.getAmplitude(0.0), Some(0.5 / 2.0))
+    assertEquals(clipB.getAmplitude(0.1), Some(0.6 / 2.0))
+    assertEquals(clipB.getAmplitude(1.5), None)
   }
 
   test("The map operation maps all values") {
-    val clip = AudioClip(x => x / 2.0, 2.0)
+    val clip = AudioClip.fromFunction(x => x / 2.0, 2.0)
     val f    = (x: Double) => x / 2.0
-    assert(Sampler.sampleClip(clip.map(f), 100).toList == Sampler.sampleClip(clip, 100).toList.map(f))
+    assertEquals(Sampler.sampleClip(clip.map(f), 100).toList, Sampler.sampleClip(clip, 100).toList.map(f))
   }
 
   test("The zipWith operation combines two clips") {
-    val clipA = AudioClip(x => x / 4.0, 2.0)
-    val clipB = AudioClip(x => x / 8.0, 3.0)
+    val clipA = AudioClip.fromFunction(x => x / 4.0, 2.0)
+    val clipB = AudioClip.fromFunction(x => x / 8.0, 3.0)
 
     val newClip = clipA.zipWith(clipB, _ + _)
-    assert(newClip.duration == 2.0)
-    assert(
+    assertEquals(newClip.duration, 2.0)
+    assertEquals(
       Sampler
         .sampleClip(newClip, 1)
-        .toList == Sampler.sampleClip(clipA, 1).zip(Sampler.sampleClip(clipB, 1)).map { case (x, y) => x + y }.toList
+        .toList,
+      Sampler.sampleClip(clipA, 1).zip(Sampler.sampleClip(clipB, 1)).map { case (x, y) => x + y }.toList
     )
   }
 
   test("Appending two audio clips correcty updates the duration") {
-    val clipA = AudioClip(x => x / 2.0, 2.0)
-    val clipB = AudioClip(x => x / 4.0, 3.0)
-    assert((clipA.append(clipB)).duration == 5.0)
+    val clipA = AudioClip.fromFunction(x => x / 2.0, 2.0)
+    val clipB = AudioClip.fromFunction(x => x / 4.0, 3.0)
+    assertEquals((clipA.append(clipB)).duration, 5.0)
+  }
+
+  test("Appending two audio clips correcty merges at the boundaries") {
+    val clipA = AudioClip.fromFunction(_ => 0.5, 2.0)
+    val clipB = AudioClip.fromFunction(_ => 1.0, 3.0)
+
+    val clip = clipA.append(clipB)
+
+    assertEquals(clip.getAmplitude(0.0), Some(0.5))
+    assertEquals(clip.getAmplitude(1.9), Some(0.5))
+    assertEquals(clip.getAmplitude(2.0), Some(1.0))
+    assertEquals(clip.getAmplitude(4.9), Some(1.0))
+    assertEquals(clip.getAmplitude(5.0), None)
   }
 
   test("Repeating a clip correcty updates the duration") {
-    val clipA = AudioClip(x => x / 2.0, 2.0)
-    assert(clipA.repeating(5).duration == 10.0)
+    val clipA = AudioClip.fromFunction(x => x / 2.0, 2.0)
+    assertEquals(clipA.repeating(5).duration, 10.0)
   }
 
   test("The mix operation combines multiple clips") {
-    val clipA = AudioClip(x => x / 4.0, 2.0)
-    val clipB = AudioClip(x => x / 8.0, 3.0)
+    val clipA = AudioClip.fromFunction(x => x / 4.0, 2.0)
+    val clipB = AudioClip.fromFunction(x => x / 8.0, 3.0)
 
     val newClip = AudioClip.mix(List(clipA, clipB))
-    assert(newClip.duration == 2.0)
-    assert(
+    assertEquals(newClip.duration, 2.0)
+    assertEquals(
       Sampler
         .sampleClip(newClip, 1)
-        .toList == Sampler.sampleClip(clipA, 1).zip(Sampler.sampleClip(clipB, 1)).map { case (x, y) => x + y }.toList
+        .toList,
+      Sampler.sampleClip(clipA, 1).zip(Sampler.sampleClip(clipB, 1)).map { case (x, y) => x + y }.toList
     )
+  }
+
+  test("A sampled AudioClip returns all samples") {
+    val clip = AudioClip.fromIndexedSeq(Vector(0.25, 0.5, 0.75, 1.0), 2.0)
+    assertEquals(clip.getAmplitude(0), Some(0.25))
+    assertEquals(clip.getAmplitude(0.49), Some(0.25))
+    assertEquals(clip.getAmplitude(0.5), Some(0.5))
+    assertEquals(clip.getAmplitude(0.99), Some(0.5))
+    assertEquals(clip.getAmplitude(1.0), Some(0.75))
+    assertEquals(clip.getAmplitude(1.49), Some(0.75))
+    assertEquals(clip.getAmplitude(1.5), Some(1.0))
+    assertEquals(clip.getAmplitude(1.99), Some(1.0))
+    assertEquals(clip.getAmplitude(2.0), None)
   }
 }

--- a/core/shared/src/test/scala/eu/joaocosta/minart/audio/AudioWaveSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/audio/AudioWaveSpec.scala
@@ -1,0 +1,18 @@
+package eu.joaocosta.minart.audio
+
+class AudioWaveSpec extends munit.FunSuite {
+
+  test("A sampled AudioWave returns all samples") {
+    val wave = AudioWave.fromIndexedSeq(Vector(0.25, 0.5, 0.75, 1.0), 2.0)
+    assertEquals(wave.getAmplitude(0), 0.25)
+    assertEquals(wave.getAmplitude(0.49), 0.25)
+    assertEquals(wave.getAmplitude(0.5), 0.5)
+    assertEquals(wave.getAmplitude(0.99), 0.5)
+    assertEquals(wave.getAmplitude(1.0), 0.75)
+    assertEquals(wave.getAmplitude(1.49), 0.75)
+    assertEquals(wave.getAmplitude(1.5), 1.0)
+    assertEquals(wave.getAmplitude(1.99), 1.0)
+    assertEquals(wave.getAmplitude(2.0), 0.0)
+  }
+
+}

--- a/examples/snapshot/11-audio-playback.md
+++ b/examples/snapshot/11-audio-playback.md
@@ -51,17 +51,17 @@ We then take the first 1.0 seconds, to turn our `AudioWave` into an `AudioClip`.
 
 An audio clip is jut a wave with a defined duration.
 
-### Audio from oscilators
+### Audio from oscillators
 
 In the code above, you can see that we generated our audio by:
  - Defining a frequency and duration
  - Converting it to an amplitude using `Math.sin`
 
-Turns out this use case is pretty common, so Minart provides some `Oscilator`s out of the box.
+Turns out this use case is pretty common, so Minart provides some `Oscillator`s out of the box.
 
-To combine the output from multiple oscilators, we can use `AudioClip#append`.
+To combine the output from multiple oscillators, we can use `AudioClip#append`.
 
-Here's a bass line generated using Oscilators:
+Here's a bass line generated using Oscillators:
 
 ```scala
 val bass =


### PR DESCRIPTION
Related to https://github.com/JD557/minart/issues/600

So, turns out that `AudioClips` were defined in `[0, duration]`, but if `t == duration` the wave would be `0`.

I think it makes more sense to define them in `[0, duration)`, so that each sample takes the same amount of time (otherwise the last sample would take slightly bit more.

I added some more unit tests, but I'm marking this as a draft for now until I test this with some actual audio to see if I can spot any improvements.