### PR TITLE
Add Plane/SurfaceView#transformPixels

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/PerPixelTransformation.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/PerPixelTransformation.scala
@@ -1,0 +1,8 @@
+package eu.joaocosta.minart.graphics
+
+/** Function describing how to transform pixels in an image:
+  * Given a color and a position, returns the new color.
+  */
+trait PerPixelTransformation {
+  def apply(color: Color, x: Int, y: Int): Color
+}

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/Plane.scala
@@ -14,12 +14,23 @@ trait Plane extends Function2[Int, Int, Color] { outer =>
   /** Returns the color at position (x, y). */
   def getPixel(x: Int, y: Int): Color
 
+  /** Applies a per-pixel transformation to all pixels on this plane.
+    *
+    * This is similar to flatMap, but more performant.
+    */
+  final def transformPixels(f: PerPixelTransformation): Plane = new Plane {
+    def getPixel(x: Int, y: Int): Color = f(outer.getPixel(x, y), x, y)
+  }
+
   /** Maps the colors from this plane. */
   final def map(f: Color => Color): Plane = new Plane {
     def getPixel(x: Int, y: Int): Color = f(outer.getPixel(x, y))
   }
 
-  /** Flatmaps this plane */
+  /** Flatmaps this plane.
+    *
+    *  Note: Performance intensive applications should use [[transformPixels]] instead to avoid boxing.
+    */
   final def flatMap(f: Color => Plane): Plane = new Plane {
     def getPixel(x: Int, y: Int): Color = f(outer.getPixel(x, y)).getPixel(x, y)
   }

--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/SurfaceView.scala
@@ -10,10 +10,19 @@ import eu.joaocosta.minart.geometry.{AxisAlignedBoundingBox, Shape}
 sealed trait SurfaceView extends Surface {
   def unsafeGetPixel(x: Int, y: Int): Color
 
+  /** Applies a per-pixel transformation to all pixels on this surface voew
+    *
+    * This is similar to flatMap, but more performant.
+    */
+  def transformPixels(f: PerPixelTransformation): SurfaceView
+
   /** Maps the colors from this surface view. */
   def map(f: Color => Color): SurfaceView
 
-  /** Flatmaps the inner plane of this surface view */
+  /** Flatmaps the inner plane of this surface view.
+    *
+    * Note: Performance intensive applications should use [[transformPixels]] instead to avoid boxing.
+    */
   def flatMap(f: Color => Plane): SurfaceView
 
   /** Contramaps the positions from this surface view. */
@@ -152,6 +161,9 @@ object SurfaceView {
     def unsafeGetPixel(x: Int, y: Int): Color =
       plane.getPixel(x, y)
 
+    def transformPixels(f: PerPixelTransformation): SurfaceView =
+      copy(plane.transformPixels(f))
+
     def map(f: Color => Color): SurfaceView = copy(plane.map(f))
 
     def flatMap(f: Color => Plane): SurfaceView =
@@ -260,6 +272,8 @@ object SurfaceView {
       }
       b.result()
     }
+
+    def transformPixels(f: PerPixelTransformation): SurfaceView = toPlaneSurfaceView().transformPixels(f)
 
     def map(f: Color => Color): SurfaceView = toPlaneSurfaceView().map(f)
 

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/PlaneSpec.scala
@@ -60,6 +60,23 @@ class PlaneSpec extends munit.FunSuite {
     assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
+  test("Transforming pixels is similar to flatmap") {
+    val flatMapSurface =
+      surface.view.repeating
+        .flatMap(color => (x, y) => if (y >= 8) color.invert else color)
+        .toRamSurface(surface.width, surface.height)
+    val transformSurface =
+      surface.view.repeating
+        .transformPixels((color, x, y) => if (y >= 8) color.invert else color)
+        .toRamSurface(surface.width, surface.height)
+    val expectedPixels =
+      flatMapSurface.getPixels()
+    val actualPixels =
+      transformSurface.getPixels()
+
+    assertEquals(actualPixels.map(_.toVector), expectedPixels.map(_.toVector))
+  }
+
   test("Contramapping updates the positions") {
     val newSurface =
       surface.view.repeating

--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/SurfaceViewSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/SurfaceViewSpec.scala
@@ -41,6 +41,23 @@ class SurfaceViewSpec extends munit.FunSuite {
     assertEquals(newPixels.map(_.toVector), expectedPixels.map(_.toVector))
   }
 
+  test("Transforming pixels is similar to flatmap") {
+    val flatMapSurface =
+      surface.view
+        .flatMap(color => (x, y) => if (y >= 8) color.invert else color)
+        .toRamSurface()
+    val transformSurface =
+      surface.view
+        .transformPixels((color, x, y) => if (y >= 8) color.invert else color)
+        .toRamSurface()
+    val expectedPixels =
+      flatMapSurface.getPixels()
+    val actualPixels =
+      transformSurface.getPixels()
+
+    assertEquals(actualPixels.map(_.toVector), expectedPixels.map(_.toVector))
+  }
+
   test("The contramap view updates the positions") {
     val newSurface = surface.view.contramap((x, y) => (y, x)).clip(0, 0, surface.height, surface.width).toRamSurface()
     val newPixels  = newSurface.getPixels()


### PR DESCRIPTION
Adds a new `PerPixelTransformation` and a `Plane/SurfaceView#transformPixels` method.

While this is equivalent to `flatMap`, the fact that `flatMap` received a `Color => AnyRef` function made it so that function was not specialized (recall that `Color` is actually an `Int`), which lead to performance problems that are not trivial to fix.

In that regard, `transformPixels` should also be quite faster (1.5x faster in my tests), with the drawback that it's not applied on `for` comprehensions, but that seems like a small limitation.