### PR TITLE
Add Kernel#gaussianBlur and Kernel.normalized

### DIFF
--- a/core/shared/src/test/scala/eu/joaocosta/minart/graphics/KernelSpec.scala
+++ b/core/shared/src/test/scala/eu/joaocosta/minart/graphics/KernelSpec.scala
@@ -109,4 +109,30 @@ class KernelSpec extends munit.FunSuite {
     assert(kernelA != kernelE)
   }
 
+  test("Can be created with automatic normalization") {
+    val kernelA = Kernel.normalized(
+      Seq(
+        Seq(1.0, 0.0, 0.0),
+        Seq(0.0, 1.0, 0.0),
+        Seq(1.0, 0.0, 1.0)
+      )
+    )
+    assert(
+      kernelA.matrix.flatten.map(_ / kernelA.normalization.toDouble).toVector == Vector(0.25, 0, 0, 0, 0.25, 0, 0.25, 0,
+        0.25)
+    )
+
+    val kernelB = Kernel.normalized(
+      Seq(
+        Seq(1.0, 0.0, 0.0),
+        Seq(0.0, -1.0, 0.0),
+        Seq(1.0, 0.0, -1.0)
+      )
+    )
+    assert(
+      kernelB.matrix.flatten.map(_ / kernelB.normalization.toDouble).toVector == Vector(0.25, 0, 0, 0, -0.25, 0, 0.25,
+        0, -0.25)
+    )
+  }
+
 }


### PR DESCRIPTION
Add out of the box support for a Gaussian blur kernel, along with a `Kernel.normalized` helper to help create convolution kernels from floating point matrices.