### PR TITLE
Specialize RamSurface#fill

### DIFF
--- a/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
+++ b/core/shared/src/main/scala/eu/joaocosta/minart/graphics/RamSurface.scala
@@ -52,6 +52,14 @@ final class RamSurface(val dataBuffer: Array[Color], val height: Int) extends Mu
       }
     }
   }
+
+  override def fill(color: Color): Unit = {
+    var i = 0
+    while (i < dataBuffer.length) {
+      dataBuffer(i) = color
+      i = i + 1
+    }
+  }
 }
 
 object RamSurface {


### PR DESCRIPTION
Optimizes `RamSurface#fill`.

I should probably have done this as part of https://github.com/JD557/minart/pull/585, but I didn't notice it at the time.