### PR TITLE
Allow audio thread to stay alive

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioPlayer.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/audio/AudioPlayer.scala
@@ -1,6 +1,7 @@
 package eu.joaocosta.minart.audio
 
 import eu.joaocosta.minart.backend.defaults.*
+import eu.joaocosta.minart.runtime.LoopFrequency
 
 /** Multi-channel mono audio player.
   *
@@ -130,5 +131,9 @@ object AudioPlayer {
   def create(settings: AudioPlayer.Settings)(using backend: DefaultBackend[Any, LowLevelAudioPlayer]): AudioPlayer =
     LowLevelAudioPlayer.create().init(settings)
 
-  final case class Settings(sampleRate: Int = 44100, bufferSize: Int = 4096)
+  final case class Settings(
+      sampleRate: Int = 44100,
+      bufferSize: Int = 4096,
+      threadFrequency: LoopFrequency = LoopFrequency.Never
+  )
 }


### PR DESCRIPTION
Adds a new `threadFrequency` parameter to the audio settings.

By default, this is set to `LoopFrequency.Never`, which uses the current behavior: If there's nothing to play, stop the audio thread.

Otherwise, the audio thread/event loop will stay alive, waiting on intervals based on the thread frequency.

The main use case for this would be `LoopFrequency.Uncapped` (or a very small value), to keep the thread busy looping and ensuring that audio playback can start as soon as possible.
This does have some drawback, especially in single threaded systems, which is why this is not the default.

Hopefully this might help with #600.